### PR TITLE
Make it possible to specify custom options for initdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,12 @@ settings:
     -  *data\_dir*: file path to initialize and store Postgres data files
     -  *maximum\_lag\_on\_failover*: the maximum bytes a follower may lag
     -  *use\_slots*: whether or not to use replication_slots.  Must be False for PostgreSQL 9.3, and you should comment out max_replication_slots. before it is not eligible become leader
+
+    -  *initdb*:  List options to be passed on to initdb
+        -  *encoding*: default encoding for new databases
+        -  *locale*: default locale for new databases
+        -  *data-checksums*  # When pg_rewind is needed on 9.3, this needs to be enabled
+
     -  *pg\_hba*: list of lines which should be added to pg\_hba.conf
         -  *- host all all 0.0.0.0/0 md5*
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -559,6 +559,7 @@ recovery_target_timeline = 'latest'
     def create_or_update_role(self, name, password, options):
         self.query("""DO $$
 BEGIN
+    SET local synchronous_commit = 'local';
     PERFORM * FROM pg_authid WHERE rolname = %s;
     IF FOUND THEN
         ALTER ROLE "{0}" WITH LOGIN {1} PASSWORD %s;

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -169,11 +169,8 @@ class Postgresql:
 
     @staticmethod
     def initdb_allowed_option(name):
-        allowed_options = set(['auth', 'auth-host', 'auth-local', 'encoding', 'data-checksums',
-                               'locale', 'lc-collate', 'lc-ctype', 'lc-messages', 'lc-monetary',
-                               'lc-numeric', 'lc-time', 'text-search-config', 'xlogdir', 'debug', 'noclean'])
-        if name not in allowed_options:
-            raise Exception('{} option for initdb is unknown or not allowed'.format(name))
+        if name in ['pgdata', 'nosync', 'pwfile', 'sync-only']:
+            raise Exception('{} option for initdb is not allowed'.format(name))
         return True
 
     def get_initdb_options(self):

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -35,6 +35,23 @@ postgresql:
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
   use_slots: True
   pgpass: /tmp/pgpass0
+  initdb:  ## We allow the following options to be passed on to initdb
+  # - auth: authmethod
+  # - auth-host: authmethod
+  # - auth-local: authmethod
+  - encoding: UTF8
+  # - data-checksums  # When pg_rewind is needed on 9.3, this needs to be enabled
+  # - locale: locale
+  # - lc-collate: locale
+  # - lc-ctype: locale
+  # - lc-messages: locale
+  # - lc-monetary: locale
+  # - lc-numeric: locale
+  # - lc-time: locale
+  # - text-search-config: CFG
+  # - xlogdir: directory
+  # - debug
+  # - noclean
   pg_rewind:
     username: postgres
     password: zalando

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -35,6 +35,23 @@ postgresql:
   maximum_lag_on_failover: 1048576 # 1 megabyte in bytes
   use_slots: True
   pgpass: /tmp/pgpass1
+  initdb:  ## We allow the following options to be passed on to initdb
+  # - auth: authmethod
+  # - auth-host: authmethod
+  # - auth-local: authmethod
+  - encoding: UTF8
+  # - data-checksums  # When pg_rewind is needed on 9.3, this needs to be enabled
+  # - locale: locale
+  # - lc-collate: locale
+  # - lc-ctype: locale
+  # - lc-messages: locale
+  # - lc-monetary: locale
+  # - lc-numeric: locale
+  # - lc-time: locale
+  # - text-search-config: CFG
+  # - xlogdir: directory
+  # - debug
+  # - noclean
   pg_rewind:
     username: postgres
     password: zalando

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -162,7 +162,7 @@ class TestPostgresql(unittest.TestCase):
         self.p = Postgresql({'name': 'test0', 'scope': 'batman', 'data_dir': 'data/test0',
                              'listen': '127.0.0.1, *:5432', 'connect_address': '127.0.0.2:5432',
                              'pg_hba': ['hostssl all all 0.0.0.0/0 md5', 'host all all 0.0.0.0/0 md5'],
-                             'superuser': {'password': ''},
+                             'superuser': {'password': 'test'},
                              'admin': {'username': 'admin', 'password': 'admin'},
                              'pg_rewind': {'username': 'admin', 'password': 'admin'},
                              'replication': {'username': 'replicator',
@@ -186,6 +186,16 @@ class TestPostgresql(unittest.TestCase):
 
     def test_data_directory_empty(self):
         self.assertTrue(self.p.data_directory_empty())
+
+    def test_get_initdb_options(self):
+        self.p.initdb_options = [{'encoding': 'UTF8'}, 'data-checksums']
+        self.assertEquals(self.p.get_initdb_options(), ['--encoding=UTF8', '--data-checksums'])
+        self.p.initdb_options = [{'foo': 'bar'}]
+        self.assertRaises(Exception, self.p.get_initdb_options)
+        self.p.initdb_options = [{'foo': 'bar', 1: 2}]
+        self.assertRaises(Exception, self.p.get_initdb_options)
+        self.p.initdb_options = [1]
+        self.assertRaises(Exception, self.p.get_initdb_options)
 
     def test_initialize(self):
         self.assertTrue(self.p.initialize())

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -190,7 +190,7 @@ class TestPostgresql(unittest.TestCase):
     def test_get_initdb_options(self):
         self.p.initdb_options = [{'encoding': 'UTF8'}, 'data-checksums']
         self.assertEquals(self.p.get_initdb_options(), ['--encoding=UTF8', '--data-checksums'])
-        self.p.initdb_options = [{'foo': 'bar'}]
+        self.p.initdb_options = [{'pgdata': 'bar'}]
         self.assertRaises(Exception, self.p.get_initdb_options)
         self.p.initdb_options = [{'foo': 'bar', 1: 2}]
         self.assertRaises(Exception, self.p.get_initdb_options)


### PR DESCRIPTION
In the initial implementation we were using the only option
--encoding=UTF8. In order to have pg_rewind working with postgresql-9.3
we have to enable data-checksums. The naive approach was to enable it
globally but taking into account some performance degradation it's better
not to do it but make it possible to configure it.

In addition to that fix all problems with setting up password of default
postgres user: execute CREATE ROLE | ALTER ROLE depending on content of
pg_authid

This pull request addresses following issues: https://github.com/zalando/patroni/issues/86 and https://github.com/zalando/patroni/issues/87