### PR TITLE
patronictl will send authorization header if it is configured

### DIFF
--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -43,7 +43,7 @@ def test_rw_config():
     load_config(CONFIG_FILE_PATH, None)
 
 
-@patch('patroni.ctl.load_config', Mock(return_value={'etcd': {'host': 'localhost:4001'}}))
+@patch('patroni.ctl.load_config', Mock(return_value={'restapi': {'auth': 'u:p'}, 'etcd': {'host': 'localhost:4001'}}))
 class TestCtl(unittest.TestCase):
 
     @patch('socket.getaddrinfo', socket_getaddrinfo)


### PR DESCRIPTION
username:password can be configured in the 'restapi' section of config file or via environment.

this pull request should solve https://github.com/zalando/patroni/issues/186