### PR TITLE
Bugfix: In some cases Ha.cluster can be None after calling `get_cluster`

### DIFF
--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -151,7 +151,7 @@ class TestZooKeeper(unittest.TestCase):
         self.zk.touch_member('exists')
         self.zk._name = 'bar'
         self.zk.touch_member('retry')
-        self.zk.fetch_cluster = True
+        self.zk._fetch_cluster = True
         self.zk.get_cluster()
         self.zk.touch_member('retry')
 


### PR DESCRIPTION
Such situation is causing patroni crash. Usually it was happening during
manual failover, after former master has demoted and `reset_cluster`
method has been called. In this case `fetch_cluster` was `False` and
`_load_cluster` method was returning value from `self._cluster`, which
was `None`.