### PR TITLE
close connection on start instead of stop

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -503,6 +503,12 @@ class Postgresql(object):
             self._state = value
 
     def start(self, block_callbacks=False):
+        # make sure we close all connections established against
+        # the former node, otherwise, we might get a stalled one
+        # after kill -9, which would report incorrect data to
+        # patroni.
+        self.close_connection()
+
         if self.is_running():
             logger.error('Cannot start PostgreSQL because one is already running.')
             return True
@@ -559,12 +565,6 @@ class Postgresql(object):
             return 'not accessible or not healty'
 
     def stop(self, mode='fast', block_callbacks=False, checkpoint=True):
-        # make sure we close all connections established against
-        # the former node, otherwise, we might get a stalled one
-        # after kill -9, which would report incorrect data to
-        # patroni.
-
-        self.close_connection()
         if not self.is_running():
             if not block_callbacks:
                 self.set_state('stopped')


### PR DESCRIPTION
https://github.com/zalando/patroni/pull/262/commits/6f5c41308f691906738a4eb799977390c1fdf0ae commit along with calling of on_start callback on start of Patroni slightly changed the behavior of the code dealing with "dead" postgres (doing "recovery"). Now it calls `start` method, when doing recovery instead of calling `restart`.

This change caused https://github.com/zalando/patroni/issues/271, because we were closing existing connection from Patroni to postgres in the `stop` method. I think `start` method is a better place for that.