### PR TITLE
Store host:port connect_address in KV to be used by routing systems

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -49,6 +49,7 @@ class Ha:
     def touch_member(self):
         data = {
             'conn_url': self.state_handler.connection_string,
+            'conn_address': self.state_handler.connect_address,
             'api_url': self.patroni.api.connection_string,
             'state': self.state_handler.state,
             'role': self.state_handler.role,

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -67,9 +67,9 @@ class Postgresql:
         self._pg_ctl = ['pg_ctl', '-w', '-D', self.data_dir]
 
         self.local_address = self.get_local_address()
-        connect_address = config.get('connect_address', None) or self.local_address
+        self.connect_address = config.get('connect_address', None) or self.local_address
         self.connection_string = 'postgres://{username}:{password}@{connect_address}/postgres'.format(
-            connect_address=connect_address, **self.replication)
+            connect_address=self.connect_address, **self.replication)
 
         self._connection = None
         self._cursor_holder = None

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -47,6 +47,7 @@ class MockPostgresql(Mock):
     name = 'postgresql0'
     role = 'replica'
     state = 'running'
+    connect_address = 'bar'
     connection_string = 'postgres://foo@bar/postgres'
 
     def is_healthy(self):


### PR DESCRIPTION
In addition to `conn_url` this PR adds `conn_address` which contains just `host:port`. This is very simple for templating tools to directly use in haproxy configuration, for example.

An example confd that uses the additional `conn_address` in an haproxy.cfg:

```
{{range $index, $name := ls "/routing/allocation"}}
	{{range $member := getvs (printf "/service/%s/members/*" $name)}}
		{{$data := json $member}}
		{{if eq $data.role "master"}}
listen {{$name}}
  mode tcp
  bind *:{{(printf "/routing/allocation/%s" $name | getv)}}
  server leader {{$data.conn_address}}
		{{end}}
	{{end}}
{{end}}
```