### PR TITLE
Initialize key can be present but empty

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -184,7 +184,7 @@ class Cluster(namedtuple('Cluster', 'initialize,config,leader,last_leader_operat
 
     """Immutable object (namedtuple) which represents PostgreSQL cluster.
     Consists of the following fields:
-    :param initialize: boolean, shows whether this cluster has initialization key stored in DC or not.
+    :param initialize: shows whether this cluster has initialization key stored in DC or not.
     :param config: global dynamic configuration, reference to `ClusterConfig` object
     :param leader: `Leader` object which represents current leader of the cluster
     :param last_leader_operation: int or long object containing position of last known leader operation.

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -87,7 +87,7 @@ class Ha(object):
             self._async_executor.run_async(self.clone, args=(clone_member, msg))
             return 'trying to bootstrap {0}'.format(msg)
         # no initialize key and node is allowed to be master and has 'bootstrap' section in a configuration file
-        elif not (self.cluster.initialize or self.patroni.nofailover) and 'bootstrap' in self.patroni.config:
+        elif self.cluster.initialize is None and not self.patroni.nofailover and 'bootstrap' in self.patroni.config:
             if self.dcs.initialize(create_new=True):  # race for initialization
                 try:
                     self.state_handler.bootstrap(self.patroni.config['bootstrap'])
@@ -419,7 +419,8 @@ class Ha(object):
     def sysid_valid(sysid):
         # sysid does tv_sec << 32, where tv_sec is the number of seconds sine 1970,
         # so even 1 << 32 would have 10 digits.
-        return str(sysid) and len(str(sysid)) >= 10 and str(sysid).isdigit()
+        sysid = str(sysid)
+        return len(sysid) >= 10 and sysid.isdigit()
 
     def post_recover(self):
         if not self.state_handler.is_running():


### PR DESCRIPTION
Nodes were trying to grab initialize key when it didn't contained sysid