### PR TITLE
Fix unit tests for Python 3.6

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,6 +101,8 @@ class MockRequest(object):
     def makefile(self, *args, **kwargs):
         return IO(self.request)
 
+    def sendall(self, *args, **kwargs):
+        pass
 
 class MockRestApiServer(RestApiServer):
 


### PR DESCRIPTION
Python 3.6 complains about
'AttributeError: 'MockRequest' object has no attribute 'sendall'