### PR TITLE
Fix the WAL-E restore

### DIFF
--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -136,7 +136,8 @@ class WALERestore(object):
                     with psycopg2.connect(self.master_connection) as con:
                         con.autocommit = True
                         with con.cursor() as cur:
-                            cur.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)", (backup_start_lsn,))
+                            cur.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)",
+                                        (backup_start_lsn,))
                             diff_in_bytes = long(cur.fetchone()[0])
                 except psycopg2.Error:
                     logger.exception('could not determine difference with the master location')
@@ -223,6 +224,7 @@ def main():
         time.sleep(RETRY_SLEEP_INTERVAL)
 
     return ret
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -149,11 +149,13 @@ class WALERestore(object):
                 except OSError:
                     logger.exception("could not remove broken %s symlink pointing to %s",
                                      dirname, os.readlink(path))
-                    return
+                    return False
             try:
                 os.mkdir(path)
             except OSError:
                 logger.exception("coud not create missing %s directory path", dirname)
+                return False
+        return True
 
     def create_replica_with_s3(self):
         # if we're set up, restore the replica using fetch latest
@@ -163,8 +165,9 @@ class WALERestore(object):
             logger.error('Error when fetching backup with WAL-E: {0}'.format(e))
             return 1
 
-        self.fix_subdirectory_path_if_broken('pg_xlog' if get_major_version(self.data_dir) < 10.0 else 'pg_wal')
-
+        if (ret == 0 and not
+           self.fix_subdirectory_path_if_broken('pg_xlog' if get_major_version(self.data_dir) < 10.0 else 'pg_wal')):
+            return 1
         return ret
 
 

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -104,16 +104,16 @@ class WALERestore(object):
                 return False
 
             backup_info = dict(zip(names, vals))
-        except subprocess.CalledProcessError as e:
-            logger.exception("could not query wal-e latest backup: {}".format(e))
+        except subprocess.CalledProcessError:
+            logger.exception("could not query wal-e latest backup")
             return None
 
         try:
             backup_size = backup_info['expanded_size_bytes']
             backup_start_segment = backup_info['wal_segment_backup_start']
             backup_start_offset = backup_info['wal_segment_offset_backup_start']
-        except Exception as e:
-            logger.exception("unable to get some of WALE backup parameters: {}".format(e))
+        except Exception:
+            logger.exception("unable to get some of WALE backup parameters")
             return None
 
         # WAL filename is XXXXXXXXYYYYYYYY000000ZZ, where X - timeline, Y - LSN logical log file,
@@ -138,8 +138,8 @@ class WALERestore(object):
                         with con.cursor() as cur:
                             cur.execute("SELECT pg_xlog_location_diff(pg_current_xlog_location(), %s)", (backup_start_lsn,))
                             diff_in_bytes = long(cur.fetchone()[0])
-                except psycopg2.Error as e:
-                    logger.exception('could not determine difference with the master location: %s', e)
+                except psycopg2.Error:
+                    logger.exception('could not determine difference with the master location')
                     if attempts_no < self.retries:  # retry in case of a temporarily connection issue
                         attempts_no = attempts_no + 1
                         time.sleep(RETRY_SLEEP_INTERVAL)

--- a/tests/test_wale_restore.py
+++ b/tests/test_wale_restore.py
@@ -13,31 +13,31 @@ wale_output = b'name last_modified expanded_size_bytes wal_segment_backup_start 
               b'00000001000000000000007F 00000040 00000001000000000000007F 00000240\n'
 
 
-@patch('os.access', MagicMock(return_value=True))
-@patch('os.makedirs', MagicMock(return_value=True))
-@patch('os.path.exists', MagicMock(return_value=True))
-@patch('os.path.isdir', MagicMock(return_value=True))
-@patch('psycopg2.extensions.cursor', MagicMock(autospec=True))
-@patch('psycopg2.extensions.connection', MagicMock(autospec=True))
+@patch('os.access', Mock(return_value=True))
+@patch('os.makedirs', Mock(return_value=True))
+@patch('os.path.exists', Mock(return_value=True))
+@patch('os.path.isdir', Mock(return_value=True))
+@patch('psycopg2.extensions.cursor', Mock(autospec=True))
+@patch('psycopg2.extensions.connection', Mock(autospec=True))
 @patch('psycopg2.connect', MagicMock(autospec=True))
