### PR TITLE
Move the functionality of restoring a replica from backup into an external script

### DIFF
--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -145,98 +145,15 @@ class Postgresql:
         env['PGPASSFILE'] = pgpass
         return self.create_replica(r, env) == 0
 
+    @staticmethod
+    def build_connstring(self, conn):
+        return "host={host} port={port} user={user}".format(**conn)
+
     def create_replica(self, master_connection, env):
-        """ creates a new replica using either pg_basebackup or WAL-E """
-        if self.should_use_s3_to_create_replica(master_connection):
-            result = self.create_replica_with_s3()
-            # if restore from the backup on S3 failed - try with the pg_basebackup
-            if result == 0:
-                return result
-        return self.create_replica_with_pg_basebackup(master_connection, env)
-
-    def create_replica_with_pg_basebackup(self, master_connection, env):
-        ret = subprocess.call(['pg_basebackup', '-R', '-D', self.data_dir, '--host=' + master_connection['host'],
-                               '--port=' + str(master_connection['port']), '-U', master_connection['user']], env=env)
-        self.delete_trigger_file()
+        connstring = self.build_connstring(master_connection, master_connection)
+        cmd = self.config['restore']
+        ret = subprocess.call(shlex.split(os.path.abspath(cmd))+[self.scope, "replica", self.data_dir, connstring], env=env)
         return ret
-
-    def create_replica_with_s3(self):
-        if not self.wal_e or not self.wal_e_path:
-            return 1
-
-        ret = subprocess.call(self.wal_e_path + ' backup-fetch {} LATEST'.format(self.data_dir), shell=True)
-        self.restore_configuration_files()
-        return ret
-
-    def should_use_s3_to_create_replica(self, master_connection):
-        """ determine whether it makes sense to use S3 and not pg_basebackup """
-        if not self.wal_e or not self.wal_e_path:
-            return False
-
-        threshold_megabytes = self.wal_e.get('threshold_megabytes', 10240)
-        threshold_backup_size_percentage = self.wal_e.get('threshold_backup_size_percentage', 30)
-
-        try:
-            latest_backup = subprocess.check_output(self.wal_e_path.split() + ['backup-list', '--detail', 'LATEST'])
-            # name    last_modified   expanded_size_bytes wal_segment_backup_start    wal_segment_offset_backup_start
-            #                                                   wal_segment_backup_stop wal_segment_offset_backup_stop
-            # base_00000001000000000000007F_00000040  2015-05-18T10:13:25.000Z
-            # 20310671    00000001000000000000007F    00000040
-            # 00000001000000000000007F    00000240
-            backup_strings = latest_backup.splitlines() if latest_backup else ()
-            if len(backup_strings) != 2:
-                return False
-
-            names = backup_strings[0].split()
-            vals = backup_strings[1].split()
-            if (len(names) != len(vals)) or (len(names) != 7):
-                return False
-
-            backup_info = dict(zip(names, vals))
-        except subprocess.CalledProcessError as e:
-            logger.error("could not query wal-e latest backup: {}".format(e))
-            return False
-
-        try:
-            backup_size = backup_info['expanded_size_bytes']
-            backup_start_segment = backup_info['wal_segment_backup_start']
-            backup_start_offset = backup_info['wal_segment_offset_backup_start']
-        except Exception as e:
-            logger.error("unable to get some of S3 backup parameters: {}".format(e))
-            return False
-
-        # WAL filename is XXXXXXXXYYYYYYYY000000ZZ, where X - timeline, Y - LSN logical log file,
-        # ZZ - 2 high digits of LSN offset. The rest of the offset is the provided decimal offset,
-        # that we have to convert to hex and 'prepend' to the high offset digits.
-
-        lsn_segment = backup_start_segment[8:16]
-        # first 2 characters of the result are 0x and the last one is L
-        lsn_offset = hex((long(backup_start_segment[16:32], 16) << 24) + long(backup_start_offset))[2:-1]
-
-        # construct the LSN from the segment and offset
-        backup_start_lsn = '{}/{}'.format(lsn_segment, lsn_offset)
-
-        conn = None
-        cursor = None
-        diff_in_bytes = long(backup_size)
-        try:
-            # get the difference in bytes between the current WAL location and the backup start offset
-            conn = psycopg2.connect(**master_connection)
-            conn.autocommit = True
-            cursor = conn.cursor()
-            cursor.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)", (backup_start_lsn,))
-            diff_in_bytes = long(cursor.fetchone()[0])
-        except psycopg2.Error as e:
-            logger.error('could not determine difference with the master location: {}'.format(e))
-            return False
-        finally:
-            cursor and cursor.close()
-            conn and conn.close()
-
-        # if the size of the accumulated WAL segments is more than a certan percentage of the backup size
-        # or exceeds the pre-determined size - pg_basebackup is chosen instead.
-        return (diff_in_bytes < long(threshold_megabytes) * 1048576) and\
-               (diff_in_bytes < long(backup_size) * float(threshold_backup_size_percentage) / 100)
 
     def is_leader(self, check_only=False):
         ret = not self.query('SELECT pg_is_in_recovery()').fetchone()[0]

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -140,11 +140,11 @@ class Postgresql:
         return self.create_replica(r, env) == 0
 
     @staticmethod
