### PR TITLE
truncate the fqdn to 63 chars, or NAMEDATALEN-1

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -56,7 +56,7 @@ def slot_name_from_member_name(member_name):
         return '_' if c in '-.' else "u{:04d}".format(ord(c))
 
     slot_name = re.sub('[^a-z0-9_]', replace_char, member_name.lower())
-    return slot_name[0:64]
+    return slot_name[0:63]
 
 
 class Postgresql(object):


### PR DESCRIPTION
as described here, https://github.com/postgres/postgres/blob/master/src/backend/replication/slot.c#L164-L210 the slot name should be truncated to 63 chars,

getting an error related to a slot_name
```
FATAL:  replication slot name "c_formationid4_main_m_1_c_formationid4_main_m_nicksaccount_svc_c" is too long
```
the leader has the following slot names

```
postgres=# select * from pg_replication_slots;
                            slot_name                            | plugin | slot_type | datoid | database | active | active_pid | xmin | catalog_xmin | restart_ls
n | confirmed_flush_lsn
-----------------------------------------------------------------+--------+-----------+--------+----------+--------+------------+------+--------------+-----------
--+---------------------
 c_formationid4_main_m_1_c_formationid4_main_m_nicksaccount_svc_ |        | physical  |        |          | f      |            |      |              |
  |
 c_formationid4_main_m_2_c_formationid4_main_m_nicksaccount_svc_ |        | physical  |        |          | f      |            |      |              |
  |
(2 rows)
```