### PR TITLE
Remove pg_hba injection and filtering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ For an example file, see ``postgres0.yml``. Regarding settings:
 
     -  *pg\_hba*: list of lines which should be added to pg\_hba.conf.
         -  *- host all all 0.0.0.0/0 md5*.
+        -  *- host replication replicator 127.0.0.1/32 md5* # A line like this is required for replication
 
     -  *replication*:
         -  *username*: replication username; user will be created during initialization.

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -447,11 +447,7 @@ class Postgresql(object):
 
     def write_pg_hba(self):
         with open(os.path.join(self.data_dir, 'pg_hba.conf'), 'a') as f:
-            f.write('\nhost replication {username} {network} md5\n'.format(**self.replication))
-            for line in self.config.get('pg_hba', []):
-                if line.split()[0].strip() == 'hostssl' and self.server_parameters.get('ssl', 'off').lower() != 'on':
-                    continue
-                f.write(line + '\n')
+            f.write('\n{}\n'.format('\n'.join(self.config.get('pg_hba', []))))
 
     @staticmethod
     def primary_conninfo(leader_url):

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -56,12 +56,12 @@ postgresql:
     username: postgres
     password: zalando
   pg_hba:
+  - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
-  - hostssl all all 0.0.0.0/0 md5
+  # - hostssl all all 0.0.0.0/0 md5
   replication:
     username: replicator
     password: rep-pass
-    network:  127.0.0.1/32
   superuser:
     username: postgres
     password: zalando

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -56,12 +56,12 @@ postgresql:
     username: postgres
     password: zalando
   pg_hba:
+  - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
-  - hostssl all all 0.0.0.0/0 md5
+  # - hostssl all all 0.0.0.0/0 md5
   replication:
     username: replicator
     password: rep-pass
-    network: 127.0.0.1/32
   superuser:
     username: postgres
     password: zalando

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -56,12 +56,12 @@ postgresql:
     username: postgres
     password: zalando
   pg_hba:
+  - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
-  - hostssl all all 0.0.0.0/0 md5
+  # - hostssl all all 0.0.0.0/0 md5
   replication:
     username: replicator
     password: rep-pass
-    network: 127.0.0.1/32
   superuser:
     username: postgres
     password: zalando

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -164,13 +164,14 @@ class TestPostgresql(unittest.TestCase):
     def setUp(self):
         self.p = Postgresql({'name': 'test0', 'scope': 'batman', 'data_dir': 'data/test0',
                              'listen': '127.0.0.1, *:5432', 'connect_address': '127.0.0.2:5432',
-                             'pg_hba': ['hostssl all all 0.0.0.0/0 md5', 'host all all 0.0.0.0/0 md5'],
+                             'pg_hba': ['host replication replicator 127.0.0.1/32 md5',
+                                        'hostssl all all 0.0.0.0/0 md5',
+                                        'host all all 0.0.0.0/0 md5'],
                              'superuser': {'username': 'test', 'password': 'test'},
                              'admin': {'username': 'admin', 'password': 'admin'},
                              'pg_rewind': {'username': 'admin', 'password': 'admin'},
                              'replication': {'username': 'replicator',
-                                             'password': 'rep-pass',
-                                             'network': '127.0.0.1/32'},
+                                             'password': 'rep-pass'},
                              'parameters': {'foo': 'bar'}, 'recovery_conf': {'foo': 'bar'},
                              'callbacks': {'on_start': 'true', 'on_stop': 'true',
                                            'on_restart': 'true', 'on_role_change': 'true',
@@ -204,6 +205,11 @@ class TestPostgresql(unittest.TestCase):
     def test_initialize(self):
         self.assertTrue(self.p.initialize())
         self.assertTrue(os.path.exists(os.path.join(self.p.data_dir, 'pg_hba.conf')))
+
+        with open(os.path.join(self.p.data_dir, 'pg_hba.conf')) as f:
+            lines = f.readlines()
+            assert 'host replication replicator 127.0.0.1/32 md5\n' in lines
+            assert 'host all all 0.0.0.0/0 md5\n' in lines
 
     @patch('os.path.exists', Mock(return_value=True))
     @patch('os.unlink', Mock())


### PR DESCRIPTION
Previously we explicitly injected a replication record into pg_hba.conf.
This doesn't allow users to explicitly write their configurations.

This change will just write the lines specified by the user.