### PR TITLE
 Refactor Postgresql.query method to use common retry mechanism

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -4,6 +4,8 @@ import json
 import logging
 import psycopg2
 
+from patroni.exceptions import PostgresConnectionException
+from patroni.utils import Retry, RetryFailedError
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from six.moves.socketserver import ThreadingMixIn
 from threading import Thread
@@ -59,6 +61,14 @@ class RestApiHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(b'Hello!')
 
+    def do_GET_patroni(self):
+        response = self.get_postgresql_status(True)
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(response).encode('utf-8'))
+
     def parse_request(self):
         """Override parse_request method to enrich basic functionality of `BaseHTTPRequestHandler` class
 
@@ -77,16 +87,22 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 self.command = mname
         return ret
 
-    def get_postgresql_status(self):
+    def query(self, sql, *params, **kwargs):
+        if not kwargs.get('retry', False):
+            return self.server.query(sql, *params)
+        retry = Retry(delay=2, retry_exceptions=PostgresConnectionException)
+        return retry(self.server.query, sql, *params)
+
+    def get_postgresql_status(self, retry=False):
         try:
-            row = self.server.query("""SELECT to_char(pg_postmaster_start_time(), 'YYYY-MM-DD HH24:MI:SS.MS TZ'),
-                                              pg_is_in_recovery(),
-                                              CASE WHEN pg_is_in_recovery()
-                                                   THEN null
-                                                   ELSE pg_current_xlog_location() END,
-                                              pg_last_xlog_receive_location(),
-                                              pg_last_xlog_replay_location(),
-                                              pg_is_in_recovery() AND pg_is_xlog_replay_paused()""")[0]
+            row = self.query("""SELECT to_char(pg_postmaster_start_time(), 'YYYY-MM-DD HH24:MI:SS.MS TZ'),
+                                       pg_is_in_recovery(),
+                                       CASE WHEN pg_is_in_recovery()
+                                            THEN null
+                                            ELSE pg_current_xlog_location() END,
+                                       pg_last_xlog_receive_location(),
+                                       pg_last_xlog_replay_location(),
+                                       pg_is_in_recovery() AND pg_is_xlog_replay_paused()""", retry=retry)[0]
             return {
                 'running': True,
                 'postmaster_start_time': row[0],
@@ -98,7 +114,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                     'location': row[2]
                 })
             }
-        except (psycopg2.OperationalError, psycopg2.InterfaceError):
+        except (psycopg2.Error, RetryFailedError, PostgresConnectionException):
             logger.exception('get_postgresql_status')
             return {'running': self.server.patroni.postgresql.is_running()}
 
@@ -128,11 +144,15 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
         self.daemon = True
 
     def query(self, sql, *params):
-        cursor = self.patroni.postgresql.connection().cursor()
-        cursor.execute(sql, params)
-        ret = [r for r in cursor]
-        cursor.close()
-        return ret
+        cursor = None
+        try:
+            with self.patroni.postgresql.connection().cursor() as cursor:
+                cursor.execute(sql, params)
+                return [r for r in cursor]
+        except psycopg2.Error as e:
+            if cursor and cursor.connection.closed == 0:
+                raise e
+            raise PostgresConnectionException('connection problems')
 
     @staticmethod
     def _set_fd_cloexec(fd):

--- a/patroni/exceptions.py
+++ b/patroni/exceptions.py
@@ -7,7 +7,7 @@ class PatroniException(Exception):
 
     def __str__(self):
         """
