### PR TITLE
Patronictl extended info

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -24,7 +24,7 @@ Version 1.3.6
 
 **Consul improvements**
 
-- Make it possible to provide datacenter configuration for Consul (DeathBorn, Alexander)
+- Make it possible to provide datacenter configuration for Consul (Vilius Okockis, Alexander)
 
   Before that Patroni was always communicating with datacenter of the host it runs on.
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -7,8 +7,8 @@ import time
 import dateutil.parser
 import datetime
 
-from patroni.exceptions import PostgresConnectionException
-from patroni.utils import deep_compare, patch_config, Retry, RetryFailedError, is_valid_pg_version, parse_int, tzutc
+from patroni.postgresql import PostgresConnectionException, PostgresException, Postgresql
+from patroni.utils import deep_compare, patch_config, Retry, RetryFailedError, parse_int, tzutc
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from six.moves.socketserver import ThreadingMixIn
 from threading import Thread
@@ -221,9 +221,11 @@ class RestApiHandler(BaseHTTPRequestHandler):
                     data = "PostgreSQL role should be either master or replica"
                     break
             elif k == 'postgres_version':
-                if not is_valid_pg_version(request[k]):
+                try:
+                    Postgresql.postgres_version_to_int(request[k])
+                except PostgresException as e:
                     status_code = 400
-                    data = "PostgreSQL version should be in the first.major.minor format"
+                    data = e.value
                     break
             elif k == 'timeout':
                 request[k] = parse_int(request[k], 's')

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -622,12 +622,15 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
     logging.debug(cluster)
     leader_name = None
     if cluster.leader:
-        leader_name = cluster.leader.member.name
+        leader_name = cluster.leader.name
 
     xlog_location_cluster = cluster.last_leader_operation or 0
 
     # Mainly for consistent pretty printing and watching we sort the output
     cluster.members.sort(key=lambda x: x.name)
+
+    extended = extended or any(m.data.get('scheduled_restart') for m in cluster.members)
+
     for m in cluster.members:
         logging.debug(m)
 
@@ -637,21 +640,13 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
         elif m.name == cluster.sync.sync_standby:
             role = 'Sync standby'
 
-        host = m.conn_kwargs()['host']
-
-        xlog_location = m.data.get('xlog_location') or 0
-        lag = ''
-        if xlog_location_cluster >= xlog_location:
+        xlog_location = m.data.get('xlog_location')
+        lag = 'unknown'
+        if xlog_location is not None and xlog_location_cluster >= xlog_location:
             lag = round((xlog_location_cluster - xlog_location)/1024/1024)
 
-        row = [
-            name,
-            m.name,
-            host,
-            role,
-            m.data.get('state', ''),
-            lag,
-        ]
+        row = [name, m.name, m.conn_kwargs()['host'], role, m.data.get('state', ''), lag]
+
         if extended:
             value = ''
             scheduled_restart = m.data.get('scheduled_restart')
@@ -664,14 +659,7 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
 
         rows.append(row)
 
-    columns = [
-        'Cluster',
-        'Member',
-        'Host',
-        'Role',
-        'State',
-        'Lag in MB',
-    ]
+    columns = ['Cluster', 'Member', 'Host', 'Role', 'State', 'Lag in MB']
     alignment = {'Cluster': 'l', 'Member': 'l', 'Host': 'l', 'Lag in MB': 'r'}
 
     if extended:
@@ -679,6 +667,21 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
         alignment['Scheduled restart'] = 'l'
 
     print_output(columns, rows, alignment, fmt)
+
+    service_info = []
+    if cluster.is_paused():
+        service_info.append('Maintenance mode: on')
+
+    if cluster.failover and cluster.failover.scheduled_at:
+        info = 'Failover scheduled at: ' + cluster.failover.scheduled_at.isoformat()
+        if cluster.failover.leader:
+            info += '\n                  from: ' + cluster.failover.leader
+        if cluster.failover.candidate:
+            info += '\n                    to: ' + cluster.failover.candidate
+        service_info.append(info)
+
+    if service_info:
+        click.echo(' ' + '\n '.join(service_info))
 
 
 @ctl.command('list', help='List the Patroni members for a given Patroni')

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -642,8 +642,10 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
             role = 'Sync standby'
 
         xlog_location = m.data.get('xlog_location')
-        lag = 'unknown'
-        if xlog_location is not None and xlog_location_cluster >= xlog_location:
+        lag = ''
+        if xlog_location is None:
+            lag = 'unknown'
+        elif xlog_location_cluster >= xlog_location:
             lag = round((xlog_location_cluster - xlog_location)/1024/1024)
 
         row = [name, m.name, m.conn_kwargs()['host'], role, m.data.get('state', ''), lag]

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -918,7 +918,8 @@ class Postgresql(object):
 
         return True, True
 
