### PR TITLE
Improve haproxy.cfg

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,21 +1,25 @@
 global
-	maxconn 100
+    maxconn 100
 
 defaults
-	log	global
-	mode	tcp
-	retries 2
-	timeout client 30m
-	timeout connect 4s
-	timeout server 30m
-	timeout check 5s
+    log global
+    mode tcp
+    retries 2
+    timeout client 30m
+    timeout connect 4s
+    timeout server 30m
+    timeout check 5s
 
-frontend ft_postgresql
-	bind *:5000
-	default_backend bk_db
+listen stats
+    mode http
+    bind *:7000
+    stats enable
+    stats uri /
 
-backend bk_db
-	option httpchk
-
+listen batman
+    bind *:5000
+    option httpchk
+    http-check expect status 200
+    default-server inter 3s fall 3 rise 2
     server postgresql_127.0.0.1_5432 127.0.0.1:5432 maxconn 100 check port 8008
     server postgresql_127.0.0.1_5433 127.0.0.1:5433 maxconn 100 check port 8009

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -20,6 +20,6 @@ listen batman
     bind *:5000
     option httpchk
     http-check expect status 200
-    default-server inter 3s fall 3 rise 2
+    default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
     server postgresql_127.0.0.1_5432 127.0.0.1:5432 maxconn 100 check port 8008
     server postgresql_127.0.0.1_5433 127.0.0.1:5433 maxconn 100 check port 8009


### PR DESCRIPTION
What was improved:
* Use more readable `listen` section
* Explicitly defined check options
* Close connections to a backend when it's marked as down
* Enable stats dashboard

Also in a Docker environment it's possible to use [Embedded DNS server](https://docs.docker.com/engine/userguide/networking/configure-dns/) and use bridged network in `docker-compose.yml`. This way `haproxy` can dynamically resolve IP addresses, sample `haproxy` config may look  like:

```
resolvers docker
    nameserver dns 127.0.0.11:53

listen batman
    ...
    server postgresql_127.0.0.1_5432 postgres1:5432 maxconn 100 check port 8008 resolvers docker resolve-prefer ipv4
```
Now it should be easier to test failing nodes in the dynamic environment and it's a good alternative to `confd`.

Unfortunately, I don't have enough time to create a proper pull request that will cover all the features.