### PR TITLE
Do not attempt to parse missing conn url

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -416,7 +416,7 @@ class Postgresql(object):
         # If there is no configuration key, or no value is specified, use basebackup
         replica_methods = self.config.get('create_replica_method') or ['basebackup']
 
-        if clone_member:
+        if clone_member and clone_member.conn_url:
             r = clone_member.conn_kwargs(self._replication)
             connstring = 'postgres://{user}@{host}:{port}/{database}'.format(**r)
             # add the credentials to connect to the replica origin to pgpass.


### PR DESCRIPTION
When trying to setup a masterless patroni (to follow an external leader) i ran into the issue that 
no conn url was specified, this caused the following errors:

```bash
Sep  2 09:02:00 ip-172-31-154-4 docker/2ab0057490d6[808]:   File "/usr/lib/python2.7/urlparse.py", line 182, in urlsplit
Sep  2 09:02:00 ip-172-31-154-4 docker/2ab0057490d6[808]:     i = url.find(':')
Sep  2 09:02:00 ip-172-31-154-4 docker/2ab0057490d6[808]: AttributeError: 'NoneType' object has no attribute 'find'
```