### PR TITLE
Do session/renew when update_leader is called

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -194,7 +194,7 @@ class AbstractDcsController(AbstractController):
 
     def stop(self, kill=False, timeout=15):
         """ terminate process and wipe out the temp work directory, but only if we actually started it"""
-        super(AbstractDcsController, self).stop(timeout=timeout)
+        super(AbstractDcsController, self).stop(kill=kill, timeout=timeout)
         if self._work_directory:
             shutil.rmtree(self._work_directory)
 
@@ -240,7 +240,7 @@ class ConsulController(AbstractDcsController):
                                 stdout=self._log, stderr=subprocess.STDOUT)
 
     def stop(self, kill=False, timeout=15):
-        super(ConsulController, self).stop(timeout=timeout)
+        super(ConsulController, self).stop(kill=kill, timeout=timeout)
         if self._work_directory:
             os.unlink(self._work_directory + '.json')
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -192,9 +192,9 @@ class AbstractDcsController(AbstractController):
     def _is_accessible(self):
         return self._is_running()
 
-    def stop_and_remove_work_directory(self, timeout=15):
+    def stop(self, kill=False, timeout=15):
         """ terminate process and wipe out the temp work directory, but only if we actually started it"""
-        self.stop(timeout=timeout)
+        super(AbstractDcsController, self).stop(timeout=timeout)
         if self._work_directory:
             shutil.rmtree(self._work_directory)
 
@@ -233,8 +233,16 @@ class ConsulController(AbstractDcsController):
         self._client = consul.Consul()
 
     def _start(self):
-        return subprocess.Popen(['consul', 'agent', '-server', '-bootstrap', '-advertise=127.0.0.1',
-                                 '-data-dir', self._work_directory], stdout=self._log, stderr=subprocess.STDOUT)
+        config_file = self._work_directory + '.json'
+        with open(config_file, 'wb') as f:
+            f.write(b'{"session_ttl_min":"5s","server":true,"bootstrap":true,"advertise_addr":"127.0.0.1"}')
+        return subprocess.Popen(['consul', 'agent', '-config-file', config_file, '-data-dir', self._work_directory],
+                                stdout=self._log, stderr=subprocess.STDOUT)
+
+    def stop(self, kill=False, timeout=15):
+        super(ConsulController, self).stop(timeout=timeout)
+        if self._work_directory:
+            os.unlink(self._work_directory + '.json')
 
     def _is_running(self):
         try:
@@ -405,19 +413,20 @@ class PatroniPoolController(object):
 
 # actions to execute on start/stop of the tests and before running invidual features
 def before_all(context):
-    context.timeout_multiplier = 2 if 'TRAVIS_BUILD_NUMBER' in os.environ or 'BUILD_NUMBER' in os.environ else 1
+    context.ci = 'TRAVIS_BUILD_NUMBER' in os.environ or 'BUILD_NUMBER' in os.environ
+    context.timeout_multiplier = 2 if context.ci else 1
     context.pctl = PatroniPoolController(context)
     context.dcs_ctl = context.pctl.known_dcs[context.pctl.dcs](context)
     context.dcs_ctl.start()
     try:
         context.dcs_ctl.cleanup_service_tree()
     except AssertionError:  # after_all handlers won't be executed in before_all
-        context.dcs_ctl.stop_and_remove_work_directory()
+        context.dcs_ctl.stop()
         raise
 
 
 def after_all(context):
-    context.dcs_ctl.stop_and_remove_work_directory()
+    context.dcs_ctl.stop()
     subprocess.call(['coverage', 'combine'])
     subprocess.call(['coverage', 'report'])
 

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -34,7 +34,7 @@ Scenario: check local configuration reload
 	Then I receive a response code 202
 
 Scenario: check dynamic configuration change via DCS
-	Given I issue a PATCH request to http://127.0.0.1:8008/config with {"ttl": 20, "loop_wait": 2, "postgresql": {"parameters": {"max_connections": 101}}}
+	Given I issue a PATCH request to http://127.0.0.1:8008/config with {"ttl": 10, "loop_wait": 2, "postgresql": {"parameters": {"max_connections": 101}}}
 	Then I receive a response code 200
 	And I receive a response loop_wait 2
 	And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 11 seconds

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -37,18 +37,26 @@ def kv_get(self, key, **kwargs):
 
 class TestHTTPClient(unittest.TestCase):
 
+    def setUp(self):
+        self.client = HTTPClient('127.0.0.1', '8500', 'http', False)
+        self.client.http.request = Mock()
+
     def test_get(self):
-        client = HTTPClient('127.0.0.1', '8500', 'http', False)
-        client.http.request = Mock()
-        client.get(Mock(), '')
-        client.get(Mock(), '', {'wait': '1s', 'index': 1})
-        client.http.request.return_value.status = 500
-        self.assertRaises(ConsulInternalError, client.get, Mock(), '')
+        self.client.get(Mock(), '')
+        self.client.get(Mock(), '', {'wait': '1s', 'index': 1})
+        self.client.http.request.return_value.status = 500
+        self.assertRaises(ConsulInternalError, self.client.get, Mock(), '')
+
+    def test_unknown_method(self):
         try:
-            client.bla(Mock(), '')
+            self.client.bla(Mock(), '')
             self.assertFail()
         except Exception as e:
             self.assertTrue(isinstance(e, AttributeError))
+
+    def test_put(self):
+        self.client.put(Mock(), '/v1/session/create')
+        self.client.put(Mock(), '/v1/session/create', data='{"foo": "bar"}')
 
 
 @patch.object(consul.Consul.KV, 'get', kv_get)
@@ -73,7 +81,8 @@ class TestConsul(unittest.TestCase):
     @patch.object(consul.Consul.Session, 'create', Mock(side_effect=ConsulException))
     def test_referesh_session(self):
         self.c._session = '1'
-        self.c._name = ''
+        self.assertFalse(self.c.refresh_session())
+        self.c._last_session_refresh = 0
         self.assertRaises(ConsulError, self.c.refresh_session)
 
     @patch.object(consul.Consul.KV, 'delete', Mock())
@@ -115,6 +124,7 @@ class TestConsul(unittest.TestCase):
     def test_write_leader_optime(self):
         self.c.write_leader_optime('1')
 
+    @patch.object(consul.Consul.Session, 'renew', Mock())
     def test_update_leader(self):
         self.c.update_leader()
 


### PR DESCRIPTION
should fix https://github.com/zalando/patroni/issues/329


in addition to that make it possible to specify ttl in Consul smaller than 20 (10 seconds).