### PR TITLE
Unify Patroni and Patronictl configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ For an example file, see ``postgres0.yml``. Regarding settings:
 
     -  *pg\_hba*: list of lines which should be added to pg\_hba.conf.
         -  *- host all all 0.0.0.0/0 md5*.
+        -  *- host replication replicator 127.0.0.1/32 md5* # A line like this is required for replication
 
     -  *replication*:
         -  *username*: replication username; user will be created during initialization.

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -24,6 +24,10 @@ from six.moves.urllib_parse import urlparse
 CONFIG_DIR_PATH = click.get_app_dir('patroni')
 CONFIG_FILE_PATH = os.path.join(CONFIG_DIR_PATH, 'patronictl.yaml')
 LOGLEVEL = 'WARNING'
+DCS_DEFAULTS = {'zookeeper': {'port': 2181, 'template': "zookeeper:\n hosts: ['{host}:{port}']"},
+                'exhibitor': {'port': 8181, 'template': "zookeeper:\n exhibitor:\n  hosts: [{host}]\n  port: {port}"},
+                'consul': {'port': 8500, 'template': "consul:\n host: '{host}:{port}'"},
+                'etcd': {'port': 4001, 'template': "etcd:\n host: '{host}:{port}'"}}
 
 
 class PatroniCtlException(ClickException):
@@ -31,42 +35,22 @@ class PatroniCtlException(ClickException):
 
 
 def parse_dcs(dcs):
-    """
-    Break up the provided dcs string
-    >>> parse_dcs('localhost') == {'etcd': {'host': 'localhost:4001'}}
-    True
-    >>> parse_dcs('localhost:8500') == {'consul': {'host': 'localhost:8500'}}
-    True
-    >>> parse_dcs('zookeeper://localhost') == {'zookeeper': {'hosts': ['localhost:2181']}}
-    True
-    >>> parse_dcs('exhibitor://localhost') == {'zookeeper': {'exhibitor': {'hosts': ['localhost'], 'port': 8181}}}
-    True
-    """
-
-    if not dcs:
-        return {}
+    if dcs is None:
+        return None
 
     parsed = urlparse(dcs)
     scheme = parsed.scheme
     if scheme == '' and parsed.netloc == '':
         parsed = urlparse('//' + dcs)
+    port = int(parsed.port) if parsed.port else None
 
     if scheme == '':
-        default_schemes = {'2181': 'zookeeper', '8181': 'exhibitor', '8500': 'consul'}
-        scheme = default_schemes.get(str(parsed.port), 'etcd')
+        scheme = ([k for k, v in DCS_DEFAULTS.items() if v['port'] == port] or ['etcd'])[0]
+    elif scheme not in DCS_DEFAULTS:
+        raise PatroniCtlException('Unknown dcs scheme: {}'.format(scheme))
 
-    port = parsed.port
-    if port is None:
-        default_ports = {'consul': 8500, 'zookeeper': 2181, 'exhibitor': 8181}
-        port = default_ports.get(str(scheme), 4001)
-
-    config = {'host': '{0}:{1}'.format(parsed.hostname, port)}
-    if scheme == 'exhibitor':
-        config = {scheme: {'port': int(port), 'hosts': [str(parsed.hostname)]}}
-        scheme = 'zookeeper'
-    elif scheme == 'zookeeper':
-        config['hosts'] = [config.pop('host')]
-    return {scheme: config}
+    dcs_info = DCS_DEFAULTS[scheme]
+    return yaml.load(dcs_info['template'].format(host=parsed.hostname or 'localhost', port=port or dcs_info['port']))
 
 
 def load_config(path, dcs):
@@ -78,10 +62,7 @@ def load_config(path, dcs):
     except (IOError, yaml.YAMLError):
         logging.exception('Could not load configuration file')
 
-    if dcs:
-        config['dcs'] = parse_dcs(dcs)
-    else:
-        config['dcs'] = parse_dcs(config.get('dcs_api'))
+    config.update(parse_dcs(dcs) or parse_dcs(config.get('dcs_api')) or {})
 
     return config
 
@@ -112,10 +93,10 @@ def ctl(ctx):
 
 
 def get_dcs(config, scope):
