### PR TITLE
Feature/pg rewind unclean shutdown

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -96,7 +96,8 @@ class Ha:
         # try to see if we are the former master that crashed. If so - we likely need to run pg_rewind
         # in order to join the former standby being promoted.
         pg_controldata = self.state_handler.controldata()
-        if not has_lock and pg_controldata.get('Database cluster state', '') == 'in production':  # crashed master
+        if not has_lock and pg_controldata and\
+                pg_controldata.get('Database cluster state', '') == 'in production':  # crashed master
             self.state_handler.require_rewind()
 
         # XXX: follow the leader calls stop, which might take quite some time.

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -343,7 +343,7 @@ recovery_target_timeline = 'latest'
                     ret = self.start()
                 else:
                     ret = False
-                    self.move_data_directory()
+                    self.remove_data_directory()
                     logger.error("unable to rewind the former leader")
             else:
                 ret = self.restart()

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -47,7 +47,7 @@ class Postgresql:
         self.replication = config['replication']
         self.superuser = config['superuser']
         self.admin = config['admin']
-        self._pg_rewind = config.get('pg_rewind', {})
+        self.pg_rewind = config.get('pg_rewind', {})
         self.callback = config.get('callbacks', {})
         self.use_slots = config.get('use_slots', True)
         self.schedule_load_slots = self.use_slots
@@ -68,23 +68,36 @@ class Postgresql:
 
         self._connection = None
         self._cursor_holder = None
+        self._need_rewind = False
         self.members = []  # list of already existing replication slots
         self.retry = Retry(max_tries=-1, deadline=10, max_delay=1, retry_exceptions=PostgresConnectionException)
-        self.init_pg_rewind()
 
-    def init_pg_rewind(self):
+    @property
+    def can_rewind(self):
+        """ check if pg_rewind executable is there and that pg_controldata indicates
+            we have either wal_log_hints or checksums turned on
+        """
+        # low-hanging fruit: check if pg_rewind configuration is there
+        if not self.pg_rewind or\
+           not (self.pg_rewind.get('username', '') and self.pg_rewind.get('password', '')):
+            return False
+
+        cmd = ['pg_rewind', '--help']
         try:
