### PR TITLE
Release the leader key when the leader restarts with an empty data dir

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -883,10 +883,11 @@ class Ha(object):
                 msg = self.post_recover()
                 if msg is not None:
                     return msg
-            
+
             # is the data directory empty and we are the leader?
             if self.state_handler.data_directory_empty() and self.has_lock():
                 self.release_leader_key_voluntarily()
+                return 'released leader key voluntarily as data dir empty and currently leader'
 
             # is data directory empty?
             if self.state_handler.data_directory_empty():

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -884,13 +884,13 @@ class Ha(object):
                 if msg is not None:
                     return msg
 
-            # is the data directory empty and we are the leader?
-            if self.state_handler.data_directory_empty() and self.has_lock():
-                self.release_leader_key_voluntarily()
-                return 'released leader key voluntarily as data dir empty and currently leader'
-
             # is data directory empty?
             if self.state_handler.data_directory_empty():
+                # is this instance the leader?
+                if self.has_lock():
+                    self.release_leader_key_voluntarily()
+                    return 'released leader key voluntarily as data dir empty and currently leader'
+
                 return self.bootstrap()  # new node
             # "bootstrap", but data directory is not empty
             elif not self.sysid_valid(self.cluster.initialize) and self.cluster.is_unlocked() and not self.is_paused():

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -883,6 +883,10 @@ class Ha(object):
                 msg = self.post_recover()
                 if msg is not None:
                     return msg
+            
+            # is the data directory empty and we are the leader?
+            if self.state_handler.data_directory_empty() and self.has_lock():
+                self.release_leader_key_voluntarily()
 
             # is data directory empty?
             if self.state_handler.data_directory_empty():

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -771,3 +771,14 @@ class TestHa(unittest.TestCase):
 
     def test_wakup(self):
         self.ha.wakeup()
+
+    def test_leader_with_empty_directory(self):
+        self.ha.cluster = get_cluster_initialized_with_leader()
+        self.ha.has_lock = true
+        self.p.data_directory_empty = true
+        self.assertEquals(self.ha.run_cycle(), 'released leader key voluntarily as data dir empty and currently leader')
+
+        # as has_lock is mocked out, we need to fake the leader key release
+        self.ha.has_lock = false
+        # will not say bootstrap from leader as replica can't self elect
+        self.assertEquals(self.ha.run_cycle(), "trying to bootstrap from replica 'other'")


### PR DESCRIPTION
On Kubernetes (and maybe other platforms) if the leader instance is killed, it may restart fast enough that the ttl never expires, and an election isn't triggered. 

If the instances are using ephemeral storage, that means the instance comes back, sees that it is the leader, but it has an empty data directory, so it tries to bootstrap off itself. The cluster then gets stuck in a read only state as replicas are available, but the leader isn't able to accept writes as it is still trying to bootstrap.

I've added a check to see if the data directory is empty and if the instance is the leader before it bootstraps. If those a are both true, then it releases the leader key voluntarily so that an election can occur between the healthy replicas.

Closes #419 