### PR TITLE
Feature/configurable pgpass

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -48,7 +48,7 @@ class Postgresql:
         self.replication = config['replication']
         self.superuser = config['superuser']
         self.admin = config['admin']
-        self.pgpass = config.get('pgpass', None)
+        self.pgpass = config.get('pgpass', None) or os.path.join(os.path.expanduser('~'), 'pgpass')
         self.pg_rewind = config.get('pg_rewind', {})
         self.callback = config.get('callbacks', {})
         self.use_slots = config.get('use_slots', True)
@@ -172,8 +172,6 @@ class Postgresql:
         os.path.exists(self.trigger_file) and os.unlink(self.trigger_file)
 
     def write_pgpass(self, record):
-        self.pgpass = self.pgpass or os.path.join(os.path.expanduser('~'), 'pgpass')
-
         with open(self.pgpass, 'w') as f:
             os.fchmod(f.fileno(), 0o600)
             f.write('{host}:{port}:*:{user}:{password}\n'.format(**record))

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -34,6 +34,7 @@ postgresql:
   data_dir: data/postgresql0
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
   use_slots: True
+  pgpass: /tmp/pgpass0
   pg_rewind:
     username: postgres
     password: zalando

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -34,6 +34,7 @@ postgresql:
   data_dir: data/postgresql1
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
   use_slots: True
+  pgpass: /tmp/pgpass1
   pg_rewind:
     username: postgres
     password: zalando


### PR DESCRIPTION
Make pgpass location configurable.

One can use pgpass configuration parameter in the postgres
subsection of Patroni. By default pgpass is written in ~/.
Mock actual writes to pgpass in the tests.