### PR TITLE
Implement noloadbalance support

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -29,6 +29,10 @@ class Patroni(object):
         self.next_run = time.time()
 
     @property
+    def noloadbalance(self):
+        return self.tags.get('noloadbalance', False)
+
+    @property
     def nofailover(self):
         return self.tags.get('nofailover', False)
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -74,12 +74,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 status_code = 503
             elif response['role'] == 'master':  # running as master but without leader lock!!!!
                 status_code = 503
-            elif response['role'] in path:
-                status_code = 200
+            elif response['role'] in path:  # response['role'] != 'master'
+                status_code = 503 if patroni.noloadbalance else 200
             else:
                 status_code = 503
         elif 'role' in response and response['role'] in path:
-            status_code = 200
+            status_code = 503 if response['role'] != 'master' and patroni.noloadbalance else 200
         elif patroni.ha.restart_scheduled() and patroni.postgresql.role == 'master' and 'master' in path:
             # exceptional case for master node when the postgres is being restarted via API
             status_code = 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,6 +54,7 @@ class MockPatroni(object):
     dcs = Mock()
     tags = {}
     version = '0.00'
+    noloadbalance = Mock(return_value=False)
 
 
 class MockRequest(object):

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -77,6 +77,10 @@ class TestPatroni(unittest.TestCase):
         self.p.next_run = time.time() - self.p.nap_time - 1
         self.p.schedule_next_run()
 
+    def test_noloadbalance(self):
+        self.p.tags['noloadbalance'] = True
+        self.assertTrue(self.p.noloadbalance)
+
     def test_nofailover(self):
         self.p.tags['nofailover'] = True
         self.assertTrue(self.p.nofailover)


### PR DESCRIPTION
Mostly this tag is necessary to give a hint to load balancer
auto-configuration tool that node should not be included into
LB configuration.
In addition to that Patroni also should not return status_code=200
for a health check if the tag is present and value is not `False`.