-        >>> str(DCSError('foo'))
+        >>> str(PatroniException('foo'))
         "'foo'"
         """
         return repr(self.value)
@@ -18,4 +18,8 @@ class PostgresException(PatroniException):
 
 
 class DCSError(PatroniException):
+    pass
+
+
+class PostgresConnectionException(PostgresException):
     pass

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1,7 +1,7 @@
 import logging
 import psycopg2
 
-from patroni.dcs import DCSError
+from patroni.exceptions import DCSError, PostgresConnectionException
 
 logger = logging.getLogger(__name__)
 
@@ -97,5 +97,5 @@ class Ha:
             if self.state_handler.is_leader():
                 self.state_handler.demote(None)
                 return 'demoted self because DCS is not accessible and i was a leader'
-        except psycopg2.Error:
+        except (psycopg2.Error, PostgresConnectionException):
             logger.exception('Error communicating with Postgresql.  Will try again')

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -1,11 +1,9 @@
 import datetime
-import dns.resolver
 import etcd
 import json
 import requests
 import urllib3
 import socket
-import time
 import unittest
 
 from dns.exception import DNSException
@@ -40,8 +38,7 @@ class MockResponse:
         return ''
 
 
-class MockPostgresql:
-    name = ''
+class MockPostgresql(Mock):
 
     def last_operation(self):
         return '0'
@@ -88,10 +85,6 @@ def etcd_write(key, value, **kwargs):
     raise etcd.EtcdException
 
 
-def etcd_delete(key, **kwargs):
-    raise etcd.EtcdException
-
-
 def etcd_read(key, **kwargs):
     if key == '/service/noleader/':
         raise DCSError('noleader')
@@ -123,16 +116,8 @@ def etcd_read(key, **kwargs):
     return etcd.EtcdResult(**response)
 
 
-def time_sleep(_):
-    pass
-
-
 class SleepException(Exception):
     pass
-
-
-def time_sleep_exception(_):
-    raise SleepException()
 
 
 class MockSRV:
@@ -151,7 +136,7 @@ def dns_query(name, type):
 def socket_getaddrinfo(*args):
     if args[0] == 'ok':
         return [(2, 1, 6, '', ('127.0.0.1', 2379)), (2, 1, 6, '', ('127.0.0.1', 2379))]
-    raise socket.error()
+    raise socket.error
 
 
 def http_request(method, url, **kwargs):
@@ -162,9 +147,6 @@ def http_request(method, url, **kwargs):
 
 class TestMember(unittest.TestCase):
 
-    def __init__(self, method_name='runTest'):
-        super(TestMember, self).__init__(method_name)
-
     def test_real_ttl(self):
         now = datetime.datetime.utcnow()
         member = Member(0, 'a', 'b', 'c', (now + datetime.timedelta(seconds=2)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'), None)
@@ -172,16 +154,14 @@ class TestMember(unittest.TestCase):
         self.assertEquals(Member(0, 'a', 'b', 'c', '', None).real_ttl(), -1)
 
 
+@patch('dns.resolver.query', dns_query)
+@patch('socket.getaddrinfo', socket_getaddrinfo)
+@patch('requests.get', requests_get)
 class TestClient(unittest.TestCase):
 
-    def __init__(self, method_name='runTest'):
-        self.setUp = self.set_up
-        super(TestClient, self).__init__(method_name)
-
-    def set_up(self):
-        socket.getaddrinfo = socket_getaddrinfo
-        requests.get = requests_get
-        dns.resolver.query = dns_query
+    @patch('dns.resolver.query', dns_query)
+    @patch('requests.get', requests_get)
+    def setUp(self):
         with patch.object(etcd.Client, 'machines') as mock_machines:
             mock_machines.__get__ = Mock(return_value=['http://localhost:2379', 'http://localhost:4001'])
             self.client = Client({'discovery_srv': 'test'})
@@ -206,11 +186,11 @@ class TestClient(unittest.TestCase):
         self.assertRaises(etcd.EtcdException, self.client._result_from_response, response)
 
     def test__get_machines_cache_from_srv(self):
-        self.client.get_srv_record = lambda e: [('localhost', 2380)]
+        self.client.get_srv_record = Mock(return_value=[('localhost', 2380)])
         self.client._get_machines_cache_from_srv('blabla')
 
     def test__get_machines_cache_from_dns(self):
-        self.client._get_machines_cache_from_dns('ok:2379')
+        self.client._get_machines_cache_from_dns('error:2379')
 
     def test__load_machines_cache(self):
         self.client._config = {}
@@ -219,25 +199,24 @@ class TestClient(unittest.TestCase):
         self.assertRaises(etcd.EtcdException, self.client._load_machines_cache)
 
 
+@patch('time.sleep', Mock())
+@patch('requests.get', requests_get)
 class TestEtcd(unittest.TestCase):
 
-    def __init__(self, method_name='runTest'):
-        self.setUp = self.set_up
-        super(TestEtcd, self).__init__(method_name)
-
-    def set_up(self):
-        time.sleep = time_sleep
+    def setUp(self):
         with patch.object(Client, 'machines') as mock_machines:
             mock_machines.__get__ = Mock(return_value=['http://localhost:2379', 'http://localhost:4001'])
             self.etcd = Etcd('foo', {'ttl': 30, 'host': 'localhost:2379', 'scope': 'test'})
             self.etcd.client.write = etcd_write
             self.etcd.client.read = etcd_read
+            self.etcd.client.delete = Mock(side_effect=etcd.EtcdException())
 
+    @patch('dns.resolver.query', dns_query)
     def test_get_etcd_client(self):
-        time.sleep = time_sleep_exception
         with patch.object(etcd.Client, 'machines') as mock_machines:
             mock_machines.__get__ = Mock(side_effect=etcd.EtcdException)
-            self.assertRaises(SleepException, self.etcd.get_etcd_client, {'discovery_srv': 'test'})
+            with patch('time.sleep', Mock(side_effect=SleepException())):
+                self.assertRaises(SleepException, self.etcd.get_etcd_client, {'discovery_srv': 'test'})
 
     def test_get_cluster(self):
         self.assertIsInstance(self.etcd.get_cluster(), Cluster)
@@ -257,7 +236,7 @@ class TestEtcd(unittest.TestCase):
     def test_take_leader(self):
         self.assertFalse(self.etcd.take_leader())
 
-    def testattempt_to_acquire_leader(self):
+    def test_attempt_to_acquire_leader(self):
         self.etcd._base_path = '/service/exists'
         self.assertFalse(self.etcd.attempt_to_acquire_leader())
         self.etcd._base_path = '/service/failed'
@@ -270,11 +249,9 @@ class TestEtcd(unittest.TestCase):
         self.assertFalse(self.etcd.initialize())
 
     def test_cancel_initializion(self):
-        self.etcd.client.delete = etcd_delete
         self.assertFalse(self.etcd.cancel_initialization())
 
     def test_delete_leader(self):
-        self.etcd.client.delete = etcd_delete
         self.assertFalse(self.etcd.delete_leader())
 
     def test_watch(self):

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -4,7 +4,7 @@ from mock import Mock, patch
 from patroni.dcs import Cluster, DCSError
 from patroni.etcd import Client, Etcd
 from patroni.ha import Ha
-from test_etcd import etcd_read, etcd_write
+from test_etcd import socket_getaddrinfo, etcd_read, etcd_write
 
 
 def true(*args, **kwargs):
@@ -52,35 +52,24 @@ class MockPostgresql:
         return 0
 
 
-def nop(*args, **kwargs):
-    pass
-
-
-def dead_etcd():
-    raise DCSError('Etcd is not responding properly')
-
-
 def get_unlocked_cluster():
     return Cluster(False, None, None, [])
 
 
 class TestHa(unittest.TestCase):
 
-    def __init__(self, method_name='runTest'):
-        self.setUp = self.set_up
-        super(TestHa, self).__init__(method_name)
-
-    def set_up(self):
+    @patch('socket.getaddrinfo', socket_getaddrinfo)
+    def setUp(self):
         self.p = MockPostgresql()
         with patch.object(Client, 'machines') as mock_machines:
             mock_machines.__get__ = Mock(return_value=['http://remotehost:2379'])
-            self.e = Etcd('foo', {'ttl': 30, 'host': 'remotehost:2379', 'scope': 'test'})
+            self.e = Etcd('foo', {'ttl': 30, 'host': 'ok:2379', 'scope': 'test'})
             self.e.client.read = etcd_read
             self.e.client.write = etcd_write
             self.ha = Ha(self.p, self.e)
             self.ha.load_cluster_from_dcs()
             self.ha.cluster = get_unlocked_cluster()
-            self.ha.load_cluster_from_dcs = nop
+            self.ha.load_cluster_from_dcs = Mock()
 
     def test_load_cluster_from_dcs(self):
         ha = Ha(self.p, self.e)
@@ -144,5 +133,5 @@ class TestHa(unittest.TestCase):
         self.assertEquals(self.ha.run_cycle(), 'no action.  i am a secondary and i am following a leader')
 
     def test_no_etcd_connection_master_demote(self):
-        self.ha.load_cluster_from_dcs = dead_etcd
+        self.ha.load_cluster_from_dcs = Mock(side_effect=DCSError('Etcd is not responding properly'))
         self.assertEquals(self.ha.run_cycle(), 'demoted self because DCS is not accessible and i was a leader')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,8 @@
-import os
-import time
 import unittest
 
-from patroni.exceptions import DCSError
+from mock import Mock, patch
+from patroni.exceptions import PatroniException
 from patroni.utils import Retry, RetryFailedError, reap_children, sigchld_handler, sigterm_handler, sleep
-
-
-def nop(*args, **kwargs):
-    pass
-
-
-def os_waitpid(a, b):
-    return (0, 0)
 
 
 def time_sleep(_):
@@ -20,36 +11,23 @@ def time_sleep(_):
 
 class TestUtils(unittest.TestCase):
 
-    def __init__(self, method_name='runTest'):
-        self.setUp = self.set_up
-        self.tearDown = self.tear_down
-        super(TestUtils, self).__init__(method_name)
-
-    def set_up(self):
-        self.time_sleep = time.sleep
-        time.sleep = nop
-
-    def tear_down(self):
-        time.sleep = self.time_sleep
-
     def test_sigterm_handler(self):
         self.assertRaises(SystemExit, sigterm_handler, None, None)
 
+    @patch('time.sleep', Mock())
     def test_reap_children(self):
         reap_children()
-        os.waitpid = os_waitpid
-        sigchld_handler(None, None)
-        reap_children()
+        with patch('os.waitpid', Mock(return_value=(0, 0))):
+            sigchld_handler(None, None)
+            reap_children()
 
+    @patch('time.sleep', time_sleep)
     def test_sleep(self):
-        time.sleep = time_sleep
         sleep(0.01)
 
 
+@patch('time.sleep', Mock())
 class TestRetrySleeper(unittest.TestCase):
-
-    def _pass(self):
-        pass
 
     def _fail(self, times=1):
         scope = dict(times=0)
@@ -59,7 +37,7 @@ class TestRetrySleeper(unittest.TestCase):
                 pass
             else:
                 scope['times'] += 1
-                raise DCSError('Failed!')
+                raise PatroniException('Failed!')
         return inner
 
     def _makeOne(self, *args, **kwargs):
@@ -78,20 +56,14 @@ class TestRetrySleeper(unittest.TestCase):
         self.assertEquals(retry._attempts, 1)
 
     def test_maximum_delay(self):
-        def sleep_func(_time):
-            pass
-
-        retry = self._makeOne(delay=10, max_tries=100, sleep_func=sleep_func)
+        retry = self._makeOne(delay=10, max_tries=100)
         retry(self._fail(times=10))
         self.assertTrue(retry._cur_delay < 4000, retry._cur_delay)
         # gevent's sleep function is picky about the type
         self.assertEquals(type(retry._cur_delay), float)
 
     def test_deadline(self):
-        def sleep_func(_time):
-            pass
-
-        retry = self._makeOne(deadline=0.0001, sleep_func=sleep_func)
+        retry = self._makeOne(deadline=0.0001)
         self.assertRaises(RetryFailedError, retry, self._fail(times=100))
 
     def test_copy(self):


### PR DESCRIPTION
query method in an api.py also needs retry in some cases (for example
when we are running is_healthiest_node check).
In all cases we should retry only when connection is closed or broken.
BUT, the connection status must be checked via cursor.connection (old
implementation was using general connection object for that). For
multi-threaded applications this is not appropriate, because some other
thread might restore connection.

In addition to that I've changed most of the unit tests to use `Mock` and
`patch` where it is possible.