### PR TITLE
Bugfix/superuser username

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -132,6 +132,8 @@ class Postgresql:
         if not self._connection or self._connection.closed != 0:
             r = parseurl('postgres://{}/postgres'.format(self.local_address))
             r.update(self.superuser)
+            if r.get('username'):
+                r['user'] = r['username']
             self._connection = psycopg2.connect(**r)
             self._connection.autocommit = True
             self.server_version = self._connection.server_version

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -63,7 +63,7 @@ postgresql:
     password: rep-pass
     network: 127.0.0.1/32
   superuser:
-    user: postgres
+    username: postgres
     password: zalando
   admin:
     username: admin

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -63,7 +63,7 @@ postgresql:
     password: rep-pass
     network: 127.0.0.1/32
   superuser:
-    user: postgres
+    username: postgres
     password: zalando
   admin:
     username: admin


### PR DESCRIPTION
Make sure username is translated into the user when calling
psycopg2.connect. Also, fix the sample configuration files to use
username everywhere.