### PR TITLE
Update python-etcd dependency to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PyYAML
 requests
 six >= 1.7
 kazoo==2.2.1
-python-etcd==0.4.3
+python-etcd==0.4.5
 python-consul==0.7.0
 click>=4.1
 prettytable>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PyYAML
 requests
 six >= 1.7
 kazoo==2.2.1
-python-etcd==0.4.5
+python-etcd>=0.4.3,<0.5
 python-consul==0.7.0
 click>=4.1
 prettytable>=0.7


### PR DESCRIPTION
There are  several issues that were fixed after 0.4.3, currently in use, and in its dependencies. The latest release should be backwards compatible.