### PR TITLE
Minimal TTL & PATRONI_LOGFORMAT

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -134,13 +134,9 @@ class Patroni(object):
 
 
 def patroni_main():
-    logformat_env_variable = 'PATRONI_LOGFORMAT'
-    logformat = r'%(asctime)s %(levelname)s: %(message)s'
-    if logformat_env_variable in os.environ:
-        logformat = os.environ[logformat_env_variable]
+    logformat = os.environ.get('PATRONI_LOGFORMAT', '%(asctime)s %(levelname)s: %(message)s')
     logging.basicConfig(format=logformat, level=logging.INFO)
     logging.getLogger('requests').setLevel(logging.WARNING)
-
 
     patroni = Patroni()
     try:

--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -134,8 +134,13 @@ class Patroni(object):
 
 
 def patroni_main():
-    logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=logging.INFO)
+    logformat_env_variable = 'PATRONI_LOGFORMAT'
+    logformat = r'%(asctime)s %(levelname)s: %(message)s'
+    if logformat_env_variable in os.environ:
+        logformat = os.environ[logformat_env_variable]
+    logging.basicConfig(format=logformat, level=logging.INFO)
     logging.getLogger('requests').setLevel(logging.WARNING)
+
 
     patroni = Patroni()
     try:

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -168,7 +168,10 @@ class Consul(AbstractDCS):
                 time.sleep(5)
 
     def set_ttl(self, ttl):
-        if self._client.http.set_ttl(ttl/2.0):  # Consul multiplies the TTL by 2x
+        ttl_ = ttl/2.0   # Consul multiplies the TTL by 2x
+        if ttl_ < 10.0:   # Minimal TTL for consul = 10, else gives "Error 500"
+            ttl_ = 10.0
+        if self._client.http.set_ttl(ttl_):
             self._session = None
             self.__do_not_watch = True
 


### PR DESCRIPTION
* Minimal TTL for consul should be at least 10, else Consul gives "Error 500"
* Really need PATRONI_LOGFORMAT — specs/settings for logging

Because if Patroni running as service and log monitoring 
using "journalctl -fu patroni" we get time recorded twice in record logs:

```
Sep 18 19:49:49 tms-db-centos-3.local.com patroni.py[1052]: 2017-09-18 19:49:49,159 INFO: no action.  i am a secondary and i am following a leader
Sep 18 19:49:59 tms-db-centos-3.local.com patroni.py[1052]: 2017-09-18 19:49:59,573 INFO: Lock owner: tms-db-centos-2; I am tms-db-centos-3
Sep 18 19:49:59 tms-db-centos-3.local.com patroni.py[1052]: 2017-09-18 19:49:59,573 INFO: does not have lock
Sep 18 19:49:59 tms-db-centos-3.local.com patroni.py[1052]: 2017-09-18 19:49:59,578 INFO: no action.  i am a secondary and i am following a leader

```
Waste of space, bad for demo.

After this patch and setting 
`  Environment="PATRONI_LOGFORMAT=%(levelname)s: %(message)s"
`
in patroni.service
we have much more compact:
```
Sep 18 20:53:57 tms-db-centos-1.local.com patroni[21865]: INFO: Lock owner: tms-db-centos-3; I am tms-db-centos-1
Sep 18 20:53:57 tms-db-centos-1.local.com patroni[21865]: INFO: does not have lock
Sep 18 20:53:57 tms-db-centos-1.local.com patroni[21865]: INFO: no action.  i am a secondary and i am following a leader


```