### PR TITLE
Patroni needs a plugin system

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -4,6 +4,7 @@ import sys
 import time
 import yaml
 
+from patroni.plugin import get_plugins
 from patroni.api import RestApiServer
 from patroni.etcd import Etcd
 from patroni.ha import Ha
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 class Patroni:
 
     def __init__(self, config):
+        self.plugins = get_plugins(config, self)
         self.nap_time = config['loop_wait']
         self.postgresql = Postgresql(config['postgresql'])
         self.ha = Ha(self.postgresql, self.get_dcs(self.postgresql.name, config))

--- a/patroni/plugin.py
+++ b/patroni/plugin.py
@@ -1,0 +1,126 @@
+"""Plugin Machinery
+
+Plugins are objects which subscribe to events. An object subscribes to an event
+by implementing a method with the event name. There is a single namespace of event
+names, plugins can subscribe to as many events as they choose.
+
+Events come in 2 flavours:
+
+    * multiple: Multiple plugins can subscribe to a multiple event. They will all be run
+                in the order of their declaration in the config file. The return value
+                may or may not be used.
+    * single: Only one of these subscribers is allowed at a time.
+
+Events must document the arguments they will be called with.
+
+Registration and Usage
+----------------------
+
+Plugins are registered by adding them to the entry points in setup.py. e.g.
+
+    entry_points={
+        'patroni.plugin': [
+            'myplugin = mymodule:MyPlugin',
+        ],
+    },
+
+Plugins are only actually used if they appear in the configuration file in an
+ordered list of plugins to use:
+
+    plugins:
+        - myplugin1
+        - myplugin2
+
+Each plugin should provide it's own documentation about what configuration it
+needs.
+"""
+import logging
+from pkg_resources import iter_entry_points
+
+EVENTS = (
+        {'name': 'postgresql_name', 'type': 'single', 'required': False},
+        )
+
+def get_plugins(config, app):
+    plugins = load(config)
+    plugins = configure(plugins, config, app)
+    return get_event_handler(plugins, EVENTS)
+
+def load(config):
+    """Gets the plugin factories from the config file.
+
+    Plugins are sorted by the order they are specified in the config file.
+    """
+    plugin_names = [c.strip() for c in config.get('plugins', [])]
+    seen = set([])
+    for i in plugin_names:
+        if i in seen:
+            raise AssertionError('Duplicate plugin: {}'.format(i))
+        seen.add(i)
+    plugins = {}
+    available_plugins = []
+    for i in iter_entry_points('patroni.plugin'):
+        available_plugins.append(i.name)
+        if i.name in plugin_names:
+            if i.name in plugins:
+                raise Exception('Duplicate plugins for name {}, one was: {}'.format(i.name, plugin_factory))
+            plugin_factory = i.load(require=False) #EEK never auto install ANYTHING
+            plugins[i.name] = plugin_factory
+    not_seen = set(plugin_names) - set(plugins)
+    if not_seen:
+        raise Exception('Plugins were configured in the config file, but I could NOT find them: {}\n'
+                'Available plugins: {}'.format(not_seen, available_plugins))
+    return [(i, plugins[i]) for i in plugin_names] # set order to what is specified in config file
+
+def configure(plugins, *args, **kw):
+    """Setup all plugins by calling them with the passed arguments"""
+    c_plugins = []
+    for name, plugin_factory in plugins:
+        plugin = plugin_factory(name, *args, **kw)
+        c_plugins.append((name, plugin))
+    return c_plugins
+
+def _handlers_executor(handlers):
+    if not handlers:
+        return None
+    def call(self, *args, **kw):
+        return [h(*args, **kw) for _, _, h in handlers]
+    return call
+
+def _handlers_executor_single(handlers):
+    if not handlers:
+        return None
+    assert len(handlers) == 1
+    handler = handlers[0][2]
+    def call(self, *args, **kw):
+        return handler(*args, **kw)
+    return call
+
+def get_event_handler(setup_plugins, events):
+    class Handler:
+        plugins = dict(setup_plugins)
+    for event_name in events:
+        if isinstance(event_name, dict):
+            spec = event_name
+            event_name = spec.pop('name')
+        else:
+            spec = dict(type='multiple',
+                    required=False)
+        handlers = []
+        for name, plugin in setup_plugins:
+            handler = getattr(plugin, event_name, None)
+            if handler is None:
+                continue
+            handlers.append((name, event_name, handler))
+        if spec['required'] and not handlers:
+            raise AssertionError('At least one plugin must implement {}'.format(event_name))
+        if spec['type'] == 'multiple':
+            executor = _handlers_executor(handlers)
+        elif spec['type'] == 'single':
+            if len(handlers) > 1:
+                raise AssertionError('Only one plugin can implement {}'.format(event_name))
+            executor = _handlers_executor_single(handlers)
+        else:
+            raise NotImplementedError('unknown event spec type')
+        setattr(Handler, event_name, executor)
+    return Handler()

--- a/patroni/plugin.py
+++ b/patroni/plugin.py
@@ -101,7 +101,7 @@ def get_event_handler(setup_plugins, events):
         plugins = dict(setup_plugins)
     for event_name in events:
         if isinstance(event_name, dict):
