### PR TITLE
Call a checkpoint on master before pg_rewind.

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -454,7 +454,8 @@ recovery_target_timeline = 'latest'
         r['user'] = r['username']
         env = self.write_pgpass(r)
         pc = "user={user} host={host} port={port} dbname=postgres sslmode=prefer sslcompression=1".format(**r)
-        # first run a checkpoint on a promoted master in order to make it store the new timeline (5540277D.8020309@iki.fi)
+        # first run a checkpoint on a promoted master in order
+        # to make it store the new timeline (5540277D.8020309@iki.fi)
         self.checkpoint(pc)
         logger.info("running pg_rewind from {}".format(pc))
         pg_rewind = ['pg_rewind', '-D', self.data_dir, '--source-server', pc]

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -82,10 +82,12 @@ postgresql:
     #use_iam: 1
   #recovery_conf:
     #restore_command: envdir /etc/wal-e.d/env wal-e wal-fetch "%f" "%p" -p 1
+  recovery_conf:
+    restore_command: cp ../wal_archive/%f %p
   parameters:
     archive_mode: "on"
     wal_level: hot_standby
-    archive_command: mkdir -p ../wal_archive && cp %p ../wal_archive/%f
+    archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f
     max_wal_senders: 5
     wal_keep_segments: 8
     archive_timeout: 1800s

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -82,10 +82,12 @@ postgresql:
     #use_iam: 1
   #recovery_conf:
     #restore_command: envdir /etc/wal-e.d/env wal-e wal-fetch "%f" "%p" -p 1
+  recovery_conf:
+    restore_command: cp ../wal_archive/%f %p
   parameters:
     archive_mode: "on"
     wal_level: hot_standby
-    archive_command: mkdir -p ../wal_archive && cp %p ../wal_archive/%f
+    archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f
     max_wal_senders: 5
     wal_keep_segments: 8
     archive_timeout: 1800s


### PR DESCRIPTION
PostgreSQL does not run a checkpoint during promition.
Since pg_rewind relies on the last checkpoint to get the timeline,
there is a short race condition right after the promotion, when
it can get the timeline wrong and fail. We work around this by
calling the checkpoint manually.

Make sure our test configuration does both archive and recovery.