### PR TITLE
Feature/reschedule next run of ha cycle depending on return value of `watch`

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -84,15 +84,13 @@ class Patroni:
             self.postgresql.load_replication_slots()
 
     def schedule_next_run(self):
-        if self.postgresql.is_promoted:
-            self.next_run = time.time()
         self.next_run += self.nap_time
         current_time = time.time()
         nap_time = self.next_run - current_time
         if nap_time <= 0:
             self.next_run = current_time
-        else:
-            self.ha.dcs.watch(nap_time)
+        elif self.ha.dcs.watch(nap_time):
+            self.next_run = time.time()
 
     def run(self):
         self.api.start()

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -182,4 +182,11 @@ class AbstractDCS:
         """ Removes the initialize key for a cluster """
 
     def watch(self, timeout):
+        """If the current node is a master it should just sleep.
+        Any other node should watch for changes of leader key with a given timeout
+
+        :returns: `!True` if you would like reschedule next run of ha cycle
+        """
+
         sleep(timeout)
+        return False

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -185,8 +185,8 @@ class AbstractDCS:
         """If the current node is a master it should just sleep.
         Any other node should watch for changes of leader key with a given timeout
 
-        :returns: `!True` if you would like reschedule next run of ha cycle
-        """
+        :param timeout: timeout in seconds
+        :returns: `!True` if you would like to reschedule the next run of ha cycle"""
 
         sleep(timeout)
         return False

--- a/patroni/zookeeper.py
+++ b/patroni/zookeeper.py
@@ -245,3 +245,5 @@ class ZooKeeper(AbstractDCS):
         self.cluster_event.wait(timeout)
         if self.cluster_event.isSet():
             self.fetch_cluster = True
+            return self.cluster and self.cluster.leader and self.cluster.leader.name != self._name
+        return False

--- a/patroni/zookeeper.py
+++ b/patroni/zookeeper.py
@@ -245,5 +245,5 @@ class ZooKeeper(AbstractDCS):
         self.cluster_event.wait(timeout)
         if self.cluster_event.isSet():
             self.fetch_cluster = True
-            return self.cluster and self.cluster.leader and self.cluster.leader.name != self._name
+            return not self.cluster or not self.cluster.leader or self.cluster.leader.name != self._name
         return False

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -11,7 +11,7 @@ from mock import Mock, patch
 from patroni.api import RestApiServer
 from patroni.dcs import Cluster, Member, Leader
 from patroni.etcd import Etcd
-from patroni.exceptions import PostgresException
+from patroni.exceptions import DCSError, PostgresException
 from patroni import Patroni, main
 from patroni.zookeeper import ZooKeeper
 from six.moves import BaseHTTPServer
@@ -31,6 +31,10 @@ class SleepException(Exception):
 
 def time_sleep(*args):
     raise SleepException()
+
+
+def keyboard_interrupt(*args):
+    raise KeyboardInterrupt
 
 
 class Mock_BaseServer__is_shut_down:
@@ -61,9 +65,13 @@ def get_cluster_not_initialized_with_leader():
 
 
 def get_cluster_initialized_with_leader():
-    return get_cluster(True, Leader(0, 0, 0, 
+    return get_cluster(True, Leader(0, 0, 0,
                        Member(0, 'leader', 'postgres://replicator:rep-pass@127.0.0.1:5435/postgres',
                               None, None, 28)))
+
+
+def get_cluster_dcs_error():
+    raise DCSError('')
 
 
 class TestPatroni(unittest.TestCase):
@@ -122,6 +130,9 @@ class TestPatroni(unittest.TestCase):
 
             self.assertRaises(SleepException, main)
 
+            Patroni.run = keyboard_interrupt
+            main()
+
             Patroni.run = run
             Patroni.touch_member = touch_member
 
@@ -178,7 +189,12 @@ class TestPatroni(unittest.TestCase):
         self.p.postgresql.data_directory_empty = true
         self.p.initialize()
 
+        self.p.ha.dcs.get_cluster = get_cluster_dcs_error
+        self.assertRaises(SleepException, self.p.initialize)
+
     def test_schedule_next_run(self):
+        self.p.ha.dcs.watch = lambda e: True
+        self.p.schedule_next_run()
         self.p.next_run = time.time() - self.p.nap_time - 1
         self.p.schedule_next_run()
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -17,10 +17,6 @@ def subprocess_call(cmd, shell=False, env=None):
     return 0
 
 
-def false(*args, **kwargs):
-    return False
-
-
 class MockCursor:
 
     def __init__(self):

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -192,3 +192,5 @@ class TestZooKeeper(unittest.TestCase):
 
     def test_watch(self):
         self.zk.watch(0)
+        self.zk.cluster_event.isSet = lambda: False
+        self.zk.watch(0)


### PR DESCRIPTION
Current etcd implementation does not yet support timeout option when
`wait=true`: coreos/etcd#2468

Originally I've implemented `watch` method for `Etcd` class in a
following manner: if the leader key was updated just because master
needs to update ttl and watch timeout is not yet expired, I was
recalculating timeout and starting `watch` call once again.
Usually after "restart" we were getting urllib3.exceptions.TimeoutError.
The only possible way to recover after such exception - close socket and
establish a new connection. With pure http it's relatively cheap, but
with https and some kind of authorization on etcd side it would became
rather expensive and should be avoided.