### PR TITLE
Speed up reattach of former leader to the cluster

### DIFF
--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -29,20 +29,23 @@ Scenario: check API requests for the primary-replica pair
 	And I receive a response role replica
 	When I issue an empty POST request to http://127.0.0.1:8009/reinitialize
 	Then I receive a response code 200
-	Given replication works from postgres0 to postgres1 after 10 seconds
 	When I issue an empty POST request to http://127.0.0.1:8008/restart
 	Then I receive a response code 200
 	And postgres0 is a leader after 5 seconds
+        When I sleep for 10 seconds
+        Then postgres1 role is the secondary after 15 seconds
 
 Scenario: check the failover via the API
 	Given I issue a POST request to http://127.0.0.1:8008/failover with leader=postgres0,candidate=postgres1
 	Then I receive a response code 200
 	And postgres1 is a leader after 5 seconds
+        And postgres1 role is the primary after 5 seconds
+        And postgres0 role is the secondary after 5 seconds
 	And replication works from postgres1 to postgres0 after 15 seconds
 
 Scenario: check the scheduled failover
 	Given I issue a scheduled failover at http://127.0.0.1:8009 from postgres1 to postgres0 in 10 seconds
 	Then I receive a response code 200
-	And postgres0 is a leader after 15 seconds
+	And postgres0 is a leader after 20 seconds
 	And replication works from postgres0 to postgres1 after 25 seconds
 

--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -85,5 +85,5 @@ def main():
         pass
     finally:
         patroni.api.shutdown()
-        patroni.postgresql.stop()
+        patroni.postgresql.stop(checkpoint=False)
         patroni.dcs.delete_leader()

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -388,7 +388,7 @@ class Postgresql(object):
         except psycopg2.Error:
             logging.exception('Exception during CHECKPOINT')
 
-    def stop(self, mode='fast', block_callbacks=False):
+    def stop(self, mode='fast', block_callbacks=False, checkpoint=True):
         # make sure we close all connections established against
         # the former node, otherwise, we might get a stalled one
         # after kill -9, which would report incorrect data to
@@ -400,9 +400,10 @@ class Postgresql(object):
                 self.set_state('stopped')
             return True
 
-        if block_callbacks:
+        if checkpoint:
             self.checkpoint()
-        else:
+
+        if not block_callbacks:
             self.set_state('stopping')
 
         ret = subprocess.call(self._pg_ctl + ['stop', '-m', mode]) == 0

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -110,25 +110,25 @@ class TestHa(unittest.TestCase):
 
     def test_start_as_replica(self):
         self.p.is_healthy = false
-        self.assertEquals(self.ha.run_cycle(), 'started as a secondary')
+        self.assertEquals(self.ha.run_cycle(), 'starting as a secondary')
 
     def test_recover_replica_failed(self):
         self.p.controldata = lambda: {'Database cluster state': 'in production'}
         self.p.is_healthy = false
         self.p.is_running = false
         self.p.follow = false
-        self.assertEquals(self.ha.run_cycle(), 'started as a secondary')
+        self.assertEquals(self.ha.run_cycle(), 'starting as a secondary')
         self.assertEquals(self.ha.run_cycle(), 'failed to start postgres')
 
     def test_recover_master_failed(self):
         self.p.follow = false
         self.p.is_healthy = false
         self.p.is_running = false
-        self.ha.has_lock = true
+        self.p.name = 'leader'
         self.p.set_role('master')
         self.p.controldata = lambda: {'Database cluster state': 'in production'}
-        self.assertEquals(self.ha.run_cycle(), 'started as readonly because i had the session lock')
-        self.assertEquals(self.ha.run_cycle(), 'removed leader key after trying and failing to start postgres')
+        self.ha.cluster = get_cluster_initialized_with_leader()
+        self.assertEquals(self.ha.run_cycle(), 'starting as readonly because i had the session lock')
 
     @patch('sys.exit', return_value=1)
     @patch('patroni.ha.Ha.sysid_valid', MagicMock(return_value=True))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -274,6 +274,7 @@ class TestHa(unittest.TestCase):
         self.assertEquals(self.ha.run_cycle(), 'failed to update leader lock during restart')
 
     @patch('requests.get', requests_get)
+    @patch('time.sleep', Mock())
     def test_manual_failover_from_leader(self):
         self.ha.has_lock = true
         self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, 'blabla', '', None))


### PR DESCRIPTION
Instead of starting it up in "read-only", it will wait 2 seconds, to give
a time to somebody to promote and after it will execute normal `recover`
procedure.