### PR TITLE
Address failure of unit tests on OS X.

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -535,7 +535,6 @@ class Postgresql(object):
         except Exception:
             logger.exception('Exception during custom bootstrap')
             return False
-
         self._post_restore()
         self.save_configuration_files()
 


### PR DESCRIPTION
- call_self calls subprocess.Popen, that, when not mocked, actually
tries to start PostgreSQL (when called from start).
- os.kill mock disrupts the working of psutil.Process, don't try to
  be overly smart about mocking the innards of it, instead, mock
  it entirely
- mock save_configuration_files/restore_configuration_files instead
  of overriding individual functions inside them, as we call both
  from othe tests as well.