-    def build_connstring(self, conn):
+    def build_connstring(conn):
         return "host={host} port={port} user={user}".format(**conn)
 
     def create_replica(self, master_connection, env):
-        connstring = self.build_connstring(master_connection, master_connection)
+        connstring = self.build_connstring(master_connection)
         cmd = self.config['restore']
         try:
             ret = subprocess.call(shlex.split(os.path.abspath(cmd))+[self.scope, "replica",

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -154,6 +154,7 @@ class Postgresql:
         cmd = self.config['restore']
         ret = subprocess.call(shlex.split(os.path.abspath(cmd))+[self.scope, "replica",
                               self.data_dir, connstring], env=env)
+        self.delete_trigger_file()
         return ret
 
     def is_leader(self, check_only=False):

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -145,7 +145,7 @@ class Postgresql:
 
     def create_replica(self, master_connection, env):
         connstring = self.build_connstring(master_connection)
-        cmd = os.path.abspath(self.config['restore'])
+        cmd = self.config['restore']
         try:
             ret = subprocess.call(shlex.split(cmd) + [self.scope, "replica", self.data_dir, connstring], env=env)
             self.delete_trigger_file()
@@ -168,7 +168,7 @@ class Postgresql:
         """ pick a callback command and call it without waiting for it to finish """
         if not self.callback or cb_name not in self.callback:
             return False
-        cmd = os.path.abspath(self.callback[cb_name])
+        cmd = self.callback[cb_name]
         if is_leader is None:
             try:
                 is_leader = self.is_leader(check_only=True)

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -152,7 +152,8 @@ class Postgresql:
     def create_replica(self, master_connection, env):
         connstring = self.build_connstring(master_connection, master_connection)
         cmd = self.config['restore']
-        ret = subprocess.call(shlex.split(os.path.abspath(cmd))+[self.scope, "replica", self.data_dir, connstring], env=env)
+        ret = subprocess.call(shlex.split(os.path.abspath(cmd))+[self.scope, "replica",
+                              self.data_dir, connstring], env=env)
         return ret
 
     def is_leader(self, check_only=False):

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -46,6 +46,7 @@ postgresql:
     env_dir: /home/postgres/etc/wal-e.d/env
     threshold_megabytes: 10240
     threshold_backup_size_percentage: 30
+  restore: /usr/bin/true
   #recovery_conf:
     #restore_command: cp ../wal_archive/%f %p
   parameters:

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -46,7 +46,7 @@ postgresql:
     env_dir: /home/postgres/etc/wal-e.d/env
     threshold_megabytes: 10240
     threshold_backup_size_percentage: 30
-  restore: /usr/bin/true
+  restore: "true"
   #recovery_conf:
     #restore_command: cp ../wal_archive/%f %p
   parameters:

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,6 +1,8 @@
 boto
 dnspython
+mock
 psycopg2
 PyYAML
 requests
+six >= 1.7
 kazoo>=2.2.1

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,4 +1,5 @@
 boto
+mock
 dnspython3
 psycopg2
 PyYAML

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -194,6 +194,6 @@ class WALERestore(Restore):
 if __name__ == '__main__':
     if len(sys.argv) == 5:
         # scope, role, datadir, connstring
-        restore = Restore(*(sys.argv[1:]))
+        restore = WALERestore(*(sys.argv[1:]))
         sys.exit(restore.run())
     sys.exit("Usage: {0} scope role datadir connstring".format(sys.argv[0]))

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -74,6 +74,7 @@ class Restore(object):
             return 1
         return ret
 
+
 class WALERestore(Restore):
 
     def __init__(self, scope, role, datadir, connstring, env=None):
@@ -133,7 +134,8 @@ class WALERestore(Restore):
         threshold_backup_size_percentage = self.wal_e.threshold_backup_size_percentage
 
         try:
-            latest_backup = subprocess.check_output(self.wal_e.cmd.split() + ['backup-list', '--detail', 'LATEST'], env=self.env)
+            latest_backup = subprocess.check_output(self.wal_e.cmd.split() + ['backup-list', '--detail', 'LATEST'],
+                                                    env=self.env)
             # name    last_modified   expanded_size_bytes wal_segment_backup_start    wal_segment_offset_backup_start
             #                                                   wal_segment_backup_stop wal_segment_offset_backup_stop
             # base_00000001000000000000007F_00000040  2015-05-18T10:13:25.000Z

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # arguments are:
 #   - cluster scope
 #   - cluster role
@@ -17,7 +18,7 @@ class Restore:
         self.scope = scope
         self.role = role
         self.connstring = connstring
-        self.datadir = datadir
+        self.data_dir = datadir
         self.env = os.environ.copy()
 
     def parse_connstring(self):
@@ -50,7 +51,6 @@ class Restore:
         ret = subprocess.call(['pg_basebackup', '-R', '-D', self.data_dir, '--host=' + master_connection['host'],
                                '--port=' + str(master_connection['port']), '-U', master_connection['user']],
                               env=self.env)
-        self.delete_trigger_file()
         return ret
 
 

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -48,7 +48,8 @@ class Restore:
     def create_replica_with_pg_basebackup(self):
         master_connection = self.parse_connstring()
         ret = subprocess.call(['pg_basebackup', '-R', '-D', self.data_dir, '--host=' + master_connection['host'],
-                               '--port=' + str(master_connection['port']), '-U', master_connection['user']], env=self.env)
+                               '--port=' + str(master_connection['port']), '-U', master_connection['user']],
+                              env=self.env)
         self.delete_trigger_file()
         return ret
 

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -1,0 +1,153 @@
+# arguments are:
+#   - cluster scope
+#   - cluster role
+#   - master connection string
+import logging
+import os
+import psycopg2
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+class Restore:
+
+    def __init__(self, scope, role, datadir, connstring):
+        self.scope = scope
+        self.role = role
+        self.connstring = connstring
+        self.datadir = datadir
+        self.env = os.environ.copy()
+
+    def parse_connstring(self):
+        # the connection string is in the form host= port= user=
+        # return the dictionary with all components as separare keys
+        result = {}
+        if self.connstring:
+            for x in self.connstring.split():
+                if x and '=' in x:
+                    key, val = x.split('=')
+                result[key.strip()] = val.strip()
+        return result
+
+    def replica_method(self):
+        return self.create_replica_with_pg_basebackup
+
+    def replica_fallback_method(self):
+        return None
+
+    def run(self):
+        """ creates a new replica using either pg_basebackup or WAL-E """
+        method_fn = self.replica_method()
+        ret = method_fn()
+        if ret != 0 and self.replica_fallback_method() is not None:
+            ret = (self.replica_fallback_method())()
+        return ret
+
+    def create_replica_with_pg_basebackup(self):
+        master_connection = self.parse_connstring()
+        ret = subprocess.call(['pg_basebackup', '-R', '-D', self.data_dir, '--host=' + master_connection['host'],
+                               '--port=' + str(master_connection['port']), '-U', master_connection['user']], env=self.env)
+        self.delete_trigger_file()
+        return ret
+
+
+class WALERestore(Restore):
+
+    def __init__(self, scope, role, datadir, connstring):
+        super(WALERestore, self).__init__(scope, role, datadir, connstring)
+
+    def replica_method(self):
+        if self.should_use_s3_to_create_replica(self):
+            return self.create_replica_with_s3
+        return self.create_replica_with_pg_basebackup
+
+    def replica_fallback_method(self):
+        return self.create_replica_with_pg_basebackup
+
+    def should_use_s3_to_create_replica(self, master_connection):
+        """ determine whether it makes sense to use S3 and not pg_basebackup """
+        if not self.wal_e or not self.wal_e_paselfth:
+            return False
+
+        threshold_megabytes = self.wal_e.get('threshold_megabytes', 10240)
+        threshold_backup_size_percentage = self.wal_e.get('threshold_backup_size_percentage', 30)
+
+        try:
+            latest_backup = subprocess.check_output(self.wal_e_path.split() + ['backup-list', '--detail', 'LATEST'])
+            # name    last_modified   expanded_size_bytes wal_segment_backup_start    wal_segment_offset_backup_start
+            #                                                   wal_segment_backup_stop wal_segment_offset_backup_stop
+            # base_00000001000000000000007F_00000040  2015-05-18T10:13:25.000Z
+            # 20310671    00000001000000000000007F    00000040
+            # 00000001000000000000007F    00000240
+            backup_strings = latest_backup.splitlines() if latest_backup else ()
+            if len(backup_strings) != 2:
+                return False
+
+            names = backup_strings[0].split()
+            vals = backup_strings[1].split()
+            if (len(names) != len(vals)) or (len(names) != 7):
+                return False
+
+            backup_info = dict(zip(names, vals))
+        except subprocess.CalledProcessError as e:
+            logger.error("could not query wal-e latest backup: {}".format(e))
+            return False
+
+        try:
+            backup_size = backup_info['expanded_size_bytes']
+            backup_start_segment = backup_info['wal_segment_backup_start']
+            backup_start_offset = backup_info['wal_segment_offset_backup_start']
+        except Exception as e:
+            logger.error("unable to get some of S3 backup parameters: {}".format(e))
+            return False
+
+        # WAL filename is XXXXXXXXYYYYYYYY000000ZZ, where X - timeline, Y - LSN logical log file,
+        # ZZ - 2 high digits of LSN offset. The rest of the offset is the provided decimal offset,
+        # that we have to convert to hex and 'prepend' to the high offset digits.
+
+        lsn_segment = backup_start_segment[8:16]
+        # first 2 characters of the result are 0x and the last one is L
+        lsn_offset = hex((long(backup_start_segment[16:32], 16) << 24) + long(backup_start_offset))[2:-1]
+
+        # construct the LSN from the segment and offset
+        backup_start_lsn = '{}/{}'.format(lsn_segment, lsn_offset)
+
+        conn = None
+        cursor = None
+        diff_in_bytes = long(backup_size)
+        try:
+            # get the difference in bytes between the current WAL location and the backup start offset
+            conn = psycopg2.connect(**master_connection)
+            conn.autocommit = True
+            cursor = conn.cursor()
+            cursor.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)", (backup_start_lsn,))
+            diff_in_bytes = long(cursor.fetchone()[0])
+        except psycopg2.Error as e:
+            logger.error('could not determine difference with the master location: {}'.format(e))
+            return False
+        finally:
+            cursor and cursor.close()
+            conn and conn.close()
+
+        # if the size of the accumulated WAL segments is more than a certan percentage of the backup size
+        # or exceeds the pre-determined size - pg_basebackup is chosen instead.
+        return (diff_in_bytes < long(threshold_megabytes) * 1048576) and\
+               (diff_in_bytes < long(backup_size) * float(threshold_backup_size_percentage) / 100)
+
+    def create_replica_with_s3(self):
+        if not self.wal_e or not self.wal_e_path:
+            return 1
+
+        ret = subprocess.call(self.wal_e_path + ' backup-fetch {} LATEST'.format(self.data_dir), shell=True)
+        self.restore_configuration_files()
+        return ret
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 5:
+        # scope, role, datadir, connstring
+        restore = Restore(*(sys.argv[1:]))
+        sys.exit(restore.run())
+    sys.exit("Usage: {0} scope role datadir connstring".format(sys.argv[0]))

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -20,7 +20,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-class Restore:
+class Restore(object):
 
     def __init__(self, scope, role, datadir, connstring):
         self.scope = scope

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -30,7 +30,7 @@ class Restore:
         self.env = os.environ.copy()
 
     @staticmethod
