### PR TITLE
Verify process start time when checking if postgres is running.

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 from patroni import call_self
 from patroni.callback_executor import CallbackExecutor
 from patroni.exceptions import PostgresConnectionException
-from patroni.utils import compare_values, parse_bool, parse_int, Retry, RetryFailedError, polling_loop
+from patroni.utils import compare_values, parse_bool, parse_int, Retry, RetryFailedError, polling_loop, int_or_none
 from six import string_types
 from six.moves.urllib.parse import quote_plus
 from threading import current_thread, Lock
@@ -707,20 +707,9 @@ class Postgresql(object):
         if not (self._version_file_exists() and os.path.isfile(self._postmaster_pid)):
             # XXX: This is dangerous in case somebody deletes the data directory while PostgreSQL is still running.
             return False
+
         pidfile = self.read_pid_file()
-        if 'pid' not in pidfile:
-            return False
-
-        try:
-            proc = psutil.Process(int(pidfile['pid']))
-        except (ValueError, psutil.NoSuchProcess):
-            return False
-
-        # If start time differs, then it's the wrong process. Allow for 3 second difference for rounding errors.
-        if 'start_time' in pidfile and abs(proc.create_time() - int(pidfile['start_time'])) > 3:
-            return False
-
-        return proc.is_running()
+        return self._is_postmaster_pid_running(int_or_none(pidfile.get('pid')), start_time=int_or_none(pidfile.get('start_time')))
 
     def read_pid_file(self):
         """Reads and parses postmaster.pid from the data directory
@@ -747,13 +736,27 @@ class Postgresql(object):
             return 0
 
     @staticmethod
-    def is_pid_running(pid):
-        try:
-            if pid < 0:
-                pid = -pid
-            return pid > 0 and pid != os.getpid() and pid != os.getppid() and (os.kill(pid, 0) or True)
-        except Exception:
+    def _is_postmaster_pid_running(pid, start_time=None):
+        # Normalize pid handling missing values and negative pids from postmaster.pid
+        if not pid:
             return False
+        if pid < 0:
+            pid = -pid
+
+        try:
+            proc = psutil.Process(pid)
+        except psutil.NoSuchProcess:
+            return False
+
+        # If the process is Patroni or Patronis host process then it's a false positive
+        if pid == os.getpid() or pid == os.getppid():
+            return False
+
+        # If process start time differs by more than 3 seconds it's a false positive
+        if start_time is not None and abs(proc.create_time() - start_time) > 3:
+            return False
+
+        return True
 
     @property
     def cb_called(self):
@@ -818,7 +821,7 @@ class Postgresql(object):
                     # Garbage in the pid file
                     pass
 
-            if not self.is_pid_running(pid):
+            if not self._is_postmaster_pid_running(pid, start_time=initiated):
                 logger.error('postmaster is not running')
                 self.set_state('start failed')
                 return False
@@ -977,7 +980,7 @@ class Postgresql(object):
     def _wait_for_postmaster_stop(self, pid):
         # This wait loop differs subtly from pg_ctl as we check for both the pid file going
         # away and if the pid is running. This seems safer.
-        while pid == self.get_pid() and self.is_pid_running(pid):
+        while pid == self.get_pid() and self._is_postmaster_pid_running(pid):
             time.sleep(STOP_POLLING_INTERVAL)
 
     def _signal_postmaster_stop(self, mode):
@@ -1007,13 +1010,13 @@ class Postgresql(object):
                 return
             logger.warning("Could not send stop signal to PostgreSQL (error: {0})".format(e.errno))
 
-        while self.is_pid_running(pid):
+        while self._is_postmaster_pid_running(pid):
             time.sleep(STOP_POLLING_INTERVAL)
 
     def _wait_for_connection_close(self, pid):
         try:
             with self.connection().cursor() as cur:
-                while pid == self.get_pid() and self.is_pid_running(pid):  # Need a timeout here?
+                while pid == self.get_pid() and self._is_postmaster_pid_running(pid):  # Need a timeout here?
                     cur.execute("SELECT 1")
                     time.sleep(STOP_POLLING_INTERVAL)
         except psycopg2.Error:

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -717,7 +717,7 @@ class Postgresql(object):
             return False
 
         # If start time differs, then it's the wrong process. Allow for 3 second difference for rounding errors.
-        if 'start_time' in pidfile and abs(proc.create_time() - int(pidfile['start_time'])) < 3:
+        if 'start_time' in pidfile and abs(proc.create_time() - int(pidfile['start_time'])) > 3:
             return False
 
         return proc.is_running()

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -709,7 +709,8 @@ class Postgresql(object):
             return False
 
         pidfile = self.read_pid_file()
-        return self._is_postmaster_pid_running(int_or_none(pidfile.get('pid')), start_time=int_or_none(pidfile.get('start_time')))
+        return self._is_postmaster_pid_running(int_or_none(pidfile.get('pid')),
+                                               start_time=int_or_none(pidfile.get('start_time')))
 
     def read_pid_file(self):
         """Reads and parses postmaster.pid from the data directory
@@ -756,7 +757,7 @@ class Postgresql(object):
         # If process start time differs by more than 3 seconds it's a false positive
         if start_time is not None and abs(proc.create_time() - start_time) > 3:
             return False
-        
+
         return True
 
     @property

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -748,14 +748,15 @@ class Postgresql(object):
         except psutil.NoSuchProcess:
             return False
 
-        # If the process is Patroni or Patronis host process then it's a false positive
-        if pid == os.getpid() or pid == os.getppid():
+        # If the process is Patroni or Patronis host process or Patronis child process then it's a false positive
+        my_pid = os.getpid()
+        if pid == my_pid or pid == os.getppid() or proc.parent() == my_pid:
             return False
 
         # If process start time differs by more than 3 seconds it's a false positive
         if start_time is not None and abs(proc.create_time() - start_time) > 3:
             return False
-
+        
         return True
 
     @property

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -713,7 +713,7 @@ class Postgresql(object):
 
         try:
             proc = psutil.Process(int(pidfile['pid']))
-        except ValueError, psutil.NoSuchProcess:
+        except (ValueError, psutil.NoSuchProcess):
             return False
 
         # If start time differs, then it's the wrong process. Allow for 3 second difference for rounding errors.

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -280,3 +280,11 @@ def polling_loop(timeout, interval=1):
         yield iteration
         iteration += 1
         time.sleep(interval)
+
+
+def int_or_none(val):
+    """Returns integer value of the parameter if convertible to int, None otherwise."""
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return None


### PR DESCRIPTION
After a crash that doesn't clean up postmaster.pid there could be a new process with the same pid resulting in a false positive for is_running(), which will lead to all kinds of bad behavior.

Fixes #548 

Not sure how portable the implementation is, needs some research. Tests are also missing, if the general approach seems fine then I will figure out how to test this code.