### PR TITLE
Remove unicode em dashes and single quotes from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Patroni: A Template for PostgreSQL HA with ZooKeeper, etcd or Consul
 ------------------------------------------------------------
 There are many ways to run high availability with PostgreSQL; for a list, see the `PostgreSQL Documentation <https://wiki.postgresql.org/wiki/Replication,_Clustering,_and_Connection_Pooling>`__.
 
-Patroni is a template for you to create your own customized, high-availability solution using Python and — for maximum accessibility — a distributed configuration store like `ZooKeeper <https://zookeeper.apache.org/>`__, `etcd <https://github.com/coreos/etcd>`__ or `Consul <https://github.com/hashicorp/consul>`__. Database engineers, DBAs, DevOps engineers, and SREs who are looking to quickly deploy HA PostgreSQL in the datacenter—or anywhere else—will hopefully find it useful.
+Patroni is a template for you to create your own customized, high-availability solution using Python and - for maximum accessibility - a distributed configuration store like `ZooKeeper <https://zookeeper.apache.org/>`__, `etcd <https://github.com/coreos/etcd>`__ or `Consul <https://github.com/hashicorp/consul>`__. Database engineers, DBAs, DevOps engineers, and SREs who are looking to quickly deploy HA PostgreSQL in the datacenter-or anywhere else-will hopefully find it useful.
 
 We call Patroni a "template" because it is far from being a one-size-fits-all or plug-and-play replication system. It will have its own caveats. Use wisely.
 
@@ -58,7 +58,7 @@ To get started, do the following from different terminals:
     > ./patroni.py postgres0.yml
     > ./patroni.py postgres1.yml
 
-You will then see a high-availability cluster start up. Test different settings in the YAML files to see how the cluster’s behavior changes. Kill some of the components to see how the system behaves.
+You will then see a high-availability cluster start up. Test different settings in the YAML files to see how the cluster's behavior changes. Kill some of the components to see how the system behaves.
 
 Add more ``postgres*.yml`` files to create an even larger cluster.
 
@@ -120,7 +120,7 @@ Contributing
 Patroni accepts contributions from the open-source community; see the `Issues Tracker <https://github.com/zalando/patroni/issues>`__ for current needs. 
 
 Before making a contribution, please let us know by posting a comment to the relevant issue. 
-If you would like to propose a new feature, please first file a new issue explaining the feature you’d like to create.
+If you would like to propose a new feature, please first file a new issue explaining the feature you'd like to create.
 
 .. |Build Status| image:: https://travis-ci.org/zalando/patroni.svg?branch=master
    :target: https://travis-ci.org/zalando/patroni


### PR DESCRIPTION
In Python 3.5, pip 8.1.2 and certain unicode-aware locales/environments, pip install from the git repo fails with this:

```
    STDOUT: Collecting git+https://github.com/zalando/patroni.git@master
      Cloning https://github.com/zalando/patroni.git (to master) to /tmp/pip-2dkxt_f5-build
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/tmp/pip-2dkxt_f5-build/setup.py", line 157, in <module>
            setup_package()
          File "/tmp/pip-2dkxt_f5-build/setup.py", line 142, in setup_package
            long_description=read('README.rst'),
          File "/tmp/pip-2dkxt_f5-build/setup.py", line 112, in read
            return open(os.path.join(__location__, fname)).read()
          File "/opt/python_virtualenvs/patroni/lib/python3.5/encodings/ascii.py", line 26, in decode
            return codecs.ascii_decode(input, self.errors)[0]
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 465: ordinal not in range(128)
```
The reason seem to be using unicode dashes and single quotes on the README (`—, ’` instead of `-, '`).

While it seems to be possible to work around it by playing with LOCALE/LC_CTYPE environment variables during pip install, I think it's worth it to just remove the fancy symbols 😅