-@patch('subprocess.check_output', MagicMock(return_value=wale_output))
+@patch('subprocess.check_output', Mock(return_value=wale_output))
 class TestWALERestore(unittest.TestCase):
 
     def setUp(self):
         self.wale_restore = WALERestore("batman", "/data", "host=batman port=5432 user=batman", "/etc", 100, 100, 1, 0)
 
     def test_should_use_s3_to_create_replica(self):
-        with patch('psycopg2.connect', MagicMock(side_effect=psycopg2.Error("foo"))):
+        with patch('psycopg2.connect', Mock(side_effect=psycopg2.Error("foo"))):
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
-        with patch('subprocess.check_output', MagicMock(side_effect=subprocess.CalledProcessError(1, "cmd", "foo"))):
+        with patch('subprocess.check_output', Mock(side_effect=subprocess.CalledProcessError(1, "cmd", "foo"))):
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
-        with patch('subprocess.check_output', MagicMock(return_value=wale_output.split(b'\n')[0])):
-            self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
-        with patch('subprocess.check_output',
-                   MagicMock(return_value=wale_output.replace(b' wal_segment_offset_backup_stop', b''))):
+        with patch('subprocess.check_output', Mock(return_value=wale_output.split(b'\n')[0])):
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
         with patch('subprocess.check_output',
-                   MagicMock(return_value=wale_output.replace(b'expanded_size_bytes', b'expanded_size_foo'))):
+                   Mock(return_value=wale_output.replace(b' wal_segment_offset_backup_stop', b''))):
+            self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
+        with patch('subprocess.check_output',
+                   Mock(return_value=wale_output.replace(b'expanded_size_bytes', b'expanded_size_foo'))):
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
 
         self.wale_restore.should_use_s3_to_create_replica()
@@ -45,23 +45,23 @@ class TestWALERestore(unittest.TestCase):
         self.assertTrue(self.wale_restore.should_use_s3_to_create_replica())
 
     def test_create_replica_with_s3(self):
-        with patch('subprocess.call', MagicMock(return_value=0)):
+        with patch('subprocess.call', Mock(return_value=0)):
             self.assertEqual(self.wale_restore.create_replica_with_s3(), 0)
             with patch.object(self.wale_restore, 'fix_subdirectory_path_if_broken', Mock(return_value=False)):
                 self.assertEqual(self.wale_restore.create_replica_with_s3(), 1)
 
-        with patch('subprocess.call', MagicMock(side_effect=Exception("foo"))):
+        with patch('subprocess.call', Mock(side_effect=Exception("foo"))):
             self.assertEqual(self.wale_restore.create_replica_with_s3(), 1)
 
     def test_run(self):
         with patch.object(self.wale_restore, 'init_error', PropertyMock(return_value=True)):
             self.assertEqual(self.wale_restore.run(), 2)
-        with patch.object(self.wale_restore, 'should_use_s3_to_create_replica', MagicMock(return_value=True)):
-            with patch.object(self.wale_restore, 'create_replica_with_s3', MagicMock(return_value=0)):
+        with patch.object(self.wale_restore, 'should_use_s3_to_create_replica', Mock(return_value=True)):
+            with patch.object(self.wale_restore, 'create_replica_with_s3', Mock(return_value=0)):
                 self.assertEqual(self.wale_restore.run(), 0)
 
-    @patch('sys.exit', MagicMock())
-    @patch.object(WALERestore, 'run', MagicMock(return_value=0))
+    @patch('sys.exit', Mock())
+    @patch.object(WALERestore, 'run', Mock(return_value=0))
     def test_main(self):
         self.assertEqual(_main(), None)
 

--- a/tests/test_wale_restore.py
+++ b/tests/test_wale_restore.py
@@ -48,7 +48,7 @@ class TestWALERestore(unittest.TestCase):
         with patch('subprocess.call', Mock(return_value=0)):
             self.assertEqual(self.wale_restore.create_replica_with_s3(), 0)
             with patch.object(self.wale_restore, 'fix_subdirectory_path_if_broken', Mock(return_value=False)):
-                self.assertEqual(self.wale_restore.create_replica_with_s3(), 1)
+                self.assertEqual(self.wale_restore.create_replica_with_s3(), 2)
 
         with patch('subprocess.call', Mock(side_effect=Exception("foo"))):
             self.assertEqual(self.wale_restore.create_replica_with_s3(), 1)

--- a/tests/test_wale_restore.py
+++ b/tests/test_wale_restore.py
@@ -2,7 +2,7 @@ import psycopg2
 import subprocess
 import unittest
 
-from mock import Mock, MagicMock, patch, PropertyMock, mock_open
+from mock import Mock, MagicMock, patch, mock_open
 from patroni.scripts.wale_restore import WALERestore, main as _main, get_major_version
 from six.moves import builtins
 
