### PR TITLE
Document that every single zookeeper host:port MUST be quoted

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -55,4 +55,4 @@ REST API
 
 ZooKeeper
 ---------
--  **PATRONI\_ZOOKEEPER\_HOSTS**: comma separated list of ZooKeeper cluster members: 'host1:port1,host2:port2,etc...'
+-  **PATRONI\_ZOOKEEPER\_HOSTS**: comma separated list of ZooKeeper cluster members: "'host1:port1','host2:port2','etc...'". It is important to quote every single entity!

--- a/features/environment.py
+++ b/features/environment.py
@@ -283,7 +283,7 @@ class ZooKeeperController(AbstractDcsController):
     def __init__(self, output_dir, export_env=True):
         super(ZooKeeperController, self).__init__('zookeeper', None, output_dir)
         if export_env:
-            os.environ['PATRONI_ZOOKEEPER_HOSTS'] = 'localhost:2181'
+            os.environ['PATRONI_ZOOKEEPER_HOSTS'] = "'localhost:2181'"
         self._client = kazoo.client.KazooClient()
 
     def _start(self):

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -224,6 +224,7 @@ class Config(object):
             try:
                 return yaml.safe_load(value)
             except Exception:
+                logger.exception('Exception when parsing list %s', value)
                 return None
 
         for param in list(os.environ.keys()):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,7 @@ class TestConfig(unittest.TestCase):
             'PATRONI_POSTGRESQL_PGPASS': '/tmp/pgpass0',
             'PATRONI_ETCD_HOST': '127.0.0.1:2379',
             'PATRONI_CONSUL_HOST': '127.0.0.1:8500',
-            'PATRONI_ZOOKEEPER_HOSTS': 'host1,host2',
+            'PATRONI_ZOOKEEPER_HOSTS': "'host1:2181','host2:2181'",
             'PATRONI_EXHIBITOR_HOSTS': 'host1,host2',
             'PATRONI_EXHIBITOR_PORT': '8181',
             'PATRONI_foo_HOSTS': '[host1,host2',  # Exception in parse_list


### PR DESCRIPTION
otherwise yaml library can not parse the list.
And make visible yaml exception when trying to parse this list.