-            self._pg_rewind_present = ('username' in self._pg_rewind and
-                                       subprocess.call(['pg_rewind',
-                                                        '--version'],
-                                                       stdout=open(os.devnull, 'w'),
-                                                       stderr=subprocess.STDOUT) == 0)
-            if self._pg_rewind_present:
-                self._pg_rewind['user'] = self._pg_rewind['username']
-        except:
-            self._pg_rewind_present = False
-        if self._pg_rewind and not self._pg_rewind_present:
-            logger.warning("pg_rewind support is disabled")
+            ret = subprocess.call(cmd, stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
+            if ret != 0:  # pg_rewind is not there, close up the shop and go home
+                return False
+        except OSError:
+            return False
+        # check if the cluster's configuration permits pg_rewind
+        data = self.controldata()
+        if data:
+            return data.get('wal_log_hints setting', 'off') == 'on' or\
+                data.get('Data page checksum version', '0') != '0'
+        return False
+
+    def require_rewind(self):
+        self._need_rewind = True
 
     def get_local_address(self):
         listen_addresses = self.listen_addresses.split(',')
@@ -209,6 +222,8 @@ class Postgresql:
         return ret
 
     def stop(self, mode='fast', block_callbacks=False):
+        if not self.is_running():
+            return True
         if block_callbacks:
             try:
                 self.query('SET statement_timeout TO 0')
@@ -315,10 +330,11 @@ recovery_target_timeline = 'latest'
                 for name, value in self.config.get('recovery_conf', {}).items():
                     f.write("{} = '{}'\n".format(name, value))
 
-    def pg_rewind(self, leader):
+    def rewind(self, leader):
         # prepare pg_rewind connection
         r = parseurl(leader.conn_url)
-        r.update(self._pg_rewind)
+        r.update(self.pg_rewind)
+        r['user'] = r['username']
         env = self.write_pgpass(r, append=True)
         pc = "user={user} host={host} port={port} dbname=postgres sslmode=prefer sslcompression=1".format(**r)
         logger.info("running pg_rewind from {}".format(pc))
@@ -331,30 +347,99 @@ recovery_target_timeline = 'latest'
             self.write_recovery_conf(leader)
         return ret
 
-    def pg_rewind_verify_cluster(self):
-        """ check that pg_rewind can be used with the cluster """
+    def controldata(self):
+        """ return the contents of pg_controldata, or non-True value if pg_controldata call failed """
+        result = None
         try:
-            return self.query("""SELECT bool_or(setting::boolean)
-                                 FROM pg_settings
-                                 WHERE name IN ( 'data_checksums', 'wal_log_hints')""").fetchone()[0]
-        except:
-            return False
+            data = subprocess.check_output(['pg_controldata', self.data_dir])
+            if data:
+                data = data.splitlines()
+                result = {l.split(':')[0]: l.split(':')[1].strip() for l in data if l}
+        except subprocess.CalledProcessError:
+            logger.exception("Error when calling pg_controldata")
+        finally:
+            return result
 
-    def follow_the_leader(self, leader):
-        if not self.check_recovery_conf(leader):
+    def read_postmaster_opts(self):
+        """ returns the list of option names/values from postgres.opts, Empty dict if read failed or no file """
+        result = {}
+        try:
+            with open(os.path.join(self.data_dir, "postmaster.opts")) as f:
+                data = f.read()
+                opts = [opt.strip('"\n') for opt in data.split(' "')]
+                for opt in opts:
+                    if '=' in opt and opt.startswith('--'):
+                        name, val = opt.split('=', 1)
+                        name = name.strip('-')
+                        result[name] = val
+        except IOError:
+            logger.exception('Error when reading postmaster.opts')
+        finally:
+            return result
+
+    def single_user_mode(self, command=None, options={}):
+        """ run a given command in a single-user mode. If the command is empty - then just start and stop """
+        cmd = ['postgres', '--single', '-D', self.data_dir]
+        for opt in sorted(options):
+            cmd.extend(['-c', '{0}={1}'.format(opt, options[opt])])
+        # need a database name to connect
+        cmd.append('postgres')
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
+        if p:
+            command and p.communicate('{}\n'.format(command))
+            p.stdin.close()
+            return p.wait()
+        return 1
+
+    def cleanup_archive_status(self):
+        status_dir = os.path.join(self.data_dir, 'pg_xlog', 'archive_status')
+        if os.path.isdir(status_dir):
+            for f in os.listdir(status_dir):
+                path = os.path.join(status_dir, f)
+                try:
+                    if os.path.isfile(path):
+                        os.remove(path)
+                    elif os.path.islink(path):  # should not happen, but just in case
+                        os.unlink(path)
+                except:
+                    logger.exception("Unable to remove {}".format(path))
+
+    def follow_the_leader(self, leader, recovery=False):
+        if not self.check_recovery_conf(leader) or recovery:
+            change_role = (self.role == 'master')
+
+            self._need_rewind = (self._need_rewind or change_role) and self.can_rewind
+            if self._need_rewind:
+                logger.info("set the rewind flag after demote")
             self.write_recovery_conf(leader)
-            change_role = self.role == 'master'
-
-            if leader and change_role and self._pg_rewind_present and self.pg_rewind_verify_cluster():
-                self.stop()
-                if self.pg_rewind(leader):
+            if not leader or not self._need_rewind:  # do not rewind until the leader becomes available
+                ret = self.restart()
+            else:  # we have a leader and need to rewind
+                if self.is_running():
+                    self.stop()
+                # at present, pg_rewind only runs when the cluster is shut down cleanly
+                # and not shutdown in recovery. We have to remove the recovery.conf if present
+                # and start/shutdown in a single user mode to emulate this.
+                # XXX: if recovery.conf is linked, it will be written anew as a normal file.
+                if os.path.isfile(self.recovery_conf):
+                    os.remove(self.recovery_conf)
+                else:
+                    os.unlink(self.recovery_conf)
+                # Archived segments might be useful to pg_rewind,
+                # clean the flags that tell we should remove them.
+                self.cleanup_archive_status()
+                # Start in a single user mode and stop to produce a clean shutdown
+                opts = self.read_postmaster_opts()
+                opts['archive_mode'] = 'on'
+                opts['archive_command'] = 'false'
+                self.single_user_mode(options=opts)
+                if self.rewind(leader):
                     ret = self.start()
                 else:
-                    ret = False
+                    logger.error("unable to rewind the former master")
                     self.remove_data_directory()
-                    logger.error("unable to rewind the former leader")
-            else:
-                ret = self.restart()
+                    ret = True
+                self._need_rewind = False
             change_role and ret and self.call_nowait(ACTION_ON_ROLE_CHANGE)
 
     def save_configuration_files(self):
@@ -379,6 +464,8 @@ recovery_target_timeline = 'latest'
         ret = subprocess.call(self._pg_ctl + ['promote']) == 0
         if ret:
             self._role = 'master'
+            logger.info("cleared rewind flag after becoming the leader")
+            self._need_rewind = False
             self.call_nowait(ACTION_ON_ROLE_CHANGE)
         return ret
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -328,7 +328,7 @@ recovery_target_timeline = 'latest'
                 # pg_rewind removes recovery.conf, we have to reinstate it.
                 if ret:
                     self.write_recovery_conf(leader)
-                    self.start()
+                    ret = self.start()
                 else:
                     self.remove_data_directory()
                     logger.error("unable to rewind the former leader")

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -77,7 +77,10 @@ class Postgresql:
             self._pg_rewind_present = ('username' in self._pg_rewind and
                                        ('wal_log_hints' in self.config['parameters'] or
                                         'data_checksums' in self.config['parameters']) and
-                                       os.system("pg_rewind --version >/dev/null 2>&1") == 0)
+                                       subprocess.call(['pg_rewind',
+                                                        '--version'],
+                                                       stdout=open(os.devnull, 'w'),
+                                                       stderr=subprocess.STDOUT) == 0)
             if self._pg_rewind_present:
                 self._pg_rewind['user'] = self._pg_rewind['username']
         except:

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -340,10 +340,7 @@ class Postgresql:
         with open(self.recovery_conf, 'r') as f:
             for line in f:
                 if line.startswith('primary_conninfo'):
