### PR TITLE
Replace invalid characters in member names for replication slot names

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -33,7 +33,7 @@ def slot_name_from_member_name(member_name):
 
     def replace_char(match):
         c = match.group(0)
-        return '_' if c in '-.' else "u%04d" % ord(c)
+        return '_' if c in '-.' else "u{:04d}".format(ord(c))
 
     slot_name = re.sub('[^a-z0-9_]', replace_char, member_name.lower())
     return slot_name[0:64]
@@ -922,7 +922,7 @@ $$""".format(name, ' '.join(options)), name, password, password)
                     for name in slot_members:
                         slot_conflicts[slot_name_from_member_name(name)].append(name)
                     logger.error("Following cluster members share a replication slot name: %s",
-                                 "; ".join("%s map to %s" % (", ".join(v), k)
+                                 "; ".join("{} map to {}".format(", ".join(v), k)
                                            for k, v in slot_conflicts.items() if len(v) > 1))
 
                 # drop unused slots

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -327,7 +327,8 @@ class TestPostgresql(unittest.TestCase):
             cluster.members.extend([alias1, alias2])
             self.p.sync_replication_slots(cluster)
             errorlog_mock.assert_called_once()
-            assert "test-3" in errorlog_mock.call_args[0][1] and "test.3" in errorlog_mock.call_args[0][1]
+            assert "test-3" in errorlog_mock.call_args[0][1]
+            assert "test.3" in errorlog_mock.call_args[0][1]
 
     @patch.object(MockConnect, 'closed', 2)
     def test__query(self):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -182,7 +182,7 @@ class TestPostgresql(unittest.TestCase):
                              'restore': 'true'})
         self.leadermem = Member(0, 'leader', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5435/postgres'})
         self.leader = Leader(-1, 28, self.leadermem)
-        self.other = Member(0, 'test1', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
+        self.other = Member(0, 'test-1', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
                             'tags': {'replicatefrom': 'leader'}})
         self.me = Member(0, 'test0', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5434/postgres'})
 
@@ -320,6 +320,14 @@ class TestPostgresql(unittest.TestCase):
         self.p.schedule_load_slots = False
         with mock.patch('patroni.postgresql.Postgresql.role', new_callable=PropertyMock(return_value='replica')):
             self.p.sync_replication_slots(cluster)
+        with mock.patch('patroni.postgresql.logger.error', new_callable=Mock()) as errorlog_mock:
+            self.p.query = Mock()
+            alias1 = Member(0, 'test-3', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5436/postgres'})
+            alias2 = Member(0, 'test.3', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5436/postgres'})
+            cluster.members.extend([alias1, alias2])
+            self.p.sync_replication_slots(cluster)
+            errorlog_mock.assert_called_once()
+            assert "test-3" in errorlog_mock.call_args[0][1] and "test.3" in errorlog_mock.call_args[0][1]
 
     @patch.object(MockConnect, 'closed', 2)
     def test__query(self):


### PR DESCRIPTION
PostgreSQL replication slot names only allow names consisting of [a-z0-9_].
Invalid characters cause replication slot creation and standby startup to fail.
This change substitutes the invalid characters with underscores or unicode
codepoints. In case multiple member names map to identical replication slots
master log will contain a corresponding error message.

Motivated by wanting to use hostnames as member names. Hostnames often
contain periods and dashes.