### PR TITLE
93compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ For an example file, see `postgres0.yml`.  Below is an explanation of settings:
   * *connect_address*: ip address + port through which Postgres is accessible from other nodes and applications.
   * *data_dir*: file path to initialize and store Postgres data files
   * *maximum_lag_on_failover*: the maximum bytes a follower may lag before it is not eligible become leader
+  * *use_slots*: whether or not to use replication_slots.  Must be False for PostgreSQL 9.3.
   * *pg_hba*: list of lines which should be added to pg_hba.conf
     * *- host all all 0.0.0.0/0 md5*
   * *replication*
@@ -84,8 +85,8 @@ For an example file, see `postgres0.yml`.  Below is an explanation of settings:
   * *admin*:
     * *username*: admin username, user will be created during initialization. It would have CREATEDB and CREATEROLE privileges
     * *password*: admin password, user will be created during initialization.
-  * *recovery_conf*: configuration settings written to recovery.conf when configuring follower
-  * *parameters*: list of configuration settings for Postgres
+  * *recovery_conf*: additional configuration settings written to recovery.conf when configuring follower
+  * *parameters*: list of configuration settings for Postgres.  Many of these are required for replication to work.
 
 ## Replication choices
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For an example file, see `postgres0.yml`.  Below is an explanation of settings:
   * *connect_address*: ip address + port through which Postgres is accessible from other nodes and applications.
   * *data_dir*: file path to initialize and store Postgres data files
   * *maximum_lag_on_failover*: the maximum bytes a follower may lag before it is not eligible become leader
-  * *use_slots*: whether or not to use replication_slots.  Must be False for PostgreSQL 9.3.
+  * *use_slots*: whether or not to use replication_slots.  Must be False for PostgreSQL 9.3, and you should comment out max_replication_slots.
   * *pg_hba*: list of lines which should be added to pg_hba.conf
     * *- host all all 0.0.0.0/0 md5*
   * *replication*

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -382,8 +382,8 @@ recovery_target_timeline = 'latest'
                 self.query("""SELECT pg_create_physical_replication_slot(%s)
                             WHERE NOT EXISTS (SELECT 1 FROM pg_replication_slots
                             WHERE slot_name = %s)""", slot, slot)
-                
-         self.members = members
+
+        self.members = members
 
     def create_replication_slots(self, cluster):
         self.sync_replication_slots([m.name for m in cluster.members if m.name != self.name])

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -43,7 +43,6 @@ class Postgresql:
     def __init__(self, config):
         self.config = config
         self.name = config['name']
-        
         self.scope = config['scope']
         self.listen_addresses, self.port = config['listen'].split(':')
         self.data_dir = config['data_dir']
@@ -257,8 +256,8 @@ class Postgresql:
                 member_conn = psycopg2.connect(**r)
                 member_conn.autocommit = True
                 member_cursor = member_conn.cursor()
-                member_cursor.execute(
-                    "SELECT pg_is_in_recovery(), %s - pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')",
+                member_cursor.execute("""SELECT pg_is_in_recovery(), 
+                    %s - pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')""",
                     (self.xlog_position(), ))
                 row = member_cursor.fetchone()
                 member_cursor.close()
@@ -362,8 +361,8 @@ recovery_target_timeline = 'latest'
 
     def xlog_position(self):
         return self.query("""SELECT CASE WHEN pg_is_in_recovery()
-                                         THEN pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')
-                                         ELSE pg_xlog_location_diff(pg_current_xlog_location(),'0/00000') END""").fetchone()[0]
+                             THEN pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')
+                             ELSE pg_xlog_location_diff(pg_current_xlog_location(),'0/00000') END""").fetchone()[0]
 
     def load_replication_slots(self):
         if self.use_slots:

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -257,7 +257,7 @@ class Postgresql:
                 member_conn.autocommit = True
                 member_cursor = member_conn.cursor()
                 member_cursor.execute("""SELECT pg_is_in_recovery(),
-                                      %s - pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')""",
+                                      %s - pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/00000')""",
                                       (self.xlog_position(), ))
                 row = member_cursor.fetchone()
                 member_cursor.close()

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -382,7 +382,8 @@ recovery_target_timeline = 'latest'
                 self.query("""SELECT pg_create_physical_replication_slot(%s)
                             WHERE NOT EXISTS (SELECT 1 FROM pg_replication_slots
                             WHERE slot_name = %s)""", slot, slot)
-            self.members = members
+                
+         self.members = members
 
     def create_replication_slots(self, cluster):
         self.sync_replication_slots([m.name for m in cluster.members if m.name != self.name])

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -50,7 +50,7 @@ class Postgresql:
         self.superuser = config['superuser']
         self.admin = config['admin']
         self.callback = config.get('callbacks', {})
-        self.use_slots = config['use_slots']
+        self.use_slots = config.get('use_slots',True)
         self.recovery_conf = os.path.join(self.data_dir, 'recovery.conf')
         self.configuration_to_save = (os.path.join(self.data_dir, 'pg_hba.conf'),
                                       os.path.join(self.data_dir, 'postgresql.conf'))

--- a/helpers/postgresql.py
+++ b/helpers/postgresql.py
@@ -256,9 +256,9 @@ class Postgresql:
                 member_conn = psycopg2.connect(**r)
                 member_conn.autocommit = True
                 member_cursor = member_conn.cursor()
-                member_cursor.execute("""SELECT pg_is_in_recovery(), 
-                    %s - pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')""",
-                    (self.xlog_position(), ))
+                member_cursor.execute("""SELECT pg_is_in_recovery(),
+                                      %s - pg_xlog_location_diff(pg_last_xlog_replay_location(),'0/0000000')""",
+                                      (self.xlog_position(), ))
                 row = member_cursor.fetchone()
                 member_cursor.close()
                 member_conn.close()

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -30,6 +30,7 @@ postgresql:
   connect_address: 127.0.0.1:5432
   data_dir: data/postgresql0
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
+  use_slots: True
   pg_hba:
   - host all all 0.0.0.0/0 md5
   - hostssl all all 0.0.0.0/0 md5

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -30,6 +30,7 @@ postgresql:
   connect_address: 127.0.0.1:5433
   data_dir: data/postgresql1
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
+  use_slots: True
   pg_hba:
   - host all all 0.0.0.0/0 md5
   - hostssl all all 0.0.0.0/0 md5

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -114,6 +114,7 @@ class TestPostgresql(unittest.TestCase):
                              'pg_hba': ['hostssl all all 0.0.0.0/0 md5', 'host all all 0.0.0.0/0 md5'],
                              'superuser': {'password': ''},
                              'admin': {'username': 'admin', 'password': 'admin'},
+                             'use_slots' : True,
                              'replication': {'username': 'replicator',
                                              'password': 'rep-pass',
                                              'network': '127.0.0.1/32'},


### PR DESCRIPTION
Makes replication slots optional (controlled by the configuration option "use_slots").  This allows Patroni to be used with 9.3.  