-                    if not pattern:
-                        return False
-                    return pattern in line
-
+                    return pattern and (pattern in line)
         return not pattern
 
     def write_recovery_conf(self, leader):

--- a/patroni/scripts/aws.py
+++ b/patroni/scripts/aws.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import requests

--- a/patroni/scripts/restore.py
+++ b/patroni/scripts/restore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # arguments are:
 #   - cluster scope
 #   - cluster role

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -34,6 +34,9 @@ postgresql:
   data_dir: data/postgresql0
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
   use_slots: True
+  pg_rewind:
+    username: postgres
+    password: zalando
   pg_hba:
   - host all all 0.0.0.0/0 md5
   - hostssl all all 0.0.0.0/0 md5
@@ -42,6 +45,7 @@ postgresql:
     password: rep-pass
     network:  127.0.0.1/32
   superuser:
+    username: postgres
     password: zalando
   admin:
     username: admin
@@ -62,3 +66,4 @@ postgresql:
     archive_timeout: 1800s
     max_replication_slots: 5
     hot_standby: "on"
+    wal_log_hints: "on"

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -34,6 +34,9 @@ postgresql:
   data_dir: data/postgresql1
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
   use_slots: True
+  pg_rewind:
+    username: postgres
+    password: zalando
   pg_hba:
   - host all all 0.0.0.0/0 md5
   - hostssl all all 0.0.0.0/0 md5
@@ -42,6 +45,7 @@ postgresql:
     password: rep-pass
     network: 127.0.0.1/32
   superuser:
+    user: postgres
     password: zalando
   admin:
     username: admin
@@ -62,3 +66,4 @@ postgresql:
     archive_timeout: 1800s
     max_replication_slots: 5
     hot_standby: "on"
+    wal_log_hints: "on"

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -117,6 +117,7 @@ class TestHa(unittest.TestCase):
         self.assertEquals(self.ha.run_cycle(), 'started as a secondary')
 
     def test_recover_replica_failed(self):
