### PR TITLE
BUGFIX: pg_rewind wasn't working when data page checksum is not enabled

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -324,7 +324,7 @@ class Postgresql(object):
 
     @staticmethod
     def configuration_allows_rewind(data):
-        return data.get('Current wal_log_hints setting', 'off') == 'on' \
+        return data.get('wal_log_hints setting', 'off') == 'on' \
             or data.get('Data page checksum version', '0') != '0'
 
     @property
@@ -1076,7 +1076,8 @@ class Postgresql(object):
                                                env={'LANG': 'C', 'LC_ALL': 'C', 'PATH': os.environ['PATH']})
                 if data:
                     data = data.decode('utf-8').splitlines()
-                    result = {l.split(':', 1)[0]: l.split(':', 1)[1].strip() for l in data if l}
+                    # pg_controldata output depends on major verion. Some of parameters are prefixed by 'Current '
+                    result = {l.split(':')[0].replace('Current ', '', 1): l.split(':', 1)[1].strip() for l in data if l}
             except subprocess.CalledProcessError:
                 logger.exception("Error when calling pg_controldata")
         return result

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -374,7 +374,7 @@ class TestPostgresql(unittest.TestCase):
             self.assertFalse(self.p.can_rewind)
         with patch('subprocess.call', side_effect=OSError):
             self.assertFalse(self.p.can_rewind)
-        with patch.object(Postgresql, 'controldata', Mock(return_value={'Current wal_log_hints setting': 'on'})):
+        with patch.object(Postgresql, 'controldata', Mock(return_value={'wal_log_hints setting': 'on'})):
             self.assertTrue(self.p.can_rewind)
         self.p.config['use_pg_rewind'] = False
         self.assertFalse(self.p.can_rewind)
@@ -545,7 +545,7 @@ class TestPostgresql(unittest.TestCase):
             data = self.p.controldata()
             self.assertEquals(len(data), 50)
             self.assertEquals(data['Database cluster state'], 'shut down in recovery')
-            self.assertEquals(data['Current wal_log_hints setting'], 'on')
+            self.assertEquals(data['wal_log_hints setting'], 'on')
             self.assertEquals(int(data['Database block size']), 8192)
 
         with patch('subprocess.check_output', Mock(side_effect=subprocess.CalledProcessError(1, ''))):


### PR DESCRIPTION
pg_controldata output depends on postgres major version and in some cases some of the parameters are prefixed by 'Current ' for old postgres versions.

Bug was introduced by commit 37c1552.
Fixes https://github.com/zalando/patroni/issues/455