### PR TITLE
Read Patroni configuration from the environment.

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -80,7 +80,7 @@ def main():
         use_env = config_env is not None
         if not use_env:
             print('Usage: {0} config.yml'.format(sys.argv[0]))
-            print('\tPatroni may also read the configuration from the {} environemnt variable'.
+            print('\tPatroni may also read the configuration from the {} environment variable'.
                   format(Patroni.PATRONI_CONFIG_VARIABLE))
             return
 

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -1,4 +1,5 @@
 import etcd
+import os
 import sys
 import time
 import unittest
@@ -56,6 +57,14 @@ class TestPatroni(unittest.TestCase):
             self.assertRaises(SleepException, _main)
         with patch.object(Patroni, 'run', Mock(side_effect=KeyboardInterrupt())):
             _main()
+        sys.argv = ['patroni.py']
+        # read the content of the yaml configuration file into the environment variable
+        # in order to test how does patroni handle the configuration passed from the environment.
+        with open('postgres0.yml', 'r') as f:
+            os.environ[Patroni.PATRONI_CONFIG_VARIABLE] = f.read()
+        with patch.object(Patroni, 'run', Mock(side_effect=SleepException())):
+            self.assertRaises(SleepException, _main)
+        del os.environ[Patroni.PATRONI_CONFIG_VARIABLE]
 
     @patch('time.sleep', Mock(side_effect=SleepException()))
     def test_run(self):


### PR DESCRIPTION
The environment variable name is PATRONI_CONFIGURATION.
If both the filename and the variable supplied, the file takes priority.

This is useful to generate the Patroni configuration dynamically.