### PR TITLE
Run is_healthiest_node against last know healthy configuration of cluster

### DIFF
--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -300,7 +300,10 @@ class Postgresql:
                 member_cursor.close()
                 member_conn.close()
                 logger.error([self.name, member.name, row])
-                if not row[0] or row[1] < 0:
+                if not row[0]:
+                    logger.warning('Master (%s) is still alive', member.name)
+                    return False
+                if row[1] < 0:
                     return False
             except psycopg2.Error:
                 continue

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -60,6 +60,10 @@ def dead_etcd():
     raise DCSError('Etcd is not responding properly')
 
 
+def get_unlocked_cluster():
+    return Cluster(False, None, None, [])
+
+
 class TestHa(unittest.TestCase):
 
     def __init__(self, method_name='runTest'):
@@ -74,8 +78,14 @@ class TestHa(unittest.TestCase):
         self.e = Etcd('foo', {'ttl': 30, 'host': 'remotehost:2379', 'scope': 'test'})
         self.ha = Ha(self.p, self.e)
         self.ha.load_cluster_from_dcs()
-        self.ha.cluster = Cluster(False, None, None, [])
+        self.ha.cluster = get_unlocked_cluster()
         self.ha.load_cluster_from_dcs = nop
+
+    def test_load_cluster_from_dcs(self):
+        ha = Ha(self.p, self.e)
+        ha.load_cluster_from_dcs()
+        self.e.get_cluster = get_unlocked_cluster
+        ha.load_cluster_from_dcs()
 
     def test_start_as_slave(self):
         self.p.is_healthy = false


### PR DESCRIPTION
This will help to survive when everything was wiped from configuration store.

https://github.com/zalando/patroni/issues/3