### PR TITLE
Remove error spinning on etcd failure and reduce log spam

### DIFF
--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -299,9 +299,9 @@ class Client(etcd.Client):
 def catch_etcd_errors(func):
     def wrapper(self, *args, **kwargs):
         try:
-            return func(self, *args, **kwargs) is not None
+            retval = func(self, *args, **kwargs) is not None
         except (RetryFailedError, etcd.EtcdException):
-            return False
+            retval = False
         except Exception as e:
             if not self._has_failed:
                 logger.exception("")
@@ -309,8 +309,9 @@ def catch_etcd_errors(func):
                 logger.error(e)
             self._has_failed = True
             raise EtcdError("unexpected error")
-        else:
-            self._has_failed = False
+
+        self._has_failed = False
+        return retval
 
     return wrapper
 

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -59,7 +59,7 @@ def etcd_watch(self, key, index=None, timeout=None, recursive=None):
         raise etcd.EtcdWatchTimedOut
     elif timeout == 5.0:
         return etcd.EtcdResult('delete', {})
-    elif timeout == 10.0:
+    elif 5 < timeout <= 10.0:
         raise etcd.EtcdException
     elif timeout == 20.0:
         raise etcd.EtcdEventIndexCleared
@@ -302,6 +302,7 @@ class TestEtcd(unittest.TestCase):
     def test_delete_cluster(self):
         self.assertFalse(self.etcd.delete_cluster())
 
+    @patch('time.sleep', Mock(side_effect=SleepException))
     @patch.object(etcd.Client, 'watch', etcd_watch)
     def test_watch(self):
         self.etcd.watch(None, 0)
@@ -310,7 +311,7 @@ class TestEtcd(unittest.TestCase):
         self.etcd.watch(20729, 4.5)
         with patch.object(AbstractDCS, 'watch', Mock()):
             self.assertTrue(self.etcd.watch(20729, 19.5))
-            self.etcd.watch(20729, 9.5)
+            self.assertRaises(SleepException, self.etcd.watch, 20729, 9.5)
 
     def test_other_exceptions(self):
         self.etcd.retry = Mock(side_effect=AttributeError('foo'))


### PR DESCRIPTION
When all etcd servers refuse connections during watch the call will fail with an exception and will be immediately retried. This creates a huge amount of log spam potentially creating additional issues on top of losing the DCS. This patch takes note if etcd failures are repeating and starting from the second failure will sleep for a second before retrying. It additionally omits the stack trace after the first failure in a streak of failures.