### PR TITLE
Use csv.DictReader when parsing wal-e backup-list

### DIFF
--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -109,6 +109,15 @@ class WALERestore(object):
                 logger.warning('wal-e did not find any backups')
                 return False
 
+            # This check might not add much, it was performed in the previous
+            # version of this code. since the old version rolled CSV parsing the
+            # check may have been part of the CSV parsing.
+            if len(rows) > 1:
+                logger.warning(
+                    'wal-e returned more than one row of backups: %r',
+                    rows)
+                return False
+
             backup_info = rows[0]
         except subprocess.CalledProcessError:
             logger.exception("could not query wal-e latest backup")

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -120,7 +120,7 @@ class WALERestore(object):
             backup_size = backup_info['expanded_size_bytes']
             backup_start_segment = backup_info['wal_segment_backup_start']
             backup_start_offset = backup_info['wal_segment_offset_backup_start']
-        except Exception:
+        except KeyError:
             logger.exception("unable to get some of WALE backup parameters")
             return None
 

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -24,7 +24,6 @@
 #       recovery_conf:
 #               restore_command: envdir /etc/wal-e.d/env wal-e wal-fetch "%f" "%p" -p 1
 import csv
-import shlex
 from collections import namedtuple
 import logging
 import os

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -97,7 +97,7 @@ class WALERestore(object):
                 logger.warning('wal-e exited without printing.')
                 return False
 
-            reader = csv.DictReader(io.StringIO(latest_backup),
+            reader = csv.DictReader(io.BytesIO(latest_backup),
                                     dialect='excel-tab')
             rows = list(reader)
             backup_info = rows[0]

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -51,18 +51,28 @@ def get_major_version(data_dir):
     return 0.0
 
 
+WALEConfig = namedtuple('WALEConfig',
+                        'dir,threshold_mb,threshold_pct,iam_string,cmd')
+
+
 class WALERestore(object):
-    def __init__(self, scope, datadir, connstring, env_dir, threshold_mb, threshold_pct, use_iam, no_master, retries):
+    def __init__(self, scope, datadir, connstring, env_dir, threshold_mb,
+                 threshold_pct, use_iam, no_master, retries):
         self.scope = scope
         self.master_connection = connstring
         self.data_dir = datadir
-        self.wal_e = namedtuple('wale', 'dir,threshold_mb,threshold_pct,iam_string,cmd')
-        self.wal_e.dir = env_dir
-        self.wal_e.threshold_mb = threshold_mb
-        self.wal_e.threshold_pct = threshold_pct
-        self.wal_e.iam_string = ' --aws-instance-profile ' if use_iam == 1 else ''
         self.no_master = no_master
-        self.wal_e.cmd = 'envdir {0} wal-e {1} '.format(self.wal_e.dir, self.wal_e.iam_string)
+
+        iam_string = ' --aws-instance-profile ' if use_iam == 1 else ''
+
+        self.wal_e = WALEConfig(
+            dir=env_dir,
+            threshold_mb=threshold_mb,
+            threshold_pct=threshold_pct,
+            iam_string=iam_string,
+            cmd='envdir {0} wal-e {1} '.format(env_dir, iam_string)
+        )
+
         self.init_error = (not os.path.exists(self.wal_e.dir))
         self.retries = retries
 

--- a/patroni/scripts/wale_restore.py
+++ b/patroni/scripts/wale_restore.py
@@ -69,16 +69,14 @@ class WALERestore(object):
         self.data_dir = datadir
         self.no_master = no_master
 
-        iam_string = ' --aws-instance-profile ' if use_iam == 1 else ''
-
         wale_cmd = [
             'envdir',
             env_dir,
             'wal-e',
         ]
 
-        if iam_string:
-            wale_cmd += [iam_string]
+        if use_iam == 1:
+            wale_cmd += ['--aws-instance-profile']
 
         self.wal_e = WALEConfig(
             env_dir=env_dir,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ click>=4.1
 prettytable>=0.7
 tzlocal
 python-dateutil
+enum34

--- a/tests/test_wale_restore.py
+++ b/tests/test_wale_restore.py
@@ -2,7 +2,6 @@ import psycopg2
 import subprocess
 import unittest
 import pytest
-import time
 
 from mock import Mock, MagicMock, patch, mock_open
 from patroni.scripts import wale_restore
@@ -93,7 +92,7 @@ def test_exit_code_enum_members_are_int_compatible(exit_code_int, exit_code):
 ])
 def test_run_exit_codes_by_should_use_s3(mock, exit_code, fx_wale_restore):
     """
-    Verify that WALERestore.run() returns the correct values based on the 
+    Verify that WALERestore.run() returns the correct values based on the
     results of WALERestore.should_use_s3t_to_create_replica().
     """
     with patch.object(fx_wale_restore, 'should_use_s3_to_create_replica',

--- a/tests/test_wale_restore.py
+++ b/tests/test_wale_restore.py
@@ -20,6 +20,7 @@ wale_output = (
     b'00000001000000000000007F\t00000240\n'
 )
 
+
 def make_wale_restore():
     return WALERestore("batman", "/data", "host=batman port=5432 user=batman",
                        "/etc", 100, 100, 1, 0, 1)


### PR DESCRIPTION
wal-e outputs in CSV format using the 'excel-tab' dialect:
https://github.com/wal-e/wal-e/blob/3164de68527e6ace269a2112291344b18b9ca6c5/wal_e/operator/backup.py#L63

The ISO date may be written with a space instead of 'T' as delimiter between date
and time, this causes the old parsing to fail.