### PR TITLE
Synchronous mode strict

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -21,7 +21,7 @@ ExecStart=/bin/patroni /etc/patroni.yml
 KillMode=process
 
 # Give a reasonable amount of time for the server to start up/shut down
-TimeoutSec=10
+TimeoutSec=30
 
 # Do not restart the service if it crashes, we want to manually inspect database on failure
 Restart=no

--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -21,7 +21,7 @@ ExecStart=/bin/patroni /etc/patroni.yml
 KillMode=process
 
 # Give a reasonable amount of time for the server to start up/shut down
-TimeoutSec=30
+TimeoutSec=10
 
 # Do not restart the service if it crashes, we want to manually inspect database on failure
 Restart=no

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -43,7 +43,6 @@ class Config(object):
         'maximum_lag_on_failover': 1048576,
         'master_start_timeout': 300,
         'synchronous_mode': False,
-        'synchronous_mode_strict': False,
         'postgresql': {
             'bin_dir': '',
             'use_slots': True,
@@ -177,8 +176,6 @@ class Config(object):
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overriden from DCS
                 if name == 'synchronous_mode':
                     config[name] = value
-                if name == 'synchronous_mode_strict':
-                    config[name] = value
                 else:
                     config[name] = int(value)
         return config
@@ -302,7 +299,7 @@ class Config(object):
             config['name'] = pg_config['name']
 
         pg_config.update({p: config[p] for p in ('name', 'scope', 'retry_timeout',
-                          'synchronous_mode', 'synchronous_mode_strict', 'maximum_lag_on_failover') if p in config})
+                          'synchronous_mode', 'maximum_lag_on_failover') if p in config})
 
         return config
 

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -43,6 +43,7 @@ class Config(object):
         'maximum_lag_on_failover': 1048576,
         'master_start_timeout': 300,
         'synchronous_mode': False,
+        'synchronous_mode_strict': False,
         'postgresql': {
             'bin_dir': '',
             'use_slots': True,
@@ -176,6 +177,8 @@ class Config(object):
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overriden from DCS
                 if name == 'synchronous_mode':
                     config[name] = value
+                if name == 'synchronous_mode_strict':
+                    config[name] = value
                 else:
                     config[name] = int(value)
         return config
@@ -299,7 +302,7 @@ class Config(object):
             config['name'] = pg_config['name']
 
         pg_config.update({p: config[p] for p in ('name', 'scope', 'retry_timeout',
-                          'synchronous_mode', 'maximum_lag_on_failover') if p in config})
+                          'synchronous_mode', 'synchronous_mode_strict', 'maximum_lag_on_failover') if p in config})
 
         return config
 

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -302,7 +302,7 @@ class Config(object):
             config['name'] = pg_config['name']
 
         pg_config.update({p: config[p] for p in ('name', 'scope', 'retry_timeout',
-                          'synchronous_mode', 'synchronous_mode_strict', 'maximum_lag_on_failover') if p in config})
+                          'synchronous_mode', 'maximum_lag_on_failover') if p in config})
 
         return config
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -248,7 +248,7 @@ class Ha(object):
 
                 if self.is_synchronous_mode_strict() and picked is None:
                     picked = 'patroni_dummy_host'
-                    logger.info("No standbys available and synchronous_mode_strict set: blocking writes with dummy hostname"
+                    logger.info("No standbys available: blocking writes with dummy hostname")
 
                 logger.info("Assigning synchronous standby status to %s", picked)
                 self.state_handler.set_synchronous_standby(picked)

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -223,9 +223,6 @@ class Ha(object):
     def is_synchronous_mode(self):
         return bool(self.cluster and self.cluster.config and self.cluster.config.data.get('synchronous_mode'))
 
-    def is_synchronous_mode_strict(self):
-        return bool(self.cluster and self.cluster.config and self.cluster.config.data.get('synchronous_mode_strict'))
-
     def process_sync_replication(self):
         """Process synchronous standby beahvior.
 
@@ -245,11 +242,6 @@ class Ha(object):
                     if not self.dcs.write_sync_state(self.state_handler.name, None, index=self.cluster.sync.index):
                         logger.info('Synchronous replication key updated by someone else.')
                         return
-
-                logger.info("Debug: %s", self.is_synchronous_mode_strict())
-                if self.is_synchronous_mode_strict() and picked is None:
-                    picked = 'patroni_dummy_host'
-
                 logger.info("Assigning synchronous standby status to %s", picked)
                 self.state_handler.set_synchronous_standby(picked)
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -246,9 +246,9 @@ class Ha(object):
                         logger.info('Synchronous replication key updated by someone else.')
                         return
 
-                logger.info("Debug: %s", self.is_synchronous_mode_strict())
                 if self.is_synchronous_mode_strict() and picked is None:
                     picked = 'patroni_dummy_host'
+                    logger.info("No standbys available and synchronous_mode_strict set: blocking writes with dummy hostname"
 
                 logger.info("Assigning synchronous standby status to %s", picked)
                 self.state_handler.set_synchronous_standby(picked)

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -223,6 +223,9 @@ class Ha(object):
     def is_synchronous_mode(self):
         return bool(self.cluster and self.cluster.config and self.cluster.config.data.get('synchronous_mode'))
 
+    def is_synchronous_mode_strict(self):
+        return bool(self.cluster and self.cluster.config and self.cluster.config.data.get('synchronous_mode_strict'))
+
     def process_sync_replication(self):
         """Process synchronous standby beahvior.
 
@@ -242,6 +245,11 @@ class Ha(object):
                     if not self.dcs.write_sync_state(self.state_handler.name, None, index=self.cluster.sync.index):
                         logger.info('Synchronous replication key updated by someone else.')
                         return
+
+                logger.info("Debug: %s", self.is_synchronous_mode_strict())
+                if self.is_synchronous_mode_strict() and picked is None:
+                    picked = 'patroni_dummy_host'
+
                 logger.info("Assigning synchronous standby status to %s", picked)
                 self.state_handler.set_synchronous_standby(picked)
 


### PR DESCRIPTION
This pull request adds a new DCS variable synchronous_mode_strict

If synchronous_mode_strict is true then when the last sync standby disappears in synchronous_mode then synchronous_standby_names is set to 'patroni_dummy_host'.

This prevents writes which can not be sync'ed to a standby - allowing a closer to zero data loss config.