-    dcs_config = config.get('dcs', {})
-    dcs_config[list(dcs_config.keys())[0]]['scope'] = scope
+    for k in set(DCS_DEFAULTS.keys()) & set(config.keys()):
+        config[k].setdefault('scope', scope)
     try:
-        return Patroni.get_dcs(scope, dcs_config)
+        return Patroni.get_dcs(scope, config)
     except PatroniException as e:
         raise PatroniCtlException(str(e))
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -446,11 +446,7 @@ class Postgresql(object):
 
     def write_pg_hba(self):
         with open(os.path.join(self.data_dir, 'pg_hba.conf'), 'a') as f:
-            f.write('\nhost replication {username} {network} md5\n'.format(**self.replication))
-            for line in self.config.get('pg_hba', []):
-                if line.split()[0].strip() == 'hostssl' and self.server_parameters.get('ssl', 'off').lower() != 'on':
-                    continue
-                f.write(line + '\n')
+            f.write('\n{}\n'.format('\n'.join(self.config.get('pg_hba', []))))
 
     @staticmethod
     def primary_conninfo(leader_url):

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -56,12 +56,12 @@ postgresql:
     username: postgres
     password: zalando
   pg_hba:
+  - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
-  - hostssl all all 0.0.0.0/0 md5
+  # - hostssl all all 0.0.0.0/0 md5
   replication:
     username: replicator
     password: rep-pass
-    network:  127.0.0.1/32
   superuser:
     username: postgres
     password: zalando

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -56,12 +56,12 @@ postgresql:
     username: postgres
     password: zalando
   pg_hba:
+  - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
-  - hostssl all all 0.0.0.0/0 md5
+  # - hostssl all all 0.0.0.0/0 md5
   replication:
     username: replicator
     password: rep-pass
-    network: 127.0.0.1/32
   superuser:
     username: postgres
     password: zalando

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -56,12 +56,12 @@ postgresql:
     username: postgres
     password: zalando
   pg_hba:
+  - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
-  - hostssl all all 0.0.0.0/0 md5
+  # - hostssl all all 0.0.0.0/0 md5
   replication:
     username: replicator
     password: rep-pass
-    network: 127.0.0.1/32
   superuser:
     username: postgres
     password: zalando

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -164,13 +164,14 @@ class TestPostgresql(unittest.TestCase):
     def setUp(self):
         self.p = Postgresql({'name': 'test0', 'scope': 'batman', 'data_dir': 'data/test0',
                              'listen': '127.0.0.1, *:5432', 'connect_address': '127.0.0.2:5432',
-                             'pg_hba': ['hostssl all all 0.0.0.0/0 md5', 'host all all 0.0.0.0/0 md5'],
+                             'pg_hba': ['host replication replicator 127.0.0.1/32 md5',
+                                        'hostssl all all 0.0.0.0/0 md5',
+                                        'host all all 0.0.0.0/0 md5'],
                              'superuser': {'username': 'test', 'password': 'test'},
                              'admin': {'username': 'admin', 'password': 'admin'},
                              'pg_rewind': {'username': 'admin', 'password': 'admin'},
                              'replication': {'username': 'replicator',
-                                             'password': 'rep-pass',
-                                             'network': '127.0.0.1/32'},
+                                             'password': 'rep-pass'},
                              'parameters': {'foo': 'bar'}, 'recovery_conf': {'foo': 'bar'},
                              'callbacks': {'on_start': 'true', 'on_stop': 'true',
                                            'on_restart': 'true', 'on_role_change': 'true',
@@ -204,6 +205,11 @@ class TestPostgresql(unittest.TestCase):
     def test_initialize(self):
         self.assertTrue(self.p.initialize())
         self.assertTrue(os.path.exists(os.path.join(self.p.data_dir, 'pg_hba.conf')))
+
+        with open(os.path.join(self.p.data_dir, 'pg_hba.conf')) as f:
+            lines = f.readlines()
+            assert 'host replication replicator 127.0.0.1/32 md5\n' in lines
+            assert 'host all all 0.0.0.0/0 md5\n' in lines
 
     @patch('os.path.exists', Mock(return_value=True))
     @patch('os.unlink', Mock())


### PR DESCRIPTION
A Patroni configuration should be enough for Patronictl
The previous dcs_api url style is still supported.