### PR TITLE
Bugfixes for Patronictl and the Development Docker environment

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -93,7 +93,7 @@ etcd:
   ttl: *ttl
   host: ${ETCD_CLUSTER}
 postgresql:
-  name: postgresql_${DOCKER_IP//./_} ## Replication slots do not allow dots in their name
+  name: ${HOSTNAME}
   scope: *scope
   listen: 0.0.0.0:5432
   connect_address: ${DOCKER_IP}:5432
@@ -119,7 +119,8 @@ postgresql:
     archive_command: 'true'
     max_wal_senders: 20
     listen_addresses: 0.0.0.0
-    wal_keep_segments: 8
+    checkpoint_segments: 64
+    wal_keep_segments: 64
     archive_timeout: 1800s
     max_replication_slots: 20
     hot_standby: "on"

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -111,7 +111,7 @@ def post_patroni(member, endpoint, content, headers={'Content-Type': 'applicatio
     url = urlparse(member.api_url)
     logging.debug(url)
     return requests.post('{}://{}/{}'.format(url.scheme, url.netloc, endpoint), headers=headers,
-                         data=json.dumps(content), timeout=30)
+                         data=json.dumps(content), timeout=60)
 
 
 def print_output(columns, rows=[], alignment=None, format='pretty', header=True, delimiter='\t'):


### PR DESCRIPTION
For easier development using Docker the $HOSTNAME variable will be used to
name the running Patroni. Bumped some _segments postgresql settings to ensure
WAL files are not removed very quickly.

Increased the timeout for the post request for Patroni, as some operations
(failover) may take considerable time to complete.

The failover to a specific member was broken in patronictl as it used a wrong
key to specify the member to failover to.

Pretty printing fix for xlog lag, to prevent false negatives to show up and have
good alignment.