### PR TITLE
Set the initialize flag to None and not False..

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -171,7 +171,7 @@ class Consul(AbstractDCS):
 
             self._cluster = Cluster(initialize, config, leader, last_leader_operation, members, failover)
         except NotFound:
-            self._cluster = Cluster(False, None, None, None, [], None)
+            self._cluster = Cluster(None, None, None, None, [], None)
         except:
             logger.exception('get_cluster')
             raise ConsulError('Consul is not responding properly')

--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -275,7 +275,7 @@ class Etcd(AbstractDCS):
 
             self._cluster = Cluster(initialize, config, leader, last_leader_operation, members, failover)
         except etcd.EtcdKeyNotFound:
-            self._cluster = Cluster(False, None, None, None, [], None)
+            self._cluster = Cluster(None, None, None, None, [], None)
         except:
             logger.exception('get_cluster')
             raise EtcdError('Etcd is not responding properly')


### PR DESCRIPTION
Initially, when the Patroni cluster key is not there, the etcd
and consul modules return an empty cluster value, with the
initialize flag set to False and not None. However, some checks
explictely verify that this flag is None, specifically, the one
that decides whether the new cluster should be bootstrapped.
This leads to the master waiting for the whole loop_wait before
running the initdb (and showing the "waiting for leader to bootstrap"
error): on the second loop_wait, the /service/cluster_name flag
is already there (because of the touch_member code).

Since I don't see where the initialize = False is explictely
differentiated from the None value, I think it makes sense to
set it to None uniformely; that's AFAIK always the case if you
use Zookeeper.