### PR TITLE
Fix/tests

### DIFF
--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1,3 +1,4 @@
+import etcd
 import unittest
 
 from mock import Mock, patch
@@ -98,6 +99,7 @@ class TestHa(unittest.TestCase):
         self.e = Etcd('foo', {'ttl': 30, 'host': 'ok:2379', 'scope': 'test'})
         self.e.client.read = etcd_read
         self.e.client.write = etcd_write
+        self.e.client.delete = Mock(side_effect=etcd.EtcdException())
         self.ha = Ha(MockPatroni(self.p, self.e))
         self.ha._async_executor.run_async = run_async
         self.ha.old_cluster = self.e.get_cluster()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -232,8 +232,8 @@ class TestPostgresql(unittest.TestCase):
         self.p.follow_the_leader(self.leader)
         self.p.require_rewind()
         with mock.patch('os.path.islink', MagicMock(return_value=True)):
-            with mock.patch('os.unlink', MagicMock(return_value=True)):
-                with mock.patch('patroni.postgresql.Postgresql.can_rewind', new_callable=PropertyMock(return_value=True)):
+            with mock.patch('patroni.postgresql.Postgresql.can_rewind', new_callable=PropertyMock(return_value=True)):
+                with mock.patch('os.unlink', MagicMock(return_value=True)):
                     self.p.follow_the_leader(self.leader, recovery=True)
         self.p.require_rewind()
         with mock.patch('patroni.postgresql.Postgresql.can_rewind', new_callable=PropertyMock(return_value=True)):


### PR DESCRIPTION
delete method of etcd client was not properly mocked what lead to execution of requests against real etcd.
It might take ~30 seconds to execute tests when etcd was not running.
In addition to that small fix of pep8 formatting in a test_postgresql.py