### PR TITLE
Fix rewind behavior when paused

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -208,7 +208,7 @@ class Ha(object):
 
         node_to_follow = self._get_node_to_follow(self.cluster)
 
-        if self.is_paused() and not self.state_handler.need_rewind:
+        if self.is_paused() and not (self.state_handler.need_rewind and self.state_handler.can_rewind):
             self.state_handler.set_role('master' if is_leader else 'replica')
             if is_leader:
                 return 'continue to run as master without lock'
@@ -900,7 +900,7 @@ class Ha(object):
                         self.dcs.delete_leader()
                         self.dcs.reset_cluster()
                         return 'removed leader lock because postgres is not running'
-                    elif not self.state_handler.need_rewind:
+                    elif not (self.state_handler.need_rewind and self.state_handler.can_rewind):
                         return 'postgres is not running'
 
                 # try to start dead postgres

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -469,6 +469,9 @@ class Postgresql(object):
             os.unlink(self._trigger_file)
 
     def write_pgpass(self, record):
+        if 'user' not in record or 'password' not in record:
+            return os.environ.copy()
+
         with open(self._pgpass, 'w') as f:
             os.fchmod(f.fileno(), 0o600)
             f.write('{host}:{port}:*:{user}:{password}\n'.format(**record))
@@ -905,7 +908,15 @@ class Postgresql(object):
     def rewind(self, r):
         # prepare pg_rewind connection
         env = self.write_pgpass(r)
-        dsn = 'user={user} host={host} port={port} dbname={database} sslmode=prefer sslcompression=1'.format(**r)
+        dsn_attrs = [
+            ('user', r.get('user')),
+            ('host', r.get('host')),
+            ('port', r.get('port')),
+            ('dbname', r.get('database')),
+            ('sslmode', 'prefer'),
+            ('sslcompression', '1'),
+        ]
+        dsn = " ".join("{0}={1}".format(k, v) for k, v in dsn_attrs if v is not None)
         logger.info('running pg_rewind from %s', dsn)
         try:
             return subprocess.call([self._pgcommand('pg_rewind'),


### PR DESCRIPTION
When `can_rewind` is False `need_rewind` will not get reset and when cluster enters paused mode and Postgres is shut down it will get restarted.

Also allow for rewind to work without an explicit superuser config. In some setups the default of OS user with no password auth is enough.