### PR TITLE
Rename ambiguous `Failover.member` to candidate

### DIFF
--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -18,7 +18,7 @@ Scenario: check API requests on a stand-alone server
 	And I receive a response text "failover is not possible: cluster does not have members except leader"
 	When I issue an empty POST request to http://127.0.0.1:8008/failover
 	Then I receive a response code 400
-	And I receive a response text "No values given for required parameters leader and member"
+	And I receive a response text "No values given for required parameters leader and candidate"
 
 Scenario: check API requests for the primary-replica pair
 	Given I start postgres1
@@ -41,7 +41,7 @@ Scenario: check the failover via the API
 	And replication works from postgres1 to postgres0 after 15 seconds
 
 Scenario: check the scheduled failover
-	Given I issue a scheduled failover at http://127.0.0.1:8009 from postgres1 to postgresq0 in 10 seconds
+	Given I issue a scheduled failover at http://127.0.0.1:8009 from postgres1 to postgres0 in 10 seconds
 	Then I receive a response code 200
 	And postgres0 is a leader after 15 seconds
 	And replication works from postgres0 to postgres1 after 25 seconds

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -316,8 +316,7 @@ def query(
     cursor = None
     for _ in watching(w, watch, clear=False):
 
-        output, cursor = query_member(cluster=cluster, cursor=cursor, member=member, role=role, command=command,
-                                      connect_parameters=connect_parameters)
+        output, cursor = query_member(cluster, cursor, member, role, command, connect_parameters)
         print_output(None, output, fmt=fmt, delimiter=delimiter)
 
         if cursor is None:
@@ -533,7 +532,7 @@ def failover(config_file, cluster_name, master, candidate, force, dcs, scheduled
             raise PatroniCtlException(message.format(scheduled))
         scheduled_at = scheduled_at.isoformat()
 
-    failover_value = {'leader': master, 'member': candidate, 'scheduled_at': scheduled_at}
+    failover_value = {'leader': master, 'candidate': candidate, 'scheduled_at': scheduled_at}
     logging.debug(failover_value)
 
     # By now we have established that the leader exists and the candidate exists
@@ -563,7 +562,7 @@ def failover(config_file, cluster_name, master, candidate, force, dcs, scheduled
         logging.warning('Failing over to DCS')
         click.echo(timestamp() + ' Could not failover using Patroni api, falling back to DCS')
         click.echo(timestamp() + ' Initializing failover from master {0}'.format(master))
-        dcs.manual_failover(leader=master, member=candidate, scheduled_at=failover_value)
+        dcs.manual_failover(master, candidate, scheduled_at=failover_value)
 
     output_members(cluster, name=cluster_name)
 

--- a/patroni/dcs.py
+++ b/patroni/dcs.py
@@ -89,16 +89,16 @@ class Leader(namedtuple('Leader', 'index,session,member')):
         return self.member.conn_url
 
 
-class Failover(namedtuple('Failover', 'index,leader,member,scheduled_at')):
+class Failover(namedtuple('Failover', 'index,leader,candidate,scheduled_at')):
 
     """
     >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader"}'))
     True
-    >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader", "member": "cluster:member"}'))
+    >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader", "member": "cluster_candidate"}'))
     True
     >>> Failover.from_node(1, 'null') is None
     True
-    >>> n = '{"leader": "cluster_leader", "member": "cluster:member", "scheduled_at": "2016-01-14T10:09:57.1394Z"}'
+    >>> n = '{"leader": "cluster_leader", "member": "cluster_candidate", "scheduled_at": "2016-01-14T10:09:57.1394Z"}'
     >>> 'tzinfo=' in str(Failover.from_node(1, n))
     True
     >>> Failover.from_node(1, None) is None
@@ -258,13 +258,13 @@ class AbstractDCS(object):
     def set_failover_value(self, value, index=None):
         """Create or update `/failover` key"""
 
-    def manual_failover(self, leader, member, scheduled_at=None, index=None):
-        failover_value = dict()
+    def manual_failover(self, leader, candidate, scheduled_at=None, index=None):
+        failover_value = {}
         if leader:
             failover_value['leader'] = leader
 
-        if member:
-            failover_value['member'] = member
+        if candidate:
+            failover_value['member'] = candidate
 
         if scheduled_at:
             failover_value['scheduled_at'] = scheduled_at.isoformat()

--- a/patroni/zookeeper.py
+++ b/patroni/zookeeper.py
@@ -190,7 +190,7 @@ class ZooKeeper(AbstractDCS):
 
     def attempt_to_acquire_leader(self):
         ret = self._create(self.leader_path, self._name, makepath=True, ephemeral=True)
-        if ret:
+        if not ret:
             logger.info('Could not take out TTL lock')
         return ret
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,8 +113,8 @@ class TestRestApiHandler(unittest.TestCase):
         # make sure socket.error gets propagated via wfile object in finalize()
         with patch.object(MockRequest, 'makefile') as makefile:
             makefile.return_value.closed = False
-            makefile.return_value.readline.side_effect = lambda x: b"foo"
-            makefile.return_value.flush = Mock(side_effect=socket.error("foo"))
+            makefile.return_value.readline = Mock(return_value=b'foo')
+            makefile.return_value.flush = Mock(side_effect=socket.error('foo'))
             MockRestApiServer(RestApiHandler, b'OPTIONS / HTTP/1.0')
 
     def test_do_GET_patroni(self):
@@ -157,29 +157,40 @@ class TestRestApiHandler(unittest.TestCase):
         request = b'POST /failover HTTP/1.0\nAuthorization: Basic dGVzdDp0ZXN0\n' +\
                   b'Content-Length: 0\n\n'
         MockRestApiServer(RestApiHandler, request)
+
+        cluster.leader.name = 'postgresql1'
+        MockRestApiServer(RestApiHandler, request)
+
         request = b'POST /failover HTTP/1.0\nAuthorization: Basic dGVzdDp0ZXN0\n' +\
                   b'Content-Length: 25\n\n{"leader": "postgresql1"}'
         MockRestApiServer(RestApiHandler, request)
+
+        cluster.leader.name = 'postgresql2'
+        request = b'POST /failover HTTP/1.0\nAuthorization: Basic dGVzdDp0ZXN0\n' +\
+                  b'Content-Length: 53\n\n{"leader": "postgresql1", "candidate": "postgresql2"}'
+        MockRestApiServer(RestApiHandler, request)
+
         cluster.leader.name = 'postgresql1'
         MockRestApiServer(RestApiHandler, request)
-        cluster.members = [Member(0, 'postgresql0', 30, {'api_url': 'http'})]
+
+        cluster.members = [Member(0, 'postgresql0', 30, {'api_url': 'http'}),
+                           Member(0, 'postgresql2', 30, {'api_url': 'http'})]
         MockRestApiServer(RestApiHandler, request)
         with patch.object(MockPatroni, 'dcs') as d:
             cluster = d.get_cluster.return_value
             cluster.leader.name = 'postgresql0'
             MockRestApiServer(RestApiHandler, request)
+            cluster.leader.name = 'postgresql2'
+            MockRestApiServer(RestApiHandler, request)
             cluster.leader.name = 'postgresql1'
             cluster.failover = None
             MockRestApiServer(RestApiHandler, request)
-            d.get_cluster = Mock(side_effect=Exception())
+            d.get_cluster = Mock(side_effect=Exception)
             MockRestApiServer(RestApiHandler, request)
             d.manual_failover.return_value = False
             MockRestApiServer(RestApiHandler, request)
         with patch.object(MockHa, 'fetch_nodes_statuses', Mock(return_value=[])):
             MockRestApiServer(RestApiHandler, request)
-        request = b'POST /failover HTTP/1.0\nAuthorization: Basic dGVzdDp0ZXN0\n' +\
-                  b'Content-Length: 50\n\n{"leader": "postgresql1", "member": "postgresql2"}'
-        MockRestApiServer(RestApiHandler, request)
 
         # Valid future date
         request = b'POST /failover HTTP/1.0\nAuthorization: Basic dGVzdDp0ZXN0\nContent-Length: 103\n\n{"leader": ' +\

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -162,6 +162,8 @@ class TestZooKeeper(unittest.TestCase):
 
     def test_take_leader(self):
         self.zk.take_leader()
+        with patch.object(MockKazooClient, 'create', Mock(side_effect=Exception)):
+            self.zk.take_leader()
 
     def test_update_leader(self):
         self.assertTrue(self.zk.update_leader())


### PR DESCRIPTION
But! 'member' is still accepted by REST API and also name 'member' is
used to strore/read this value to/from DCS (for backward comatibility)