### PR TITLE
Make it possible to change Consul session checks

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -33,7 +33,7 @@ Consul
 -  **PATRONI\_CONSUL\_CACERT**: (optional) The ca certificate. If pressent it will enable validation.
 -  **PATRONI\_CONSUL\_CERT**: (optional) File with the client certificate
 -  **PATRONI\_CONSUL\_KEY**: (optional) File with the client key. Can be empty if the key is part of certificate.
--  **PATRONI\_CONSUL\_CHECKS**: (optional) list of Consul health checks used for session. If not specified Consul will use "serfHealth" in additional to TTL based created by Patroni.
+-  **PATRONI\_CONSUL\_CHECKS**: (optional) list of Consul health checks used for the session. If not specified Consul will use "serfHealth" in additional to the TTL based check created by Patroni. Additional checks, in particular the "serfHealth", may cause the leader lock to expire faster than in `ttl` seconds when the leader instance becomes unavailable.
 
 Etcd
 ----

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -33,6 +33,7 @@ Consul
 -  **PATRONI\_CONSUL\_CACERT**: (optional) The ca certificate. If pressent it will enable validation.
 -  **PATRONI\_CONSUL\_CERT**: (optional) File with the client certificate
 -  **PATRONI\_CONSUL\_KEY**: (optional) File with the client key. Can be empty if the key is part of certificate.
+-  **PATRONI\_CONSUL\_CHECKS**: (optional) list of Consul health checks used for session. If not specified Consul will use "serfHealth" in additional to TTL based created by Patroni.
 
 Etcd
 ----

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -58,6 +58,7 @@ Most of the parameters are optional, but you have to specify one of the **host**
 -  **cacert**: (optional) The ca certificate. If pressent it will enable validation.
 -  **cert**: (optional) file with the client certificate
 -  **key**: (optional) file with the client key. Can be empty if the key is part of **cert**.
+-  **checks**: (optional) list of Consul health checks used for session. If not specified Consul will use "serfHealth" in additional to TTL based created by Patroni.
 
 Etcd
 ----

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -58,7 +58,7 @@ Most of the parameters are optional, but you have to specify one of the **host**
 -  **cacert**: (optional) The ca certificate. If pressent it will enable validation.
 -  **cert**: (optional) file with the client certificate
 -  **key**: (optional) file with the client key. Can be empty if the key is part of **cert**.
--  **checks**: (optional) list of Consul health checks used for session. If not specified Consul will use "serfHealth" in additional to TTL based created by Patroni.
+-  **checks**: (optional) list of Consul health checks used for the session. If not specified Consul will use "serfHealth" in additional to the TTL based check created by Patroni. Additional checks, in particular the "serfHealth", may cause the leader lock to expire faster than in `ttl` seconds when the leader instance becomes unavailable
 
 Etcd
 ----

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -243,11 +243,11 @@ class Config(object):
                 if name and suffix:
                     # PATRONI_(ETCD|CONSUL|ZOOKEEPER|EXHIBITOR|...)_(HOSTS?|PORT|..)
                     if suffix in ('HOST', 'HOSTS', 'PORT', 'SRV', 'URL', 'PROXY', 'CACERT', 'CERT', 'KEY',
-                                  'VERIFY', 'TOKEN') and '_' not in name:
+                                  'VERIFY', 'TOKEN', 'CHECKS') and '_' not in name:
                         value = os.environ.pop(param)
                         if suffix == 'PORT':
                             value = value and parse_int(value)
-                        elif suffix == 'HOSTS':
+                        elif suffix in ('HOSTS', 'CHECKS'):
                             value = value and _parse_list(value)
                         if value:
                             ret[name.lower()][suffix.lower()] = value

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -153,6 +153,7 @@ class Consul(AbstractDCS):
         self.set_retry_timeout(config['retry_timeout'])
         self.set_ttl(config.get('ttl') or 30)
         self._last_session_refresh = 0
+        self.__session_checks = config.get('checks')
         if not self._ctl:
             self.create_session()
 
@@ -189,6 +190,7 @@ class Consul(AbstractDCS):
         ret = not self._session
         if ret:
             self._session = self._client.session.create(name=self._scope + '-' + self._name,
+                                                        checks=self.__session_checks,
                                                         lock_delay=0.001, behavior='delete')
         self._last_session_refresh = time.time()
         return ret


### PR DESCRIPTION
If list of checks is not specified, Consul will use "serfHealth" in addition to TTL based created by Patroni.
There are some cases when people want to sacrifice fast detection of network partitioning in favor of ability to tolerate network lags.

Fixes https://github.com/zalando/patroni/issues/522