### PR TITLE
Build Cluster object for ZooKeeper the same way as for Etcd

### DIFF
--- a/patroni/zookeeper.py
+++ b/patroni/zookeeper.py
@@ -4,7 +4,7 @@ import requests
 import time
 
 from kazoo.client import KazooClient, KazooState
-from kazoo.exceptions import NoNodeError, NodeExistsError, KazooException
+from kazoo.exceptions import NoNodeError, NodeExistsError
 from patroni.dcs import AbstractDCS, Cluster, DCSError, Leader, Member, parse_connection_string
 from patroni.utils import sleep
 from requests.exceptions import RequestException

--- a/patroni/zookeeper.py
+++ b/patroni/zookeeper.py
@@ -110,10 +110,7 @@ class ZooKeeper(AbstractDCS):
         try:
             return self.client.get(key, watch)
         except NoNodeError:
-            pass
-        except:
-            logger.exception('get_node')
-        return None
+            return None
 
     @staticmethod
     def member(name, value, znode):
@@ -124,10 +121,7 @@ class ZooKeeper(AbstractDCS):
         try:
             return self.client.get_children(key, watch)
         except NoNodeError:
-            pass
-        except:
-            logger.exception('get_children')
-        return []
+            return []
 
     def load_members(self):
         members = []

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -58,8 +58,6 @@ class MockKazooClient:
     def get(self, path, watch=None):
         if path == '/no_node':
             raise NoNodeError
-        elif path == '/other_exception':
-            raise Exception()
         elif '/members/' in path:
             return (
                 'postgres://repuser:rep-pass@localhost:5434/postgres?application_name=http://127.0.0.1:8009/patroni',
@@ -77,8 +75,6 @@ class MockKazooClient:
     def get_children(self, path, watch=None, include_data=False):
         if path == '/no_node':
             raise NoNodeError
-        elif path == '/other_exception':
-            raise Exception()
         elif path in ['/service/bla/', '/service/test/']:
             return ['initialize', 'leader', 'members', 'optime']
         return ['foo', 'bar', 'buzz']
@@ -142,11 +138,9 @@ class TestZooKeeper(unittest.TestCase):
 
     def test_get_node(self):
         self.assertIsNone(self.zk.get_node('/no_node'))
-        self.assertIsNone(self.zk.get_node('/other_exception'))
 
     def test_get_children(self):
         self.assertListEqual(self.zk.get_children('/no_node'), [])
-        self.assertListEqual(self.zk.get_children('/other_exception'), [])
 
     def test__inner_load_cluster(self):
         self.zk._base_path = self.zk._base_path.replace('test', 'bla')

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -75,6 +75,12 @@ class MockKazooClient:
             return ('foo', ZnodeStat(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
 
     def get_children(self, path, watch=None, include_data=False):
+        if path == '/no_node':
+            raise NoNodeError
+        elif path == '/other_exception':
+            raise Exception()
+        elif path in ['/service/bla/', '/service/test/']:
+            return ['initialize', 'leader', 'members', 'optime']
         return ['foo', 'bar', 'buzz']
 
     def create(self, path, value="", acl=None, ephemeral=False, sequence=False, makepath=False):
@@ -137,6 +143,10 @@ class TestZooKeeper(unittest.TestCase):
     def test_get_node(self):
         self.assertIsNone(self.zk.get_node('/no_node'))
         self.assertIsNone(self.zk.get_node('/other_exception'))
+
+    def test_get_children(self):
+        self.assertListEqual(self.zk.get_children('/no_node'), [])
+        self.assertListEqual(self.zk.get_children('/other_exception'), [])
 
     def test__inner_load_cluster(self):
         self.zk._base_path = self.zk._base_path.replace('test', 'bla')


### PR DESCRIPTION
Previous implementation was always setting Cluster.initialize to True.
Also it was throwing ZooKeeperError when there were no members in a
cluster.

Plus BUGFIX of a bug introduced with
https://github.com/zalando/patroni/pull/34 in a `load_members` method.
- data = self.get_node(self.member_path)
+ data = self.get_node(self.members_path + member)
It was always fetching the same node for all cluster members.
Fortunately Etcd doesn't have such problem because we are fetching the
whole cluster directory with one recursive API call.