### PR TITLE
Retry requests to configuration store

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,16 @@
+class PatroniException(Exception):
+    pass
+
+
+class DCSError(PatroniException):
+    """Parent class for all kind of exceptions related to selected distributed configuration store"""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        """
+        >>> str(DCSError('foo'))
+        "'foo'"
+        """
+        return repr(self.value)

--- a/helpers/dcs.py
+++ b/helpers/dcs.py
@@ -1,6 +1,7 @@
 import abc
 
 from collections import namedtuple
+from helpers import DCSError
 from helpers.utils import calculate_ttl, sleep
 from six.moves.urllib_parse import urlparse, urlunparse, parse_qsl
 
@@ -20,20 +21,6 @@ def parse_connection_string(value):
     conn_url = urlunparse((scheme, netloc, path, params, '', fragment))
     api_url = ([v for n, v in parse_qsl(query) if n == 'application_name'] or [None])[0]
     return conn_url, api_url
-
-
-class DCSError(Exception):
-    """Parent class for all kind of exceptions related to selected distributed configuration store"""
-
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self):
-        """
-        >>> str(DCSError('foo'))
-        "'foo'"
-        """
-        return repr(self.value)
 
 
 class Member(namedtuple('Member', 'index,name,conn_url,api_url,expiration,ttl')):

--- a/helpers/etcd.py
+++ b/helpers/etcd.py
@@ -211,7 +211,7 @@ class Etcd(AbstractDCS):
 
     @catch_etcd_errors
     def take_leader(self):
-        return self.client.set(self.client_path('/leader'), self._name, self.ttl)
+        return self.retry(self.client.set, self.client_path('/leader'), self._name, self.ttl)
 
     def attempt_to_acquire_leader(self):
         try:

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,9 +1,12 @@
 import datetime
 import os
+import random
 import re
 import signal
 import sys
 import time
+
+from helpers import DCSError
 
 interrupted_sleep = False
 reap_children = False
@@ -107,3 +110,77 @@ def reap_children():
             pass
         finally:
             reap_children = False
+
+
+class RetryFailedError(DCSError):
+    """Raised when retrying an operation ultimately failed, after retrying the maximum number of attempts."""
+
+
+class Retry:
+    """Helper for retrying a method in the face of retry-able exceptions"""
+
+    def __init__(self, max_tries=1, delay=0.1, backoff=2, max_jitter=0.8, max_delay=3600,
+                 sleep_func=time.sleep, deadline=None, retry_exceptions=DCSError):
+        """Create a :class:`Retry` instance for retrying function calls
+
+        :param max_tries: How many times to retry the command. -1 means infinite tries.
+        :param delay: Initial delay between retry attempts.
+        :param backoff: Backoff multiplier between retry attempts. Defaults to 2 for exponential backoff.
+        :param max_jitter: Additional max jitter period to wait between retry attempts to avoid slamming the server.
+        :param max_delay: Maximum delay in seconds, regardless of other backoff settings. Defaults to one hour.
+        :param retry_exceptions: single exception or tuple"""
+
+        self.max_tries = max_tries
+        self.delay = delay
+        self.backoff = backoff
+        self.max_jitter = int(max_jitter * 100)
+        self.max_delay = float(max_delay)
+        self._attempts = 0
+        self._cur_delay = delay
+        self.deadline = deadline
+        self._cur_stoptime = None
+        self.sleep_func = sleep_func
+        self.retry_exceptions = retry_exceptions
+
+    def reset(self):
+        """Reset the attempt counter"""
+        self._attempts = 0
+        self._cur_delay = self.delay
+        self._cur_stoptime = None
+
+    def copy(self):
+        """Return a clone of this retry manager"""
+        return Retry(max_tries=self.max_tries, delay=self.delay, backoff=self.backoff,
+                     max_jitter=self.max_jitter / 100.0, max_delay=self.max_delay, sleep_func=self.sleep_func,
+                     deadline=self.deadline, retry_exceptions=self.retry_exceptions)
+
+    def __call__(self, func, *args, **kwargs):
+        """Call a function with arguments until it completes without throwing a `retry_exceptions`
+
+        :param func: Function to call
+        :param args: Positional arguments to call the function with
+        :params kwargs: Keyword arguments to call the function with
+
+        The function will be called until it doesn't throw one of the retryable exceptions"""
+        self.reset()
+
+        while True:
+            try:
+                if self.deadline is not None and self._cur_stoptime is None:
+                    self._cur_stoptime = time.time() + self.deadline
+                return func(*args, **kwargs)
+            except self.retry_exceptions:
+                # Note: max_tries == -1 means infinite tries.
+                if self._attempts == self.max_tries:
+                    raise RetryFailedError("Too many retry attempts")
+                self._attempts += 1
+                sleeptime = self._cur_delay + (
+                    random.randint(0, self.max_jitter) / 100.0)
+
+                if self._cur_stoptime is not None and \
+                   time.time() + sleeptime >= self._cur_stoptime:
+                    raise RetryFailedError("Exceeded retry deadline")
+                else:
+                    self.sleep_func(sleeptime)
+                self._cur_delay = min(self._cur_delay * self.backoff,
+                                      self.max_delay)

--- a/patroni.py
+++ b/patroni.py
@@ -94,8 +94,8 @@ class Patroni:
                     self.ha.state_handler.drop_replication_slots()
             except:
                 logger.exception('Exception when changing replication slots')
