### PR TITLE
Fix pg_rewind behaviour

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -207,6 +207,16 @@ class Ha(object):
             msg = "starting as a secondary"
             node_to_follow = self._get_node_to_follow(self.cluster)
 
+        # once we already tried to start postgres but failed, single user mode is a rescue in this case
+        if self.recovering and not self.state_handler.rewind_executed and self.state_handler.can_rewind:
+            data = self.state_handler.controldata()
+            if data.get('Database cluster state') not in ('shut down', 'shut down in recovery'):
+                self.recovering = False
+                msg = 'fixing cluster state in a single user mode'
+                self._async_executor.schedule(msg)
+                self._async_executor.run_async(self.state_handler.fix_cluster_state)
+                return msg
+
         self.recovering = True
 
         self._async_executor.schedule('restarting after failure')

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -193,6 +193,15 @@ class TestHa(unittest.TestCase):
         self.ha.cluster = get_cluster_initialized_with_leader()
         self.assertEquals(self.ha.run_cycle(), 'running pg_rewind from leader')
 
+    @patch.object(Postgresql, 'can_rewind', PropertyMock(return_value=True))
+    @patch.object(Postgresql, 'fix_cluster_state', Mock())
+    def test_single_user_after_recover_failed(self):
+        self.p.controldata = lambda: {'Database cluster state': 'in production'}
+        self.p.is_running = false
+        self.p.follow = false
+        self.assertEquals(self.ha.run_cycle(), 'starting as a secondary')
+        self.assertEquals(self.ha.run_cycle(), 'fixing cluster state in a single user mode')
+
     @patch('sys.exit', return_value=1)
     @patch('patroni.ha.Ha.sysid_valid', MagicMock(return_value=True))
     def test_sysid_no_match(self, exit_mock):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -327,10 +327,10 @@ class TestPostgresql(unittest.TestCase):
     @patch.object(Postgresql, 'can_rewind', PropertyMock(return_value=True))
     def test__get_local_timeline_lsn(self):
         self.p.trigger_check_diverged_lsn()
-        with patch.object(Postgresql, 'controldata', Mock(return_value={'Database cluster state': 'shut down'})):
-            self.p.rewind_needed_and_possible(self.leader)
         with patch.object(Postgresql, 'controldata',
-                          Mock(return_value={'Database cluster state': 'shut down in recovery'})):
+                          Mock(return_value={'Database cluster state': 'shut down in recovery',
+                                             'Minimum recovery ending location': '0/0',
+                                             "Min recovery ending loc's timeline": '0'})):
             self.p.rewind_needed_and_possible(self.leader)
         with patch.object(Postgresql, 'is_running', Mock(return_value=True)):
             with patch.object(MockCursor, 'fetchone', Mock(side_effect=[(False, ), Exception])):


### PR DESCRIPTION
When Patroni does calculation whether it should run pg_rewind or not, it relies on pg_controldata output or gets necessary information from replication connection.
In some cases (when for example postgres running as a master was killed), we can't use pg_controldata output immediately, but trying to start postgres. Such start could fail with the following errror:
```
2017-09-18 08:00:38.659 UTC,,,55,,59bf7d26.37,1,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"ending log output to stderr",,"Future log output will go to log destination ""csvlog"".",,,,,,,""
2017-09-18 08:00:38.661 UTC,,,57,,59bf7d26.39,1,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"database system was interrupted; last known up at 2017-09-16 22:35:22 UTC",,,,,,,,,""
2017-09-18 08:00:39.012 UTC,,,57,,59bf7d26.39,2,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"restored log file ""00000006.history"" from archive",,,,,,,,,""
2017-09-18 08:00:39.222 UTC,,,57,,59bf7d26.39,3,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"entering standby mode",,,,,,,,,""
2017-09-18 08:00:39.433 UTC,,,57,,59bf7d26.39,4,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"restored log file ""00000006.history"" from archive",,,,,,,,,""
2017-09-18 08:00:39.437 UTC,,,57,,59bf7d26.39,5,,2017-09-18 08:00:38 UTC,,0,FATAL,XX000,"requested timeline 6 is not a child of this server's history","Latest checkpoint is at 29/1A000178 on timeline 5, but in the history of the requested timeline, the server forked off from that timeline at 29/1A000140.",,,,,,,,""
2017-09-18 08:00:39.439 UTC,,,55,,59bf7d26.37,2,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"startup process (PID 57) exited with exit code 1",,,,,,,,,""
2017-09-18 08:00:39.439 UTC,,,55,,59bf7d26.37,3,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"aborting startup due to startup process failure",,,,,,,,,""
2017-09-18 08:00:39.441 UTC,,,55,,59bf7d26.37,4,,2017-09-18 08:00:38 UTC,,0,LOG,00000,"database system is shut down",,,,,,,,,""
```
After that it's not possible to start such cluster in a normal mode, only single-user is possible.

The second problems is: if postgres was running as master, pg_controldata reports:
```
Database cluster state:               shut down in recovery
Minimum recovery ending location:     0/0
Min recovery ending loc's timeline:   0
```

And this info can't be used for calculations. In this case we should use `Latest checkpoint location` and `Latest checkpoint's TimeLineID`