-    def terminate_starting_postmaster(self, postmaster):
+    @staticmethod
+    def terminate_starting_postmaster(postmaster):
         """Terminates a postmaster that has not yet opened ports or possibly even written a pid file. Blocks
         until the process goes away."""
         postmaster.signal_stop('immediate')

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -86,12 +86,12 @@ class Postgresql(object):
         'wal_level': ('hot_standby', lambda v: v.lower() in ('hot_standby', 'replica', 'logical'), 90100),
         'hot_standby': ('on', lambda _: False, 90100),
         'max_connections': (100, lambda v: int(v) >= 100, 90100),
-        'max_wal_senders': (5, lambda v: int(v) >= 5, 90100),
+        'max_wal_senders': (10, lambda v: int(v) >= 10, 90100),
         'wal_keep_segments': (8, lambda v: int(v) >= 8, 90100),
         'max_prepared_transactions': (0, lambda v: int(v) >= 0, 90100),
         'max_locks_per_transaction': (64, lambda v: int(v) >= 64, 90100),
         'track_commit_timestamp': ('off', lambda v: parse_bool(v) is not None, 90500),
-        'max_replication_slots': (5, lambda v: int(v) >= 5, 90400),
+        'max_replication_slots': (10, lambda v: int(v) >= 10, 90400),
         'max_worker_processes': (8, lambda v: int(v) >= 8, 90400),
         'wal_log_hints': ('on', lambda _: False, 90400)
     }

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1624,15 +1624,15 @@ $$""".format(name, ' '.join(options)), name, password, password)
         90313
         >>> Postgresql.postgres_version_to_int('10.1')
         100001
-        >>> Postgresql.postgres_version_to_int('10')
+        >>> Postgresql.postgres_version_to_int('10')  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
             ...
         PostgresException: 'Invalid PostgreSQL version format: X.Y or X.Y.Z is accepted: 10'
-        >>> Postgresql.postgres_version_to_int('9.6')
+        >>> Postgresql.postgres_version_to_int('9.6')  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
             ...
         PostgresException: 'Invalid PostgreSQL version format: X.Y or X.Y.Z is accepted: 9.6'
-        >>> Postgresql.postgres_version_to_int('a.b.c')
+        >>> Postgresql.postgres_version_to_int('a.b.c')  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
             ...
         PostgresException: 'Invalid PostgreSQL version: a.b.c'

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -12,7 +12,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from patroni.callback_executor import CallbackExecutor
-from patroni.exceptions import PostgresConnectionException
+from patroni.exceptions import PostgresConnectionException, PostgresException
 from patroni.utils import compare_values, parse_bool, parse_int, Retry, RetryFailedError, polling_loop
 from patroni.postmaster import PostmasterProcess
 from six import string_types
@@ -1616,7 +1616,7 @@ $$""".format(name, ' '.join(options)), name, password, password)
 
     @staticmethod
     def postgres_version_to_int(pg_version):
-        """ Convert the server_version to integer
+        """Convert the server_version to integer
 
         >>> Postgresql.postgres_version_to_int('9.5.3')
         90503
@@ -1627,26 +1627,31 @@ $$""".format(name, ' '.join(options)), name, password, password)
         >>> Postgresql.postgres_version_to_int('10')
         Traceback (most recent call last):
             ...
-        Exception: Invalid PostgreSQL format: X.Y or X.Y.Z is accepted: 10
+        PostgresException: 'Invalid PostgreSQL version format: X.Y or X.Y.Z is accepted: 10'
+        >>> Postgresql.postgres_version_to_int('9.6')
+        Traceback (most recent call last):
+            ...
+        PostgresException: 'Invalid PostgreSQL version format: X.Y or X.Y.Z is accepted: 9.6'
         >>> Postgresql.postgres_version_to_int('a.b.c')
         Traceback (most recent call last):
             ...
-        Exception: Invalid PostgreSQL version: a.b.c
+        PostgresException: 'Invalid PostgreSQL version: a.b.c'
         """
-        components = pg_version.split('.')
 
