### PR TITLE
Pass the consul token as a header

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -83,8 +83,7 @@ class HTTPClient(object):
             else:
                 kwargs['timeout'] = self._read_timeout
             if isinstance(params, dict) and 'token' in params and params['token']:
-                kwargs['headers'] = {'X-Consul-Token': params['token']}
-                del params['token']
+                kwargs['headers'] = {'X-Consul-Token': params.pop('token')}
             return callback(self.response(self.http.request(method.upper(), self.uri(path, params), **kwargs)))
         return wrapper
 

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -82,6 +82,9 @@ class HTTPClient(object):
                 kwargs['timeout'] = (float(params['wait'][:-1]) if 'wait' in params else 300) + 1
             else:
                 kwargs['timeout'] = self._read_timeout
+            if isinstance(params, dict) and 'token' in params and params['token']:
+                kwargs['headers'] = {'X-Consul-Token': params['token']}
+                del params['token']
             return callback(self.response(self.http.request(method.upper(), self.uri(path, params), **kwargs)))
         return wrapper
 


### PR DESCRIPTION
Headers are now the prefered way to pass the token to the consul
API - https://www.consul.io/api/index.html#authentication