### PR TITLE
Avoid retries when syncing replication slots.

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -84,6 +84,10 @@ class Patroni(object):
         nap_time = self.next_run - current_time
         if nap_time <= 0:
             self.next_run = current_time
+            # Release the GIL so we don't starve anyone waiting on async_executor lock
+            time.sleep(0.001)
+            # Warn user that Patroni is not keeping up
+            logger.warning("Loop time exceeded, rescheduling immediately.")
         elif self.dcs.watch(nap_time):
             self.next_run = time.time()
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -571,9 +571,7 @@ class Ha(object):
 
             # try to start dead postgres
             if not self.state_handler.is_healthy():
-                msg = self.recover()
-                if msg is not None:
-                    return msg
+                return self.recover()
 
             try:
                 if self.cluster.is_unlocked():

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -315,11 +315,9 @@ class TestPostgresql(unittest.TestCase):
     def test_sync_replication_slots(self):
         self.p.start()
         cluster = Cluster(True, None, self.leader, 0, [self.me, self.other, self.leadermem], None)
+        with mock.patch('patroni.postgresql.Postgresql._query', Mock(side_effect=psycopg2.OperationalError)):
+            self.p.sync_replication_slots(cluster)
         self.p.sync_replication_slots(cluster)
-        self.p.query = Mock(side_effect=psycopg2.OperationalError)
-        self.p.schedule_load_slots = True
-        self.p.sync_replication_slots(cluster)
-        self.p.schedule_load_slots = False
         with mock.patch('patroni.postgresql.Postgresql.role', new_callable=PropertyMock(return_value='replica')):
             self.p.sync_replication_slots(cluster)
         with mock.patch('patroni.postgresql.logger.error', new_callable=Mock()) as errorlog_mock:


### PR DESCRIPTION
Do not retry postgres queries that fetch, create and drop slots at the end of
the HA cycle. The complete run_cycle routine executes with the async_executor
lock. This lock is also used with scheduling operations like reinit or restart
in different threads. Looks like CPython threading class has fairness issues
when multiple threads try to acquire the same lock and one of them executes
long-running actions while holding it: the others have little chances of
acquiring the lock in order. To get around this issue, the long action (i.e.
retrying the query) is removed.

Investigation by Ants Aasma and Alexander Kukushkin.