@@ -24,11 +24,24 @@ wale_output = b'name last_modified expanded_size_bytes wal_segment_backup_start 
 class TestWALERestore(unittest.TestCase):
 
     def setUp(self):
-        self.wale_restore = WALERestore("batman", "/data", "host=batman port=5432 user=batman", "/etc", 100, 100, 1, 0)
+        self.wale_restore = WALERestore("batman", "/data", "host=batman port=5432 user=batman", "/etc", 100, 100, 1, 0, 1)
 
     def test_should_use_s3_to_create_replica(self):
+        self.assertTrue(self.wale_restore.should_use_s3_to_create_replica())
+
         with patch('psycopg2.connect', Mock(side_effect=psycopg2.Error("foo"))):
+            save_no_master = self.wale_restore.no_master
+            save_master_connection = self.wale_restore.master_connection
+
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
+            self.wale_restore.no_master = 1
+            self.assertTrue(self.wale_restore.should_use_s3_to_create_replica())  # this would do 2 retries 1 sec each
+            self.wale_restore.master_connection = ''
+            self.assertTrue(self.wale_restore.should_use_s3_to_create_replica())
+
+            self.wale_restore.no_master = save_no_master
+            self.wale_restore.master_connection = save_master_connection
+
         with patch('subprocess.check_output', Mock(side_effect=subprocess.CalledProcessError(1, "cmd", "foo"))):
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
         with patch('subprocess.check_output', Mock(return_value=wale_output.split(b'\n')[0])):
@@ -40,10 +53,6 @@ class TestWALERestore(unittest.TestCase):
                    Mock(return_value=wale_output.replace(b'expanded_size_bytes', b'expanded_size_foo'))):
             self.assertFalse(self.wale_restore.should_use_s3_to_create_replica())
 
-        self.wale_restore.should_use_s3_to_create_replica()
-        self.wale_restore.no_master = 1
-        self.assertTrue(self.wale_restore.should_use_s3_to_create_replica())
-
     def test_create_replica_with_s3(self):
         with patch('subprocess.call', Mock(return_value=0)):
             self.assertEqual(self.wale_restore.create_replica_with_s3(), 0)
@@ -54,16 +63,23 @@ class TestWALERestore(unittest.TestCase):
             self.assertEqual(self.wale_restore.create_replica_with_s3(), 1)
 
     def test_run(self):
-        with patch.object(self.wale_restore, 'init_error', PropertyMock(return_value=True)):
-            self.assertEqual(self.wale_restore.run(), 2)
+        self.wale_restore.init_error = True
+        self.assertEqual(self.wale_restore.run(), 2)  # this would do 2 retries 1 sec each
+        self.wale_restore.init_error = False
         with patch.object(self.wale_restore, 'should_use_s3_to_create_replica', Mock(return_value=True)):
             with patch.object(self.wale_restore, 'create_replica_with_s3', Mock(return_value=0)):
                 self.assertEqual(self.wale_restore.run(), 0)
+            with patch.object(self.wale_restore, 'should_use_s3_to_create_replica', Mock(return_value=None)):
+                self.assertEqual(self.wale_restore.run(), 1)
+            with patch.object(self.wale_restore, 'should_use_s3_to_create_replica', Mock(side_effect=Exception)):
+                self.assertEqual(self.wale_restore.run(), 2)
 
     @patch('sys.exit', Mock())
-    @patch.object(WALERestore, 'run', Mock(return_value=0))
     def test_main(self):
-        self.assertEqual(_main(), None)
+        with patch.object(WALERestore, 'run', Mock(return_value=0)):
+            self.assertEqual(_main(), 0)
+        with patch.object(WALERestore, 'run', Mock(return_value=1)):
+            self.assertEqual(_main(), 1)
 
     @patch('os.path.isfile', Mock(return_value=True))
     def test_get_major_version(self):


### PR DESCRIPTION
Namely:
- broken xlog symlink after the restore
- retry only when there were an exception, not when the decision was made not to use the WAL-E because of the information from the master.

- Challenge the use of WAL-E even when 'no_master' flag is set. This flag in
  fact does not indicate that the master is absent. In order to check the master
  absense the script looks whether the connection string is not empty.

- Retry on a failure to fetch current xlog position from the master. The reason
  it has to be separate from retries in the main loop is that we don't just
  retry the connection attempt, but also make a decision when either it was
  successfull or all attempts are exhausted.