### PR TITLE
postgresql.py Postgresql.check_startup_state_changed if pg_isready re…

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -813,6 +813,8 @@ class Postgresql(object):
                 # Let the main loop of run cycle clean up the mess.
                 logger.warning("%s status returned from pg_isready",
                                "Unknown" if ready == STATE_UNKNOWN else "Invalid")
+                return False
+
             self.set_state('running')
             self._schedule_load_slots = self.use_slots
             self.save_configuration_files()


### PR DESCRIPTION
`check_startup_state_changed` checks `pg_isready` states. I believe we should `return False` if we found `unknown` state as in reality we are not making any request to postgres and which is because of wrong parameters specified to `pg_isready`. If it is `unknown` state then we are modifying current state of `postgresql` to `running` which seems bug.