### PR TITLE
Cover case when failover is now and via DCS

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -454,7 +454,7 @@ def parse_scheduled(scheduled):
             raise PatroniCtlException(message.format(scheduled))
         return scheduled_at
 
-    return None
+    return tzlocal.get_localzone().localize(datetime.datetime.now())
 
 
 @ctl.command('restart', help='Restart cluster member')
@@ -628,7 +628,7 @@ def failover(config_file, cluster_name, master, candidate, force, dcs, scheduled
         logging.warning('Failing over to DCS')
         click.echo(timestamp() + ' Could not failover using Patroni api, falling back to DCS')
         click.echo(timestamp() + ' Initializing failover from master {0}'.format(master))
-        dcs.manual_failover(master, candidate, scheduled_at=failover_value)
+        dcs.manual_failover(master, candidate, scheduled_at=parse_scheduled(scheduled))
 
     output_members(cluster, cluster_name)
 

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -454,7 +454,7 @@ def parse_scheduled(scheduled):
             raise PatroniCtlException(message.format(scheduled))
         return scheduled_at
 
-    return tzlocal.get_localzone().localize(datetime.datetime.now())
+    return None
 
 
 @ctl.command('restart', help='Restart cluster member')
@@ -590,12 +590,13 @@ def failover(config_file, cluster_name, master, candidate, force, dcs, scheduled
 
     scheduled_at = parse_scheduled(scheduled)
 
+    scheduled_at_str = None
     if scheduled_at:
         if cluster.is_paused():
             raise PatroniCtlException("Can't schedule failover in the paused state")
-        scheduled_at = scheduled_at.isoformat()
+        scheduled_at_str = scheduled_at.isoformat()
 
-    failover_value = {'leader': master, 'candidate': candidate, 'scheduled_at': scheduled_at}
+    failover_value = {'leader': master, 'candidate': candidate, 'scheduled_at': scheduled_at_str}
 
     logging.debug(failover_value)
 
@@ -628,7 +629,7 @@ def failover(config_file, cluster_name, master, candidate, force, dcs, scheduled
         logging.warning('Failing over to DCS')
         click.echo(timestamp() + ' Could not failover using Patroni api, falling back to DCS')
         click.echo(timestamp() + ' Initializing failover from master {0}'.format(master))
-        dcs.manual_failover(master, candidate, scheduled_at=parse_scheduled(scheduled))
+        dcs.manual_failover(master, candidate, scheduled_at=scheduled_at)
 
     output_members(cluster, cluster_name)
 


### PR DESCRIPTION
In the line 631 call goes to the dcs module. If the `scheduled_at` is `now`, then `parse_scheduled` returned `None` and anyway `failover_value` is passed as an argument, which, as a `dict`, has no `isoformat` method. It then happily fails here:

        if scheduled_at:
            failover_value['scheduled_at'] = scheduled_at.isoformat()

https://github.com/zalando/patroni/blob/master/patroni/dcs/__init__.py#L412

    Traceback (most recent call last):
      File "/usr/local/bin/patronictl", line 9, in <module>
        load_entry_point('patroni==1.1', 'console_scripts', 'patronictl')()
      File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 716, in __call__
        return self.main(*args, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 696, in main
        rv = self.invoke(ctx)
      File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
        return callback(*args, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/patroni/ctl.py", line 631, in failover
        dcs.manual_failover(master, candidate, scheduled_at=failover_value)
      File "/usr/local/lib/python2.7/dist-packages/patroni/dcs/__init__.py", line 397, in manual_failover
        failover_value['scheduled_at'] = scheduled_at.isoformat()

Instead, the code shall return valid date for `now` case and pass a correct value to the `dcs` module.