### PR TITLE
Fix watchdog on Python 3 

### DIFF
--- a/features/steps/watchdog.py
+++ b/features/steps/watchdog.py
@@ -31,7 +31,7 @@ def watchdog_was_closed(context, name):
     assert context.pctl.get_watchdog(name).was_closed
 
 
-@step('I wait for next {name:w} watchdog ping')
+@step('I reset {name:w} watchdog state')
 def watchdog_reset_pinged(context, name):
     context.pctl.get_watchdog(name).reset()
 

--- a/features/watchdog.feature
+++ b/features/watchdog.feature
@@ -14,7 +14,8 @@ Feature: watchdog
     Then postgres0 watchdog has been closed
 
   Scenario: watchdog is opened and pinged after resume
-    Given I run patronictl.py resume batman
+    Given I reset postgres0 watchdog state
+    And I run patronictl.py resume batman
     Then I receive a response returncode 0
     And postgres0 watchdog has been pinged after 10 seconds
 
@@ -23,7 +24,8 @@ Feature: watchdog
     Then postgres0 watchdog has been closed
 
   Scenario: watchdog is triggered if patroni stops responding
-    Given I start postgres0 with watchdog
+    Given I reset postgres0 watchdog state
+    And I start postgres0 with watchdog
     Then postgres0 role is the primary after 10 seconds
     When postgres0 hangs for 30 seconds
     Then postgres0 watchdog is triggered after 30 seconds

--- a/patroni/watchdog/base.py
+++ b/patroni/watchdog/base.py
@@ -133,6 +133,7 @@ class Watchdog(object):
 
         try:
             self.impl.open()
+            actual_timeout = self._set_timeout()
         except WatchdogError as e:
             logger.warning("Could not activate %s: %s", self.impl.describe(), e)
             self.impl = NullWatchdog()
@@ -140,8 +141,6 @@ class Watchdog(object):
         if self.impl.is_running and not self.impl.can_be_disabled:
             logger.warning("Watchdog implementation can't be disabled."
                            " Watchdog will trigger after Patroni loses leader key.")
-
-        actual_timeout = self._set_timeout()
 
         if not self.impl.is_running or actual_timeout > self.config.timeout:
             if self.config.mode == MODE_REQUIRED:

--- a/patroni/watchdog/linux.py
+++ b/patroni/watchdog/linux.py
@@ -173,7 +173,7 @@ class LinuxWatchdogDevice(WatchdogBase):
                 raise WatchdogError("Could not get information about watchdog device: {}".format(e))
             self._support_cache = WatchdogInfo(info.options,
                                                info.firmware_version,
-                                               str(bytearray(info.identity)).rstrip('\x00'))
+                                               bytearray(info.identity).decode(errors='ignore').rstrip('\x00'))
         return self._support_cache
 
     def describe(self):


### PR DESCRIPTION
(fixes #528)

A misunderstanding of the `ioctl()` call interface. If `mutable=False` then `fcntl.ioctl()` actually returns the arg buffer back. This accidentally worked on Python2 because `int` and `str` comparison did not return an error. Error reporting is actually done by raising `IOError` on Python2 and `OSError` on Python3.

Fix is to let `IOError`, `OSError` bubble up from `LinuxWatchdog._ioctl` and wrap it in `WatchdogError` with error context information in calling functions.

Also properly handle errors in `set_timeout()`, have them result in only a warning if watchdog support is not required.
