### PR TITLE
Refactor code dealing with database connection string/params

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -21,7 +21,6 @@ from click import ClickException
 from patroni.config import Config
 from patroni.dcs import get_dcs as _get_dcs
 from patroni.exceptions import PatroniException
-from patroni.postgresql import get_conn_kwargs
 from prettytable import PrettyTable
 from six.moves.urllib_parse import urlparse
 
@@ -182,16 +181,6 @@ def watching(w, watch, max_count=None, clear=True):
         yield 0
 
 
-def build_connect_parameters(conn_url, connect_parameters):
-    params = get_conn_kwargs(conn_url, connect_parameters)
-    params.update({'fallback_application_name': 'Patroni ctl', 'connect_timeout': '5'})
-    if 'database' in connect_parameters:
-        params['database'] = connect_parameters['database']
-    else:
-        params.pop('database')
-    return params
-
-
 def get_all_members(cluster, role='master'):
     if role == 'master':
         if cluster.leader is not None:
@@ -216,7 +205,12 @@ def get_cursor(cluster, connect_parameters, role='master', member=None):
     if member is None:
         return None
 
-    params = build_connect_parameters(member.conn_url, connect_parameters)
+    params = member.conn_kwargs(connect_parameters)
+    params.update({'fallback_application_name': 'Patroni ctl', 'connect_timeout': '5'})
+    if 'database' in connect_parameters:
+        params['database'] = connect_parameters['database']
+    else:
+        params.pop('database')
 
     conn = psycopg2.connect(**params)
     conn.autocommit = True
@@ -253,7 +247,7 @@ def dsn(cluster_name, config_file, dcs, role, member):
     if m is None:
         raise PatroniCtlException('Can not find a suitable member')
 
-    params = get_conn_kwargs(m.conn_url)
+    params = m.conn_kwargs()
     click.echo('host={host} port={port}'.format(**params))
 
 
@@ -584,7 +578,7 @@ def output_members(cluster, name, fmt='pretty'):
         if m.name == leader_name:
             leader = '*'
 
-        host = get_conn_kwargs(m.conn_url)['host']
+        host = m.conn_kwargs()['host']
 
         xlog_location = m.data.get('xlog_location') or 0
         lag = ''

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -141,9 +141,8 @@ class Ha(object):
 
         node_to_follow = self._get_node_to_follow(self.cluster)
 
-        if not self.state_handler.check_recovery_conf(node_to_follow) or recovery:
-            self._async_executor.schedule('changing primary_conninfo and restarting')
-            self._async_executor.run_async(self.state_handler.follow, (node_to_follow, self.cluster.leader, recovery))
+        self.state_handler.follow(node_to_follow, self.cluster.leader, recovery, self._async_executor)
+
         return ret
 
     def enforce_master_role(self, message, promote_message):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -278,7 +278,7 @@ class TestPostgresql(unittest.TestCase):
             mock_pg_rewind.return_value = True
             self.p.follow(self.leader, self.leader)
 
-        self.assertTrue(self.p.follow(None, None))  # check_recovery_conf...
+        self.p.follow(None, None)  # check_recovery_conf...
 
     @patch('subprocess.check_output', Mock(return_value=0, side_effect=pg_controldata_string))
     def test_can_rewind(self):


### PR DESCRIPTION
In the original code we were parsing/deparsing url-style connection
strings back and forth. That was not really resource greedy but rather
annoying. Also it was not really obvious how to switch all local
connections to unix-sockets (preferably).

This commit isolates different use-cases of working with connection
strings and minimizes amount of code parsing and deparsing them. Also it
introduces one new helper method in the `Member` object - `conn_kwargs`.
This method can accept as a parameter dict object with credentials
(username and password). As a result it returns dict object which could
be used by `psycopg2.connect` or for building connection urls for
pg_rewind, pg_basebackup or some other replica creation methods.

Params for local connection are builded in the `_local_connect_kwargs`
method and could be changed to unix-socket later easily.

This pull request partially implements https://github.com/zalando/patroni/issues/85
I don't really want to change the way how we keep connection string in DCS, so I tried to minimize parsing/deparsing of them.
The only step we need to do afterwards - implement possibility to connect to the postgres via unix-socket.