-    def parse_connstring(self, connstring):
+    def parse_connstring(connstring):
         # the connection string is in the form host= port= user=
         # return the dictionary with all components as separare keys
         result = {}

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -75,8 +75,8 @@ class WALERestore(Restore):
            self.env.get('WALE_BACKUP_THRESHOLD_MEGABYTES')) is None:
                 self.init_error = True
         else:
-            self.wal_e = namedtuple('WALE', 'threshold_megabytes', 'threshold_backup_size_percentage',
-                                    's3_bucket', 'cmd', 'dir', 'env_file')
+            self.wal_e = namedtuple('WALE',
+                                    'threshold_megabytes threshold_backup_size_percentage s3_bucket cmd dir env_file')
 
             self.wal_e.dir = self.env.get('WALE_ENV_DIR', '/home/postgres/etc/wal-e.d/env')
             self.wal_e.env_file = os.path.join(self.wal_e.dir, 'WALE_S3_PREFIX')

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -118,9 +118,9 @@ class TestPostgresql(unittest.TestCase):
                                              'password': 'rep-pass',
                                              'network': '127.0.0.1/32'},
                              'parameters': {'foo': 'bar'}, 'recovery_conf': {'foo': 'bar'},
-                             'callbacks': {'on_start': '/usr/bin/true', 'on_stop': '/usr/bin/true',
-                                           'on_restart': '/usr/bin/true', 'on_role_change': '/bin/true',
-                                           'on_reload': '/usr/bin/true'
+                             'callbacks': {'on_start': 'true', 'on_stop': 'true',
+                                           'on_restart': 'true', 'on_role_change': 'true',
+                                           'on_reload': 'true'
                                            },
                              'restore': '/usr/bin/true'})
         psycopg2.connect = psycopg2_connect

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -122,7 +122,8 @@ class TestPostgresql(unittest.TestCase):
                              'callbacks': {'on_start': '/usr/bin/true', 'on_stop': '/usr/bin/true',
                                            'on_restart': '/usr/bin/true', 'on_role_change': '/bin/true',
                                            'on_reload': '/usr/bin/true'
-                                           }})
+                                           },
+                             'restore': '/usr/bin/true'})
         psycopg2.connect = psycopg2_connect
         if not os.path.exists(self.p.data_dir):
             os.makedirs(self.p.data_dir)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -50,7 +50,6 @@ class TestRestore(unittest.TestCase):
         self.assertEqual(ret, 1)
 
 
