### PR TITLE
AttributeError: 'dict' object has no attribute 'sleep_func'

### DIFF
--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -1,6 +1,7 @@
 import logging
+import time
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient, KazooState, KazooRetry
 from kazoo.exceptions import NoNodeError, NodeExistsError
 from kazoo.handlers.threading import SequentialThreadingHandler
 from patroni.dcs import AbstractDCS, ClusterConfig, Cluster, Failover, Leader, Member, SyncState
@@ -51,8 +52,9 @@ class ZooKeeper(AbstractDCS):
             hosts = ','.join(hosts)
 
         self._client = KazooClient(hosts, handler=PatroniSequentialThreadingHandler(config['retry_timeout']),
-                                   timeout=config['ttl'], connection_retry={'max_delay': 1, 'max_tries': -1},
-                                   command_retry={'deadline': config['retry_timeout'], 'max_delay': 1, 'max_tries': -1})
+                                   timeout=config['ttl'], connection_retry=KazooRetry(max_delay=1, max_tries=-1,
+                                   sleep_func=time.sleep), command_retry=KazooRetry(deadline=config['retry_timeout'],
+                                   max_delay=1, max_tries=-1, sleep_func=time.sleep))
         self._client.add_listener(self.session_listener)
 
         self._my_member_data = None


### PR DESCRIPTION
Based on debian 8 with Python 2.7.9 and Kazoo 1.3.1 connecting to a remote ZooKeeper service, the following exception is thrown:
```
$ /opt/patroni/patroni.py /etc/patroni/node01.yml 
Traceback (most recent call last):
  File "/opt/patroni/patroni.py", line 6, in <module>
    main()
  File "/opt/patroni/patroni/__init__.py", line 172, in main
    return patroni_main()
  File "/opt/patroni/patroni/__init__.py", line 139, in patroni_main
    patroni = Patroni()
  File "/opt/patroni/patroni/__init__.py", line 25, in __init__
    self.dcs = get_dcs(self.config)
  File "/opt/patroni/patroni/dcs/__init__.py", line 65, in get_dcs
    return value(config[name])
  File "/opt/patroni/patroni/dcs/zookeeper.py", line 55, in __init__
    command_retry={'deadline': config['retry_timeout'], 'max_delay': 1, 'max_tries': -1})
  File "/usr/lib/python2.7/dist-packages/kazoo/client.py", line 215, in __init__
    if self.handler.sleep_func != self._conn_retry.sleep_func:
AttributeError: 'dict' object has no attribute 'sleep_func'
```
This patch is adding the sleep function needed in the `connection_retry` and `command_retry` parameters. The KazooClient is trying to compare them with the ones included in the handler at instantiation.