### PR TITLE
Handle haproxy requests. Improve failover status code.

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -15,8 +15,7 @@ frontend ft_postgresql
 	default_backend bk_db
 
 backend bk_db
-	option httpchk GET /master
-    http-check expect string '"master"'
+	option httpchk
 
     server postgresql_127.0.0.1_5432 127.0.0.1:5432 maxconn 100 check port 8008
     server postgresql_127.0.0.1_5433 127.0.0.1:5433 maxconn 100 check port 8009

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -43,7 +43,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             if not self.wfile.closed:
                 self.wfile.flush()
                 self.wfile.close()
-        except:
+        except socket.error:
             pass
         self.rfile.close()
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -271,8 +271,9 @@ class Ha:
         if self.is_healthiest_node():
             if self.acquire_lock():
                 if self.cluster.failover:
-                    logger.info('Cleanning up failover key after acquiring leader lock...')
+                    logger.info('Cleaning up failover key after acquiring leader lock...')
                     self.dcs.manual_failover('', '')
+                self.dcs.get_cluster()
                 return self.enforce_master_role('acquired session lock as a leader',
                                                 'promoted self to leader by acquiring session lock')
             else:


### PR DESCRIPTION
By default, haproxy sens an OPTION request, which we didn't
handle until now. In addition, all haproxy requests that doesn't
examine the request body close the connection as soon as the status
code is obtained. Such behavior breaks BaseHTTPRequestHandler,
namely handle_one_request, which doesn't check for connection reset
by peer and throw this error on a higher level, but since we don't
call this function directly, there is no place in the code to catch
it, therefore, we have to patch this function in the base class.
In addition, patch the StreamRequestHandler finish() function in
order to handle the connection reset error.

Re-read the cluster from DCS right after the failover to supply
the correct new values to the API thread. Fix a typo.