### PR TITLE
Reimplement pg_ctl status in python

### DIFF
--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -20,6 +20,7 @@ from test_postgresql import Postgresql, psycopg2_connect
 @patch.object(Postgresql, 'write_pg_hba', Mock())
 @patch.object(Postgresql, '_write_postgresql_conf', Mock())
 @patch.object(Postgresql, 'write_recovery_conf', Mock())
+@patch.object(Postgresql, 'is_running', Mock(return_value=True))
 @patch.object(BaseHTTPServer.HTTPServer, '__init__', Mock())
 @patch.object(AsyncExecutor, 'run', Mock())
 @patch.object(etcd.Client, 'write', etcd_write)


### PR DESCRIPTION
subprocess.call was causing problems when the server was running under high load.