### PR TITLE
added explicit dependency for python-wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update -y \
     && apt-get upgrade -y \
     && apt-get install -y curl jq haproxy zookeeper postgresql-${PGVERSION} python-psycopg2 python-yaml \
         python-requests python-six python-click python-dateutil python-tzlocal python-urllib3 \
-        python-dnspython python-pip python-setuptools python-kazoo python-prettytable python \
+        python-dnspython python-pip python-setuptools python-kazoo python-prettytable python-wheel python \
     && pip install python-etcd==0.4.3 python-consul==0.6.0 --upgrade \
     && apt-get remove -y python-pip python-setuptools \
     && apt-get autoremove -y \


### PR DESCRIPTION
When Building the Dockerfile (```docker build -t patroni .```), i got the following error inbetween:

```
Building wheels for collected packages: python-etcd, python-consul, dnspython
  Running setup.py bdist_wheel for python-etcd: started
  Running setup.py bdist_wheel for python-etcd: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-j3NXKC/python-etcd/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpz8fKCtpip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for python-etcd
```

The patch fixes this by installing 'python-wheel' with apt.