### PR TITLE
Do not pick nofailover replicas as sync candidates.

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1296,7 +1296,7 @@ $$""".format(name, ' '.join(options)), name, password, password)
             member = members.get(app_name)
             if (state != 'streaming' or not member
                     or member.tags.get('nosync', False)
-                    or member.tags.get('nofailover', False)):
+                    or member.nofailover):
                 continue
             if sync_state == 'sync':
                 return app_name, True

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1294,7 +1294,9 @@ $$""".format(name, ' '.join(options)), name, password, password)
                      FROM pg_stat_replication
                     ORDER BY flush_location DESC"""):
             member = members.get(app_name)
-            if state != 'streaming' or not member or member.tags.get('nosync', False):
+            if (state != 'streaming' or not member
+                    or member.tags.get('nosync', False)
+                    or member.tags.get('nofailover', False)):
                 continue
             if sync_state == 'sync':
                 return app_name, True

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -189,6 +189,9 @@ class TestPostgresql(unittest.TestCase):
         self.other = Member(0, 'test-1', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres',
                             'tags': {'replicatefrom': 'leader'}})
         self.me = Member(0, 'test0', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5434/postgres'})
+        self.other_nofailover = Member(0, 'test-nofailover', 28,
+                                       {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5435/postgres',
+                                        'tags': {'nofailover': True}})
 
     def tearDown(self):
         shutil.rmtree('data')
@@ -705,8 +708,8 @@ class TestPostgresql(unittest.TestCase):
         self.assertFalse(self.p.is_pid_running(None))
 
     def test_pick_sync_standby(self):
-        cluster = Cluster(True, None, self.leader, 0, [self.me, self.other, self.leadermem], None,
-                          SyncState(0, self.me.name, self.leadermem.name))
+        cluster = Cluster(True, None, self.leader, 0, [self.me, self.other, self.leadermem, self.other_nofailover],
+                          None, SyncState(0, self.me.name, self.leadermem.name))
 
         with patch.object(Postgresql, "query", return_value=[
                     (self.leadermem.name, 'streaming', 'sync'),
@@ -737,6 +740,11 @@ class TestPostgresql(unittest.TestCase):
 
         with patch.object(Postgresql, "query", return_value=[]):
             self.assertEquals(self.p.pick_synchronous_standby(cluster), (None, False))
+
+        with patch.object(Postgresql, "query", return_value=[
+                    (self.other_nofailover.name, 'streaming', 'sync'),
+                ]):
+            self.assertIsNone(self.p.pick_synchronous_standby(cluster)[0])
 
     def test_set_sync_standby(self):
         def value_in_conf():


### PR DESCRIPTION
Otherwise, we would have a sync replica we would not be able to
use for failover. Implements the suggestion at the end of the discussion at #400 