### PR TITLE
Remove restrictions on running pg_rewind.

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -106,12 +106,6 @@ class Ha(object):
             return 'waiting for leader to bootstrap'
 
     def recover(self):
-        # try to see if we are the former master that crashed. If so - we likely need to run pg_rewind
-        # in order to join the former standby being promoted.
-        if self.state_handler.role == 'master':
-            pg_controldata = self.state_handler.controldata()
-            if pg_controldata and pg_controldata.get('Database cluster state', '') == 'in production':  # crashed master
-                self.state_handler.require_rewind()
         self.recovering = True
         return self.follow("starting as readonly because i had the session lock", "starting as a secondary", True, True)
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -79,7 +79,7 @@ class Postgresql(object):
 
         self._state = 'stopped'
         self._state_lock = Lock()
-        self._role = 'replica' if os.path.exists(self.recovery_conf) else 'master'
+        self._role = self.get_postgres_role_from_data_directory()
         self._role_lock = Lock()
 
         if self.is_running():
@@ -123,6 +123,9 @@ class Postgresql(object):
                 local_address = 'localhost'  # connection via localhost is preferred
                 break
         return local_address + ':' + self.port
+
+    def get_postgres_role_from_data_directory(self):
+        return 'replica' if os.path.exists(self.recovery_conf) else 'master'
 
     @property
     def _connect_kwargs(self):
@@ -347,7 +350,7 @@ class Postgresql(object):
             logger.error('Cannot start PostgreSQL because one is already running.')
             return True
 
-        self.set_role('replica' if os.path.exists(self.recovery_conf) else 'master')
+        self.set_role(self.get_postgres_role_from_data_directory())
         if os.path.exists(self.postmaster_pid):
             os.remove(self.postmaster_pid)
             logger.info('Removed %s', self.postmaster_pid)

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -79,7 +79,7 @@ class Postgresql(object):
 
         self._state = 'stopped'
         self._state_lock = Lock()
-        self._role = 'replica'
+        self._role = 'replica' if os.path.exists(self.recovery_conf) else 'master'
         self._role_lock = Lock()
 
         if self.is_running():

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -91,6 +91,7 @@ class TestHa(unittest.TestCase):
                                  'data_dir': 'data/postgresql0', 'superuser': {}, 'admin': {},
                                  'replication': {'username': '', 'password': '', 'network': ''}})
             self.p.set_state('running')
+            self.p.set_role('replica')
             self.p.check_replication_lag = true
             self.p.can_create_replica_without_replication_connection = MagicMock(return_value=False)
             self.e = Etcd('foo', {'ttl': 30, 'host': 'ok:2379', 'scope': 'test'})

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -257,12 +257,10 @@ class TestPostgresql(unittest.TestCase):
         self.p.follow(Leader(-1, 28, self.other))
         self.p.rewind = mock_pg_rewind
         self.p.follow(self.leader)
-        self.p.require_rewind()
         with mock.patch('os.path.islink', MagicMock(return_value=True)):
             with mock.patch('patroni.postgresql.Postgresql.can_rewind', new_callable=PropertyMock(return_value=True)):
                 with mock.patch('os.unlink', MagicMock(return_value=True)):
                     self.p.follow(self.leader, recovery=True)
-        self.p.require_rewind()
         with mock.patch('patroni.postgresql.Postgresql.can_rewind', new_callable=PropertyMock(return_value=True)):
             self.p.rewind.return_value = True
             self.p.follow(self.leader, recovery=True)


### PR DESCRIPTION
Previously, pg_rewind was called only if a crashed master tried
to rejoin the cluster. It didn't cover the important case of a
master shut down cleanly, but with a combination of a smart
shutdown and subsequently a fast shutdown. Since out pg_rewind
code does not depend on the "uncleanness" of the master's shutdown,
we can call it unconditionally in all cases where the former master
tries to rejoin as a replica.

This resolves  #167.