-
 @patch('os.access', MagicMock(return_value=True))
 @patch('os.makedirs', MagicMock(return_value=True))
 @patch('os.path.exists', MagicMock(return_value=True))
@@ -76,7 +75,6 @@ class TestWALERestore(unittest.TestCase):
         self.wale_restore.setup()
         self.assertFalse(self.wale_restore.init_error)
 
-
     # have to redefine the class-level os.access mock inside the function
     # since the class-level mock will be applied after the function level one.
     @patch('os.access', return_value=False)
@@ -84,7 +82,6 @@ class TestWALERestore(unittest.TestCase):
         os.access = mock_no_access
         self.wale_restore.setup()
         self.assertTrue(self.wale_restore.init_error)
-
 
     # The 3 tests above only differ with the mock function instead of a subprocess call
     # in the first one, subprocess call should return success only for wal-e command,

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,114 @@
+import unittest
+from mock import MagicMock, patch
+import os
+from scripts.restore import Restore, WALERestore
+
+
+def fake_cursor_fetchone(*args, **kwargs):
+    return ('16777216',)
+
+
+def fake_call_fail_for_wal_e(*args, **kwargs):
+    if len(args) > 0 and 'backup-fetch' in args[0]:
+        return 1
+    return 0
+
+
+def fake_call_fail_for_base_backup(*args, **kwargs):
+    if len(args) > 0 and 'backup-fetch' in args[0]:
+        return 0
+    return 1
+
+
+def fake_backup_data(self, *args, **kwargs):
+    """ return the fake result of WAL-E backup-list"""
+    return """name    last_modified   expanded_size_bytes wal_segment_backup_start    wal_segment_offset_backup_start wal_segment_backup_stop wal_segment_offset_backup_stop
+base_00000001000000000000007F_00000040  2015-05-18T10:13:25.000Z 167772160   00000001000000000000007F    00000040 00000001000000000000007F    00000240
+"""
+
+
+class TestRestore(unittest.TestCase):
+
+    def setUp(self):
+        self.restore = Restore("batman", "master", "/data", "host=batman port=5432 user=batman")
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_parse_connstring(self):
+        self.assertDictEqual(self.restore.master_connection, {'host': 'batman', 'port': '5432', 'user': 'batman'})
+
+    @patch('subprocess.call', MagicMock(return_value=0))
+    def test_run(self):
+        ret = self.restore.run()
+        self.assertEqual(ret, 0)
+
+    @patch('subprocess.call', MagicMock(return_value=1))
+    def test_run_fail(self):
+        ret = self.restore.run()
+        self.assertEqual(ret, 1)
+
+
+
+@patch('os.access', MagicMock(return_value=True))
+@patch('os.makedirs', MagicMock(return_value=True))
+@patch('os.path.exists', MagicMock(return_value=True))
+@patch('os.path.isdir', MagicMock(return_value=True))
+@patch('psycopg2.extensions.cursor.fetchone', MagicMock(side_effect=fake_cursor_fetchone))
+@patch('psycopg2.extensions.cursor', MagicMock(autospec=True))
+@patch('psycopg2.extensions.connection', MagicMock(autospec=True))
+@patch('psycopg2.connect', MagicMock(autospec=True))
+@patch('subprocess.check_output', MagicMock(side_effect=fake_backup_data))
+class TestWALERestore(unittest.TestCase):
+
+    def setUp(self):
+        env = {}
+        env['WAL_S3_BUCKET'] = 'batman'
+        env['WALE_BACKUP_THRESHOLD_PERCENTAGE'] = 100
+        env['WALE_BACKUP_THRESHOLD_MEGABYTES'] = 100
+        self.wale_restore = WALERestore("batman", "master", "/data", "host=batman port=5432 user=batman", env=env)
+
+    def tearDown(self):
+        pass
+
+    def test_setup(self):
+        self.wale_restore.setup()
+        self.assertFalse(self.wale_restore.init_error)
+
+
+    # have to redefine the class-level os.access mock inside the function
+    # since the class-level mock will be applied after the function level one.
+    @patch('os.access', return_value=False)
+    def test_setup_fail(self, mock_no_access):
+        os.access = mock_no_access
+        self.wale_restore.setup()
+        self.assertTrue(self.wale_restore.init_error)
+
+
+    # The 3 tests above only differ with the mock function instead of a subprocess call
+    # in the first one, subprocess call should return success only for wal-e command,
+    # checking the primary use-case of restoring from WAL-E backup.
+    # In the second one, we test fallbacks by failing at WAL-E, but succeeding at
+    # pg_basebackup.
+    # Finally, the last use case is when all subprocess.call fails. resulting in a
+    # failure to restore from replica
+    @patch('subprocess.call',
+           MagicMock(side_effect=lambda *args, **kwargs: 0 if 'wal-e' in args[0] else 1))
+    def test_run(self):
+        self.wale_restore.setup()
+        ret = self.wale_restore.run()
+        self.assertEqual(ret, 0)
+
+    @patch('subprocess.call',
+           MagicMock(side_effect=lambda *args, **kwargs: 0 if 'pg_basebackup' in args[0] else 1))
+    def test_run_fallback(self):
+        self.wale_restore.setup()
+        ret = self.wale_restore.run()
+        self.assertEqual(ret, 0)
+
+    @patch('subprocess.call', MagicMock(return_value=1))
+    def test_run_all_fail(self):
+        self.wale_restore.setup()
+        ret = self.wale_restore.run()
+        self.assertEqual(ret, 1)


### PR DESCRIPTION
Move the functionality of restoring a replica from backup into an external script. Now one can plugin-in new methods for bringing replicas to life (EBS snapshots, cloning from some external source, etc) without hacking into Patroni.

scripts/restore.py provides former functionality of choosing between WAL-E and pg_basebackup. In order for it to work, the spilo image has to install WAL-E and export environment variables.
