### PR TITLE
 Make it possible to override default namespace (/service/) from a config file

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -83,10 +83,11 @@ cat > /patroni/postgres.yml <<__EOF__
 
 ttl: &ttl 30
 loop_wait: &loop_wait 10
-scope: &scope ${PATRONI_SCOPE}
+scope: &scope '${PATRONI_SCOPE}'
+namespace: 'patroni'
 restapi:
-  listen: 127.0.0.1:8008
-  connect_address: 127.0.0.1:8008
+  listen: 0.0.0.0:8008
+  connect_address: ${DOCKER_IP}:8008
 etcd:
   scope: *scope
   ttl: *ttl

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -123,7 +123,7 @@ class AbstractDCS:
         """
         self._name = name
         self._namespace = '/{}'.format(config.get('namespace', '/service/').strip('/'))
-        self._base_path = '/'.join([self._namespace, config['scope']])
+        self._base_path = '/'.join([self._namespace, str(config['scope']]))
 
         self._cluster = None
         self._cluster_thread_lock = Lock()

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -123,7 +123,7 @@ class AbstractDCS:
         """
         self._name = name
         self._namespace = '/{}'.format(config.get('namespace', '/service/').strip('/'))
-        self._base_path = '/'.join([self._namespace, str(config['scope'])])
+        self._base_path = '/'.join([self._namespace, config['scope']])
 
         self._cluster = None
         self._cluster_thread_lock = Lock()

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -122,8 +122,8 @@ class AbstractDCS:
             i.e.: `zookeeper` for zookeeper, `etcd` for etcd, etc...
         """
         self._name = name
-        self._scope = config['scope']
-        self._base_path = '/service/' + self._scope
+        self._namespace = '/{}'.format(config.get('namespace', '/service/').strip('/'))
+        self._base_path = '/'.join([self._namespace, config['scope']])
 
         self._cluster = None
         self._cluster_thread_lock = Lock()

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -123,7 +123,7 @@ class AbstractDCS:
         """
         self._name = name
         self._namespace = '/{}'.format(config.get('namespace', '/service/').strip('/'))
-        self._base_path = '/'.join([self._namespace, str(config['scope']]))
+        self._base_path = '/'.join([self._namespace, str(config['scope'])])
 
         self._cluster = None
         self._cluster_thread_lock = Lock()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -346,7 +346,7 @@ class TestPostgresql(unittest.TestCase):
         self.p.remove_data_directory()
 
     @patch('subprocess.check_output', MagicMock(return_value=0, side_effect=pg_controldata_string))
-    @patch('subprocess.check_output', side_effect=subprocess.CalledProcessError)
+    @patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(1, ''))
     @patch('subprocess.check_output', side_effect=Exception('Failed'))
     def test_controldata(self, check_output_call_error, check_output_generic_exception):
         data = self.p.controldata()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -354,7 +354,7 @@ class TestPostgresql(unittest.TestCase):
         self.p.remove_data_directory()
 
     @patch('subprocess.check_output', MagicMock(return_value=0, side_effect=pg_controldata_string))
-    @patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(1, ''))
+    @patch('subprocess.check_output', side_effect=subprocess.CalledProcessError)
     @patch('subprocess.check_output', side_effect=Exception('Failed'))
     def test_controldata(self, check_output_call_error, check_output_generic_exception):
         data = self.p.controldata()


### PR DESCRIPTION
If the namespace is not specified in a config file /service/ would be used.

Also it's possible to use just '/' as a namespace.
In this case we would have the following structure in a DCS:
  /scope1
  /scope2
  ...