+        self.p.controldata = lambda: {'Database cluster state': 'in production'}
         self.p.is_healthy = false
         self.p.follow_the_leader = false
         self.assertEquals(self.ha.run_cycle(), 'failed to start postgres')

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -221,6 +221,7 @@ class TestPostgresql(unittest.TestCase):
 
     @patch('patroni.postgresql.Postgresql.rewind', return_value=False)
     @patch('patroni.postgresql.Postgresql.remove_data_directory', MagicMock(return_value=True))
+    @patch('patroni.postgresql.Postgresql.single_user_mode', MagicMock(return_value=1))
     def test_follow_the_leader(self, mock_pg_rewind):
         self.p.demote()
         self.p.follow_the_leader(None)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -337,7 +337,7 @@ class TestPostgresql(unittest.TestCase):
 
         subprocess.check_output = check_output_call_error
         data = self.p.controldata()
-        self.assertIsNone(data)
+        self.assertEquals(data, dict())
 
         subprocess.check_output = check_output_generic_exception
         self.assertRaises(Exception, self.p.controldata())
@@ -394,6 +394,7 @@ class TestPostgresql(unittest.TestCase):
         mock_unlink.assert_not_called()
 
         mock_remove.reset_mock()
+
         mock_file.return_value = False
         mock_link.return_value = True
         self.p.cleanup_archive_status()
@@ -402,7 +403,9 @@ class TestPostgresql(unittest.TestCase):
 
         mock_unlink.reset_mock()
         mock_remove.reset_mock()
+
         mock_file.side_effect = Exception("foo")
+        mock_link.side_effect = Exception("foo")
         self.p.cleanup_archive_status()
         mock_unlink.assert_not_called()
         mock_remove.assert_not_called()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -9,6 +9,7 @@ from patroni.exceptions import PostgresConnectionException
 from patroni.postgresql import Postgresql
 from patroni.utils import RetryFailedError
 from test_ha import false
+import subprocess
 
 
 class MockCursor:
@@ -132,12 +133,32 @@ class TestPostgresql(unittest.TestCase):
     def test_sync_from_leader(self):
         self.assertTrue(self.p.sync_from_leader(self.leader))
 
-    def test_follow_the_leader(self):
+    @patch('os.system', side_effect=Exception("Test"))
+    def test_init_pg_rewind(self, mock_system):
+        self.p.init_pg_rewind()
+        # prepare parameters for pg_rewind
+        self.p._pg_rewind = {'username': 'foo'}
+        self.p.config['parameters']['data_checksums'] = 1
+        os.system = mock_system
+        self.p.init_pg_rewind()
+
+    @patch('subprocess.call', side_effect=Exception("Test"))
+    def test_pg_rewind(self, mock_call):
+        self.assertTrue(self.p.pg_rewind(self.leader))
+        self.p
+        subprocess.call = mock_call
+        self.assertFalse(self.p.pg_rewind(self.leader))
+
+    @patch('patroni.postgresql.Postgresql.pg_rewind', return_value=False)
+    def test_follow_the_leader(self, mock_pg_rewind):
         self.p.demote(self.leader)
         self.p.follow_the_leader(None)
+        self.p._pg_rewind_present = True
         self.p.demote(self.leader)
         self.p.follow_the_leader(self.leader)
         self.p.follow_the_leader(Leader(-1, None, 28, self.other))
+        self.p.pg_rewind = mock_pg_rewind
+        self.p.follow_the_leader(self.leader)
 
     def test_create_replica(self):
         self.p.delete_trigger_file = Mock(side_effect=OSError())


### PR DESCRIPTION
Add support for pg_rewind.

Make sure pg_rewind can be called in both the case when the former master lost the connect (and hence, was shut down cleanly), and in the case when the master crashed. In the latter case the single-user mode is employed to start the postgresql and shut it down cleanly in order to have a proper shut down status in pg_controldata.

Add new config parameter section, pg_rewind, which must contain the 'username' and 'password' parameters of a database superuser, in order to run pg_rewind. If this section is missing or not pg_rewind is present, the cluster will just try to restart itself.

Add some aux functions like controldata and read_postmaster_opts in postgresql.py, they might be useful in implementing other features (i.e. checking if postgresql is running or making sure the new node belongs to the same cluster.
