### PR TITLE
BUGFIX: patronictl edit-config didn't worked with zookeeper

### DIFF
--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -34,9 +34,9 @@ Scenario: check local configuration reload
 	Then I receive a response code 202
 
 Scenario: check dynamic configuration change via DCS
-	Given I issue a PATCH request to http://127.0.0.1:8008/config with {"ttl": 10, "loop_wait": 2, "postgresql": {"parameters": {"max_connections": 101}}}
-	Then I receive a response code 200
-	And I receive a response loop_wait 2
+	Given I run patronictl.py edit-config -s 'ttl=10' -s 'loop_wait=2' -p 'max_connections=101' --force batman
+	Then I receive a response returncode 0
+	And I receive a response output "+loop_wait: 2"
 	And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 11 seconds
 	When I issue a GET request to http://127.0.0.1:8008/config
 	Then I receive a response code 200

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -903,14 +903,14 @@ def apply_config_changes(before_editing, data, kvpairs):
         if prefix == ('postgresql', 'parameters'):
             path = ['.'.join(path)]
 
+        key = path[0]
         if len(path) == 1:
             if value is None:
-                config.pop(path[0], None)
+                config.pop(key, None)
             else:
-                config[path[0]] = value
+                config[key] = value
         else:
-            key = path[0]
-            if key not in config:
+            if not isinstance(config.get(key), dict):
                 config[key] = {}
             set_path_value(config[key], path[1:], value, prefix + (key,))
             if config[key] == {}:
@@ -1017,7 +1017,7 @@ def edit_config(obj, cluster_name, force, quiet, kvpairs, pgkvpairs, apply_filen
         return
 
     if force or click.confirm('Apply these changes?'):
-        if not dcs.set_config_value(json.dumps(changed_data), cluster.config.modify_index):
+        if not dcs.set_config_value(json.dumps(changed_data), cluster.config.index):
             raise PatroniCtlException("Config modification aborted due to concurrent changes")
         click.echo("Configuration changed")
 


### PR DESCRIPTION
When updating config key we should use `ClusterConfig.index` instead of
`ClusterConfig.modify_index`. The second one should be used by Patroni
internally to check that key was really changed, because when key is
deleted and recreated it's version always starts from the same value: 0

In addition to that use patronictl instead of http PATCH in some of
acceptance tests to change cluster config.

Fixes https://github.com/zalando/patroni/issues/491