### PR TITLE
Fix 'error: [Errno 32] Broken pipe' error in patroni logs

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -16,6 +16,7 @@ frontend ft_postgresql
 
 backend bk_db
 	option httpchk
+	http-check expect rstring .*
 
     server postgresql_127.0.0.1_5432 127.0.0.1:5432 maxconn 100 check port 8008
     server postgresql_127.0.0.1_5433 127.0.0.1:5433 maxconn 100 check port 8009


### PR DESCRIPTION
I've got a lot of errors from Patroni when using with HAProxy:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 596, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 331, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 654, in __init__
    self.finish()
  File "/usr/lib/python2.7/SocketServer.py", line 713, in finish
    self.wfile.close()
  File "/usr/lib/python2.7/socket.py", line 283, in close
    self.flush()
  File "/usr/lib/python2.7/socket.py", line 307, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
```

Solution copied from: https://github.com/openshift/origin-server/pull/1793/files?diff=unified#diff-779cddf5d4f1921ec8647d9b3b77d460

Errors 'error: [Errno 32] Broken pipe' wanished after adding this option to haproxy.cfg.