### PR TITLE
Avoid excessive log output in the API thread.

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -251,7 +251,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         return {'tags': self.server.patroni.tags}
 
     def log_message(self, format, *args):
-        logger.debug("API thread: "+format % args)
+        logger.debug("API thread: " + format % args)
 
 
 class RestApiServer(ThreadingMixIn, HTTPServer, Thread):

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -243,12 +243,16 @@ class RestApiHandler(BaseHTTPRequestHandler):
         except (psycopg2.Error, RetryFailedError, PostgresConnectionException):
             state = self.server.patroni.postgresql.state
             if state in ['stopped', 'starting', 'stopping', 'restarting', 'running']:
-                logger.exception('get_postgresql_status')
+                if state == 'running':
+                    logger.exception('get_postgresql_status')
                 state = 'unknown' if state == 'running' else state
             return {'state': state}
 
     def get_tags(self):
         return {'tags': self.server.patroni.tags}
+
+    def log_message(self, format, *args):
+        logger.debug("API thread: "+format % args)
 
 
 class RestApiServer(ThreadingMixIn, HTTPServer, Thread):

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -242,10 +242,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
             }
         except (psycopg2.Error, RetryFailedError, PostgresConnectionException):
             state = self.server.patroni.postgresql.state
-            if state in ['stopped', 'starting', 'stopping', 'restarting', 'running']:
-                if state == 'running':
-                    logger.exception('get_postgresql_status')
-                state = 'unknown' if state == 'running' else state
+            if state == 'running':
+                logger.exception('get_postgresql_status')
+                state = 'unknown'
             return {'state': state}
 
     def get_tags(self):


### PR DESCRIPTION
Set log level for BaseHTTPRequestHandler request logging to debug.
Avoid complains about PostgreSQL being unreachable if we know it
is not running.