### PR TITLE
Clear environment of PostgreSQL

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -358,8 +358,9 @@ class Postgresql(object):
         if not block_callbacks:
             self.set_state('starting')
 
-        env = os.environ.copy()
-        if 'username' in self.superuser:
+        env = {'PATH': os.environ.get('PATH')}
+        # pg_ctl will write a FATAL if the username is incorrect. exporting PGUSER if necessary
+        if 'username' in self.superuser and self.superuser['username'] != os.environ.get('USER'):
             env['PGUSER'] = self.superuser['username']
         ret = subprocess.call(self._pg_ctl + ['start', '-o', self.server_options()], env=env, preexec_fn=os.setsid) == 0
 


### PR DESCRIPTION
Environment variables available to the postmaster can be examined
by non-superusers (e.g. plperl is trusted, yet you can show the environment).

In some environments secrets may be written in environment variables.
Commit 9744019341608c475873d4d214299e3019cb1361 introduced the ability to
specify the full Patroni configuration as an environment variable,
PATRONI_CONFIGURATION.

PATRONI_CONFIGURATION will by definition contain secrets, the passwords for superuser,
replcation user etc.

We therefore only retain a small subset of the environment for pg_ctl start, to ensure
no leakage of these values are possible.