-        result = []
-        if len(components) < 2 or len(components) > 3:
-            raise Exception("Invalid PostgreSQL format: X.Y or X.Y.Z is accepted: {0}".format(pg_version))
+        try:
+            components = list(map(int, pg_version.split('.')))
+        except ValueError:
+            raise PostgresException('Invalid PostgreSQL version: {0}'.format(pg_version))
+
+        if len(components) < 2 or len(components) == 2 and components[0] < 10 or len(components) > 3:
+            raise PostgresException('Invalid PostgreSQL version format: X.Y or X.Y.Z is accepted: {0}'
+                                    .format(pg_version))
+
         if len(components) == 2:
             # new style verion numbers, i.e. 10.1 becomes 100001
-            components.insert(1, '0')
-        try:
-            result = [c if int(c) > 10 else '0{0}'.format(c) for c in components]
-            result = int(''.join(result))
-        except ValueError:
-            raise Exception("Invalid PostgreSQL version: {0}".format(pg_version))
-        return result
+            components.insert(1, 0)
+
+        return int(''.join('{0:02d}'.format(c) for c in components))
 
     @staticmethod
     def postgres_major_version_to_int(pg_version):

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -1,6 +1,5 @@
 import random
 import time
-import re
 
 from dateutil import tz
 from patroni.exceptions import PatroniException
@@ -192,10 +191,6 @@ def compare_values(vartype, unit, old_value, new_value):
 
 def _sleep(interval):
     time.sleep(interval)
-
-
-def is_valid_pg_version(version):
-    return re.match(r'[1-9][0-9]?(\.(0|([1-9][0-9]?))){1,2}$', version)
 
 
 class RetryFailedError(PatroniException):

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -195,7 +195,7 @@ def _sleep(interval):
 
 
 def is_valid_pg_version(version):
-    return re.match(r'[1-9][0-9]?(\.(0|([1-9][0-9]?))){2}$', version)
+    return re.match(r'[1-9][0-9]?(\.(0|([1-9][0-9]?))){1,2}$', version)
 
 
 class RetryFailedError(PatroniException):

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -237,8 +237,8 @@ class TestCtl(unittest.TestCase):
         assert result.exit_code == 1
 
         # Wrong pg version
-        result = self.runner.invoke(ctl, ['restart', 'alpha', '--any', '--pg-version', '9.1.2.3'], input='y')
-        assert 'Error: PostgreSQL version' in result.output
+        result = self.runner.invoke(ctl, ['restart', 'alpha', '--any', '--pg-version', '9.1'], input='y')
+        assert 'Error: Invalid PostgreSQL version format' in result.output
         assert result.exit_code == 1
 
         result = self.runner.invoke(ctl, ['restart', 'alpha', '--pending', '--force', '--timeout', '10min'])

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,8 +1,6 @@
-import errno
 import mock  # for the mock.call method, importing it without a namespace breaks python3
 import os
 import psycopg2
-import psutil
 import shutil
 import subprocess
 import unittest
@@ -104,6 +102,7 @@ class MockPostmaster(object):
         self.wait_for_user_backends_to_close = Mock()
         self.signal_stop = Mock(return_value=None)
         self.wait = Mock()
+
 
 def pg_controldata_string(*args, **kwargs):
     return b"""

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -63,7 +63,7 @@ class TestPostmasterProcess(unittest.TestCase):
         c2.cmdline = Mock(return_value=["postgres: postgres postgres [local] idle"])
         with patch('psutil.Process.children', Mock(return_value=[c1, c2])):
             proc = PostmasterProcess(123)
-            proc.wait_for_user_backends_to_close()
+            self.assertIsNone(proc.wait_for_user_backends_to_close())
             mock_wait.assert_called_with([c2])
 
     @patch('subprocess.Popen')

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -4,6 +4,7 @@ from mock import Mock, patch
 from patroni.postmaster import PostmasterProcess
 import psutil
 
+
 class TestPostmasterProcess(unittest.TestCase):
     @patch('psutil.Process.__init__', Mock())
     def test_init(self):
@@ -20,9 +21,9 @@ class TestPostmasterProcess(unittest.TestCase):
 
         mock_init.side_effect = None
         with patch.object(psutil.Process, 'pid', 123), \
-             patch.object(psutil.Process, 'parent', return_value=124), \
-             patch('os.getpid', return_value=125) as mock_ospid, \
-             patch('os.getppid', return_value=126):
+                patch.object(psutil.Process, 'parent', return_value=124), \
+                patch('os.getpid', return_value=125) as mock_ospid, \
+                patch('os.getppid', return_value=126):
 
             self.assertNotEquals(PostmasterProcess.from_pidfile({"pid": "123"}), None)
 


### PR DESCRIPTION
 Show information about scheduled failover and maintenance mode when showing list of cluster members.

Fixes https://github.com/zalando/patroni/issues/557

In addition to that fix postgres version check regexp and apply pep8 formatting to the tests.