### PR TITLE
Write postgres options to postgresql.conf

### DIFF
--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -52,22 +52,23 @@ class TestPatroni(unittest.TestCase):
     @patch.object(Etcd, 'delete_leader', Mock())
     @patch.object(Client, 'machines')
     def test_patroni_main(self, mock_machines):
-        _main()
-        sys.argv = ['patroni.py', 'postgres0.yml']
-
-        mock_machines.__get__ = Mock(return_value=['http://remotehost:2379'])
-        with patch.object(Patroni, 'run', Mock(side_effect=SleepException)):
-            self.assertRaises(SleepException, _main)
-        with patch.object(Patroni, 'run', Mock(side_effect=KeyboardInterrupt())):
+        with patch('subprocess.call', Mock(return_value=1)):
             _main()
-        sys.argv = ['patroni.py']
-        # read the content of the yaml configuration file into the environment variable
-        # in order to test how does patroni handle the configuration passed from the environment.
-        with open('postgres0.yml', 'r') as f:
-            os.environ[Patroni.PATRONI_CONFIG_VARIABLE] = f.read()
-        with patch.object(Patroni, 'run', Mock(side_effect=SleepException())):
-            self.assertRaises(SleepException, _main)
-        del os.environ[Patroni.PATRONI_CONFIG_VARIABLE]
+            sys.argv = ['patroni.py', 'postgres0.yml']
+
+            mock_machines.__get__ = Mock(return_value=['http://remotehost:2379'])
+            with patch.object(Patroni, 'run', Mock(side_effect=SleepException)):
+                self.assertRaises(SleepException, _main)
+            with patch.object(Patroni, 'run', Mock(side_effect=KeyboardInterrupt())):
+                _main()
+            sys.argv = ['patroni.py']
+            # read the content of the yaml configuration file into the environment variable
+            # in order to test how does patroni handle the configuration passed from the environment.
+            with open('postgres0.yml', 'r') as f:
+                os.environ[Patroni.PATRONI_CONFIG_VARIABLE] = f.read()
+            with patch.object(Patroni, 'run', Mock(side_effect=SleepException())):
+                self.assertRaises(SleepException, _main)
+            del os.environ[Patroni.PATRONI_CONFIG_VARIABLE]
 
     def test_run(self):
         self.p.ha.dcs.watch = Mock(side_effect=SleepException)


### PR DESCRIPTION
Originally we were passing postgresql options as an argument of `pg_ctl
start`. It was nice and convenient because doesn't require to touch
configuration files but this method has one significant drawback: it
wasn't possible to change values of options which were passed as an
arguments without restart (event for the case when option reqires only
reload). Instead of doing that (passing options as arguments) we will:
1) rename original postgresql.conf to postgresql-base.conf
2) write options into postgresql.conf which has `include
  'postgresql-base.conf'` on the first line

In addition to that this commit makes some attributes of `Postgresql`
class private (prefixes them with '_')