### PR TITLE
Provide more context for healthchecks and monitoring.

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -10,6 +10,7 @@ from patroni.ha import Ha
 from patroni.postgresql import Postgresql
 from patroni.utils import setup_signal_handlers, reap_children
 from patroni.zookeeper import ZooKeeper
+from .version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ class Patroni:
         self.tags = config.get('tags', dict())
         self.postgresql = Postgresql(config['postgresql'])
         self.dcs = self.get_dcs(self.postgresql.name, config)
+        self.version = __version__
         self.api = RestApiServer(self, config['restapi'])
         self.ha = Ha(self)
         self.next_run = time.time()

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -92,6 +92,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
     def do_GET_patroni(self):
         response = self.get_postgresql_status(True)
         response.update(self.get_tags())
+        response['patroni'] = {'version': self.server.patroni.version, 'scope': self.server.patroni.postgresql.scope}
 
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
@@ -233,6 +234,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 'state': self.server.patroni.postgresql.state,
                 'postmaster_start_time': row[0],
                 'role': 'replica' if row[1] else 'master',
+                'server_version': self.server.patroni.postgresql.server_version,
                 'xlog': ({
                     'received_location': row[3],
                     'replayed_location': row[4],

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -133,6 +133,7 @@ class Postgresql:
             r = parseurl('postgres://{}/postgres'.format(self.local_address))
             self._connection = psycopg2.connect(**r)
             self._connection.autocommit = True
+            self.server_version = self._connection.server_version
         return self._connection
 
     def _cursor(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,8 @@ class MockPostgresql(Mock):
     name = 'test'
     state = 'running'
     role = 'master'
+    server_version = '999999'
+    scope = 'dummy'
 
     def connection(self):
         return psycopg2_connect()
@@ -51,6 +53,7 @@ class MockPatroni:
     ha = MockHa()
     dcs = Mock()
     tags = {}
+    version = '0.00'
 
 
 class MockRequest:

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -40,6 +40,9 @@ class MockResponse:
 
 class MockPostgresql(Mock):
 
+    server_version = '999999'
+    scope = 'dummy'
+
     def last_operation(self):
         return '0'
 

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -48,6 +48,8 @@ class MockPostgresql(Mock):
     role = 'replica'
     state = 'running'
     connection_string = 'postgres://foo@bar/postgres'
+    server_version = '999999'
+    scope = 'dummy'
 
     def is_healthy(self):
         return True


### PR DESCRIPTION
Include version numbers of both PostgreSQL and patroni for the /patroni endpoint.
Scope is also returned.