### PR TITLE
Call touch_member right after demote and promote.

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -132,6 +132,7 @@ class Ha:
             return message
         else:
             self.state_handler.promote()
+            self.touch_member()
             return promote_message
 
     @staticmethod
@@ -244,6 +245,7 @@ class Ha:
         if delete_leader:
             self.state_handler.stop()
             self.dcs.delete_leader()
+            self.touch_member()
             self.dcs.reset_cluster()
         self.state_handler.follow_the_leader(None)
 


### PR DESCRIPTION
This is necessary to propagate actual information about node into DCS.