### PR TITLE
Added Upstart job for running patroni under Ubuntu 14.04 or 12.04.

### DIFF
--- a/extras/startup-scripts/README.md
+++ b/extras/startup-scripts/README.md
@@ -1,0 +1,10 @@
+# startup scripts for Patroni
+
+This directory contains sample startup scripts for various OSes 
+and management tools for Patroni.
+
+Scripts supplied:
+
+### patroni.upstart.conf
+
+Upstart job for Ubuntu 12.04 or 14.04.  Requires Upstart > 1.4. Intended for systems where Patroni has been installed on a base system, rather than in Docker.

--- a/extras/startup-scripts/patroni.upstart.conf
+++ b/extras/startup-scripts/patroni.upstart.conf
@@ -1,0 +1,36 @@
+# patroni - patroni daemon
+#
+# controls startup/shutdown of postgres
+# you should disable any postgres start jobs
+#
+# assumes that patroni has been installed into the
+# pythonpath by using setup.py install
+
+description    "patroni start daemon"
+
+start on net-device-up
+stop on runlevel [06]
+
+respawn
+respawn limit 5 10
+
+# set location of patroni
+env PATRONI=/usr/local/bin/patroni
+# virtualenv example
+# env PATRONI=/var/lib/postgresql/patronienv/bin/patroni
+
+# set location of config file
+env PATRONICONF=/etc/patroni/patroni.yml
+
+# set log dir for patroni logs
+# postgres user must have write permission
+env POSTGRESLOGDIR=/var/log/postgresql
+
+setuid postgres
+setgid postgres
+
+script
+    exec start-stop-daemon --start \
+        --exec $PATRONI -- $PATRONICONF \
+        >> $POSTGRESLOGDIR/patroni.log 2>&1
+end script


### PR DESCRIPTION
This branch starts adding some sample startup scripts for running patroni in production.  Because of my own needs, I started with Upstart.  I would expect to add things like init.d scripts, systemd configs, and maybe even kubernetes configs here.