### PR TITLE
Make sure Patroni doesn't die when an AttributeError arises out of etcd.

### DIFF
--- a/patroni/etcd.py
+++ b/patroni/etcd.py
@@ -141,7 +141,7 @@ def catch_etcd_errors(func):
     def wrapper(*args, **kwargs):
         try:
             return not func(*args, **kwargs) is None
-        except (RetryFailedError, etcd.EtcdException):
+        except (RetryFailedError, etcd.EtcdException, AttributeError):
             return False
     return wrapper
 


### PR DESCRIPTION
During failover testing we have seen Patroni die with an AttributeError which was raised by Etcd.
As we need to ensure Patroni will survive this, we catch this error as well.

Excerpt from the trace:

Traceback (most recent call last):
  File "/patroni/etcd.py", line 248, in delete_leader
    return self.client.delete(self.leader_path, prevValue=self._name)
  File "/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py", line 162, in __init__
    host = host.strip('[]')
AttributeError: 'NoneType' object has no attribute 'strip'