### PR TITLE
Do not raise an exception on last_leader_operation.

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -352,9 +352,8 @@ class Ha:
 
     def _run_cycle(self):
         try:
+            self.touch_member()  # also creates /service/cluster key if necessary, preventing exception on the next line
             self.load_cluster_from_dcs()
-
-            self.touch_member()
 
             # cluster has leader key but not initialize key
             if not self.cluster.is_unlocked() and not self.cluster.initialize:

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -316,7 +316,8 @@ class Postgresql:
         return True
 
     def check_replication_lag(self, last_leader_operation):
-        return last_leader_operation - self.xlog_position() <= self.config.get('maximum_lag_on_failover', 0)
+        return (last_leader_operation if last_leader_operation else 0) -\
+            self.xlog_position() <= self.config.get('maximum_lag_on_failover', 0)
 
     def write_pg_hba(self):
         with open(os.path.join(self.data_dir, 'pg_hba.conf'), 'a') as f:


### PR DESCRIPTION
If patroni is attached to an already running instance,
the load_cluster during its initial run_cycle will return
Nones for DCS key values, but those values will actually
be examined in the function that checks for the healthiest node.

Fix the issue by making that function handle None values correctly,
and by making sure that even on the first we load some meaningful
values from DCS by touching the member key there first (which would
also create the whole /service/cluster_name directory if it's not there).