### PR TITLE
Call touch_member at the end of HA loop

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -180,7 +180,7 @@ class Consul(AbstractDCS):
 
     def touch_member(self, data, **kwargs):
         cluster = self.cluster
-        member = cluster and ([m for m in cluster.members if m.name == self._name] or [None])[0]
+        member = cluster and cluster.get_member(self._name, fallback_to_leader=False)
         create_member = self.refresh_session()
         if member and (create_member or member.session != self._session):
             try:
@@ -203,6 +203,9 @@ class Consul(AbstractDCS):
 
     @catch_consul_errors
     def attempt_to_acquire_leader(self, permanent=False):
+        if not self._session and not permanent:
+            self.refresh_session()
+
         args = {} if permanent else {'acquire': self._session}
         ret = self._client.kv.put(self.leader_path, self._name, **args)
         if not ret:

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -232,7 +232,7 @@ class ZooKeeper(AbstractDCS):
 
     def touch_member(self, data, ttl=None, permanent=False):
         cluster = self.cluster
-        member = cluster and ([m for m in cluster.members if m.name == self._name] or [None])[0]
+        member = cluster and cluster.get_member(self._name, fallback_to_leader=False)
         data = data.encode('utf-8')
         if member and self._client.client_id is not None and member.session != self._client.client_id[0]:
             try:

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -91,6 +91,8 @@ class TestConsul(unittest.TestCase):
 
     @patch.object(consul.Consul.KV, 'put', Mock(return_value=False))
     def test_take_leader(self):
+        self.c.set_ttl(20)
+        self.c.refresh_session = Mock()
         self.c.take_leader()
 
     @patch.object(consul.Consul.KV, 'put', Mock(return_value=True))


### PR DESCRIPTION
To make sure that we have up-to-date state of member in DCS after HA loop has changed something.