-            spec = event_name
+            spec = event_name.copy()
             event_name = spec.pop('name')
         else:
             spec = dict(type='multiple',

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ class PyTest(TestCommand):
         params = {'args': self.test_args}
         if self.cov:
             params['args'] += self.cov
-            params['plugins'] = ['cov']
         if self.junitxml:
             params['args'] += self.junitxml
         params['args'] += ['--doctest-modules', MAIN_PACKAGE, '-s', '-vv']

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,114 @@
+from mock import patch, Mock
+
+import pytest
+
+from patroni.plugin import load, configure, get_event_handler
+
+class Plugin1:
+
+    def __init__(self, name, log):
+        self.log = log
+        self.name = name
+
+    def event(self, arg1):
+        self.log.append((self.name, 'event', arg1))
+
+
+class Plugin2:
+
+    def __init__(self, name, log):
+        self.log = log
+        self.name = name
+
+    def event(self, arg1):
+        self.log.append((self.name, 'event', arg1))
+        return arg1 + '-ho'
+
+    def other_event(self, arg1, arg2):
+        self.log.append((self.name, 'other_event', arg1, arg2))
+        return arg1 + arg2
+
+@patch('patroni.plugin.iter_entry_points')
+def test_multiple_plugins(iter_entry_points):
+    plugin1 = Mock()
+    plugin1.name = 'plugin1'
+    plugin2 = Mock()
+    plugin2.name = 'plugin2'
+    plugin3 = Mock()
+    plugin3.name = 'plugin3'
+    iter_entry_points.return_value = [plugin2, plugin3, plugin1]
+    config_12 = dict(plugins=['plugin1', 'plugin2'])
+    config_21 = dict(plugins=['plugin2', 'plugin1'])
+    config_23 = dict(plugins=['plugin2', 'plugin3'])
+    plugins = load(config_12)
+    plugin1.load.assert_called_once_with(require=False)
+    assert plugins == [('plugin1', plugin1.load()), ('plugin2', plugin2.load())]
+    # reverse order in the config file and you see the plugins are returned in that order
+    plugins = load(config_21)
+    assert plugins == [('plugin2', plugin2.load()), ('plugin1', plugin1.load())]
+    # try now with only one plugin configured
+    assert not plugin3.load.called
+    plugins = load(config_23)
+    plugin3.load.assert_called_once_with(require=False)
+    assert plugins == [('plugin2', plugin2.load()), ('plugin3', plugin3.load())]
+
+def test_get_event_handler():
+    log = []
+    plugins = configure([
+            ('plugin1', Plugin1),
+            ('plugin2', Plugin2),
+            ('plugin3', Plugin1),
+            ], log)
+    handler = get_event_handler(plugins, ['no_op_event', 'event', 'other_event'])
+    assert log == []
+    # The no-op event has no handlers, so it is defined as None
+    assert handler.no_op_event is None
+    # Call the real event
+    result = handler.event('hey')
+    assert result == [
+        None,
+        'hey-ho',
+        None,
+        ]
+    assert log == [
+        ('plugin1', 'event', 'hey'),
+        ('plugin2', 'event', 'hey'),
+        ('plugin3', 'event', 'hey'),
+        ]
+    log[:] = []
+    # with non-returning events, the events are just called
+    result = handler.other_event(1, 5)
+    assert result == [6]
+    assert log == [
+        ('plugin2', 'other_event', 1, 5),
+        ]
+
+def test_get_event_handler_with_single_event():
+    # Test an "single" event. This is an event which can not have more than one handler
+    log = []
+    plugins = configure([
+            ('plugin2', Plugin2),
+            ], log)
+    handler = get_event_handler(plugins, [dict(name='event', type='single', required=True)])
+    # Call the real event
+    result = handler.event('hey')
+    assert result == 'hey-ho'
+    assert log == [
+        ('plugin2', 'event', 'hey'),
+        ]
+    # it is an error to configure no handlers for this event
+    plugins = configure([], log)
+    with pytest.raises(AssertionError) as ex:
+        handler = get_event_handler(plugins, [dict(name='event', type='single', required=True)])
+    # unless not required
+    plugins = configure([
+            ], log)
+    handler = get_event_handler(plugins, [dict(name='event', type='single', required=False)])
+    assert handler.event is None
+    # and more than one is allways an error
+    plugins = configure([
+            ('plugin1', Plugin1),
+            ('plugin2', Plugin2),
+            ], log)
+    with pytest.raises(AssertionError) as ex:
+        handler = get_event_handler(plugins, [dict(name='event', type='single', required=True)])

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
+[tox]
+envlist = py27,py33,py34
+
 [flake8]
 max-line-length=120
 
-[testenv:py27]
-deps = -rrequirements-py2.txt
-
-[testenv:py33]
-deps = -rrequirements-py3.txt
+[testenv]
+deps = pytest
+commands =
+	python setup.py develop
+	py.test

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,5 @@ max-line-length=120
 deps = pytest
 commands =
 	python setup.py develop
-	py.test
+	python setup.py test
+	python setup.py flake8


### PR DESCRIPTION
Basically, there are a number of places where it would be useful to have a plugin system more powerful than "run external script". For example, the DCS class should be a plugin and preferably in a separate package to simplify dependencies. In my specific case I have 2 examples of things I would like to do:

 * Set the name of the node automatically (i.e. from AWS EC2 metadata) so I can have identical config files on each node
 * Add extra metadata to the data the node stores in the DCS. Specifically I want to add the EC2 availability zone so I can set HAProxy weights to have appservers pefer database servers in their availability zone.

I have made this pull request which contains the basic machinery I think is appropriate. Then I have a proof of concept branch (https://github.com/jinty/patroni/tree/plugins-example) which implements a default node name event and plugin for that event. See:
   https://github.com/jinty/patroni/commit/c35d89d35c5337067bdf915d355ac2d6da37d6e0
   https://github.com/jinty/patroni/commit/9ea29f1920032ce5592007fea93c0e257a309b69
   