### PR TITLE
shutdown postgresql before bootstrap when we lost data directory

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1015,6 +1015,7 @@ class Ha(object):
             # is data directory empty?
             if self.state_handler.data_directory_empty():
                 self.state_handler.set_role('uninitialized')
+                self.state_handler.stop()
                 # In case datadir went away while we were master. TODO: check for this and try to stop postgresql.
                 self.watchdog.disable()
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -760,7 +760,7 @@ class Postgresql(object):
                 self.postmaster = {'pid': pmpid, 'start_time': pmstart}
                 logger.info("Updated postmaster info: {}".format(self.postmaster))
             except ValueError:
-                # Garbage in the pid file
+                logger.exception("Cannot update postmaster info with data duw garbage in pid file: {}".format(pid_data))
                 pass
         else:
             logger.warning("Cannot update postmaster info with data from pid file: {}".format(pid_data))

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -764,7 +764,7 @@ class Postgresql(object):
                 return process.pid
             else:
                 logger.info("Process with pid %s was started at different time %s .",
-                               process.pid, process.create_time())
+                            process.pid, process.create_time())
         except psutil.NoSuchProcess:
             logger.info("Cannot find process %s .", self._postmaster_info['pid'])
         return 0

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -760,8 +760,7 @@ class Postgresql(object):
                 self.postmaster = {'pid': pmpid, 'start_time': pmstart}
                 logger.info("Updated postmaster info: {}".format(self.postmaster))
             except ValueError:
-                logger.exception("Cannot update postmaster info with data duw garbage in pid file: {}".format(pid_data))
-                pass
+                logger.exception("Cannot update postmaster info with data due garbage in pid file: {}".format(pid_data))
         else:
             logger.warning("Cannot update postmaster info with data from pid file: {}".format(pid_data))
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -737,7 +737,7 @@ class Postgresql(object):
             return 0
 
     def get_pid_with_lost_data_dir(self):
-        process = filter(lambda p: p.name() == "postgres" and self._data_dir in p.cmdline(), psutil.process_iter())
+        process = list(filter(lambda p: p.name() == "postgres" and self._data_dir in p.cmdline(), psutil.process_iter()))
         if process:
             return process[0].pid
         return 0

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -142,6 +142,7 @@ class Postgresql(object):
         self._pg_hba_conf = os.path.join(self._config_dir, 'pg_hba.conf')
         self._recovery_conf = os.path.join(self._data_dir, 'recovery.conf')
         self._postmaster_pid = os.path.join(self._data_dir, 'postmaster.pid')
+        self.postmaster = {'pid': 0, 'start_time': 0}
         self._trigger_file = config.get('recovery_conf', {}).get('trigger_file') or 'promote'
         self._trigger_file = os.path.abspath(os.path.join(self._data_dir, self._trigger_file))
 
@@ -170,6 +171,7 @@ class Postgresql(object):
             self._write_postgresql_conf()  # we are "joining" already running postgres
             if self._replace_pg_hba():
                 self.reload()
+            self.update_postmaster_info()
 
     @property
     def _configuration_to_save(self):
@@ -737,10 +739,35 @@ class Postgresql(object):
             return 0
 
     def get_pid_with_lost_data_dir(self):
-        process = list(filter(lambda p: p.name() == "postgres" and self._data_dir in p.cmdline(), psutil.process_iter()))
+        process = list(filter(
+            lambda p: p.pid == self.postmaster["pid"] and p.name() == "postgres" and self._data_dir in p.cmdline(),
+            psutil.process_iter()))
+        logger.debug("Cached postmaster info: {}, possible processes: {}".format(self.postmaster, process))
         if process:
-            return process[0].pid
+            if abs(self.postmaster["start_time"] - process[0].create_time()) < 2:
+                return process[0].pid
+            else:
+                logger.info("Process with pid {} was started at different time {}"
+                            .format(process[0].pid, process[0].create_time()))
         return 0
+
+    def update_postmaster_info(self):
+        pid_data = self.read_pid_file()
+        if len(pid_data) > 5:
+            try:
+                pmpid = int(pid_data['pid'])
+                pmstart = int(pid_data['start_time'])
+                self.postmaster = {'pid': pmpid, 'start_time': pmstart}
+                logger.info("Updated postmaster info: {}".format(self.postmaster))
+            except ValueError:
+                # Garbage in the pid file
+                pass
+        else:
+            logger.warning("Cannot update postmaster info with data from pid file: {}".format(pid_data))
+
+    def clean_postmaster_info(self):
+        self.postmaster = {'pid': 0, 'start_time': 0}
+        logger.info("postmaster info was cleaned: {}".format(self.postmaster))
 
     @staticmethod
     def is_pid_running(pid):
@@ -893,6 +920,8 @@ class Postgresql(object):
         if not self.wait_for_port_open(pid, start_initiated, start_timeout):
             return False
 
+        self.update_postmaster_info()
+
         ret = self.wait_for_startup(start_timeout)
         if ret is not None:
             return ret
@@ -946,6 +975,7 @@ class Postgresql(object):
                 pid = self.get_pid_with_lost_data_dir()
                 if pid > 0:
                     self.terminate_starting_postmaster(pid)
+                    self.clean_postmaster_info()
                     return True, True
             if on_safepoint:
                 on_safepoint()
@@ -972,6 +1002,7 @@ class Postgresql(object):
             on_safepoint()
 
         self._wait_for_postmaster_stop(pid)
+        self.clean_postmaster_info()
 
         return True, True
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -766,7 +766,8 @@ class Postgresql(object):
 
     def get_pid_with_lost_data_dir(self):
         process = list(filter(
-            lambda p: p.pid == self._postmaster_info["pid"] and p.name() == "postgres" and self._data_dir in p.cmdline(),
+            lambda p:
+            p.pid == self._postmaster_info["pid"] and p.name() == "postgres" and self._data_dir in p.cmdline(),
             psutil.process_iter()))
         logger.info("Cached postmaster info: {}, possible processes: {}".format(self._postmaster_info, process))
         if process:


### PR DESCRIPTION
Tries to kill postgresql before bootstrap to prevent old process from interfering. Fix for second part of https://github.com/zalando/patroni/issues/542 