-            self.schedule_next_run()
             reap_children()
+            self.schedule_next_run()
 
 
 def main():

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -26,6 +26,10 @@ class MockResponse:
 
     @property
     def data(self):
+        if self.content == 'TimeoutError':
+            raise urllib3.exceptions.TimeoutError
+        if self.content == 'Exception':
+            raise Exception
         return self.content
 
     @property
@@ -76,6 +80,8 @@ def etcd_watch(key, index=None, timeout=None, recursive=None):
 
 
 def etcd_write(key, value, **kwargs):
+    if key == '/service/exists/leader':
+        raise etcd.EtcdAlreadyExist
     if key == '/service/test/leader':
         if kwargs.get('prevValue', None) == 'foo' or not kwargs.get('prevExist', True):
             return True
@@ -190,6 +196,15 @@ class TestClient(unittest.TestCase):
         self.assertEquals(self.client.get_srv_record('blabla'), [])
         self.assertEquals(self.client.get_srv_record('exception'), [])
 
+    def test__result_from_response(self):
+        response = MockResponse()
+        response.content = 'TimeoutError'
+        self.assertRaises(urllib3.exceptions.TimeoutError, self.client._result_from_response, response)
+        response.content = 'Exception'
+        self.assertRaises(etcd.EtcdException, self.client._result_from_response, response)
+        response.content = '{}'
+        self.assertRaises(etcd.EtcdException, self.client._result_from_response, response)
+
     def test__get_machines_cache_from_srv(self):
         self.client.get_srv_record = lambda e: [('localhost', 2380)]
         self.client._get_machines_cache_from_srv('blabla')
@@ -241,6 +256,12 @@ class TestEtcd(unittest.TestCase):
 
     def test_take_leader(self):
         self.assertFalse(self.etcd.take_leader())
+
+    def testattempt_to_acquire_leader(self):
+        self.etcd._base_path = '/service/exists'
+        self.assertFalse(self.etcd.attempt_to_acquire_leader())
+        self.etcd._base_path = '/service/failed'
+        self.assertFalse(self.etcd.attempt_to_acquire_leader())
 
     def test_update_leader(self):
         self.assertTrue(self.etcd.update_leader(MockPostgresql()))

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -202,7 +202,7 @@ class TestClient(unittest.TestCase):
         self.assertRaises(urllib3.exceptions.TimeoutError, self.client._result_from_response, response)
         response.content = 'Exception'
         self.assertRaises(etcd.EtcdException, self.client._result_from_response, response)
-        response.content = '{}'
+        response.content = b'{}'
         self.assertRaises(etcd.EtcdException, self.client._result_from_response, response)
 
     def test__get_machines_cache_from_srv(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,8 @@ import os
 import time
 import unittest
 
-from helpers.utils import reap_children, sigchld_handler, sigterm_handler, sleep
+from helpers import DCSError
+from helpers.utils import Retry, RetryFailedError, reap_children, sigchld_handler, sigterm_handler, sleep
 
 
 def nop(*args, **kwargs):
@@ -43,3 +44,58 @@ class TestUtils(unittest.TestCase):
     def test_sleep(self):
         time.sleep = time_sleep
         sleep(0.01)
+
+
+class TestRetrySleeper(unittest.TestCase):
+
+    def _pass(self):
+        pass
+
+    def _fail(self, times=1):
+        scope = dict(times=0)
+
+        def inner():
+            if scope['times'] >= times:
+                pass
+            else:
+                scope['times'] += 1
+                raise DCSError('Failed!')
+        return inner
+
+    def _makeOne(self, *args, **kwargs):
+        return Retry(*args, **kwargs)
+
+    def test_reset(self):
+        retry = self._makeOne(delay=0, max_tries=2)
+        retry(self._fail())
+        self.assertEquals(retry._attempts, 1)
+        retry.reset()
+        self.assertEquals(retry._attempts, 0)
+
+    def test_too_many_tries(self):
+        retry = self._makeOne(delay=0)
+        self.assertRaises(RetryFailedError, retry, self._fail(times=999))
+        self.assertEquals(retry._attempts, 1)
+
+    def test_maximum_delay(self):
+        def sleep_func(_time):
+            pass
+
+        retry = self._makeOne(delay=10, max_tries=100, sleep_func=sleep_func)
+        retry(self._fail(times=10))
+        self.assertTrue(retry._cur_delay < 4000, retry._cur_delay)
+        # gevent's sleep function is picky about the type
+        self.assertEquals(type(retry._cur_delay), float)
+
+    def test_deadline(self):
+        def sleep_func(_time):
+            pass
+
+        retry = self._makeOne(deadline=0.0001, sleep_func=sleep_func)
+        self.assertRaises(RetryFailedError, retry, self._fail(times=10))
+
+    def test_copy(self):
+        _sleep = lambda t: None
+        retry = self._makeOne(sleep_func=_sleep)
+        rcopy = retry.copy()
+        self.assertTrue(rcopy.sleep_func is _sleep)


### PR DESCRIPTION
This functionality is inspired by kazoo and KazooRetry.
Idea: when etcd is not available or is not responding properly don't give up immediately but retry during some period of time (currently 10 seconds and this value is hardcoded).
