### PR TITLE
More improvements in patronictl

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -152,12 +152,12 @@ def print_output(columns, rows=None, alignment=None, fmt='pretty', header=True, 
         click.echo(t)
         return
 
-    if fmt in ['json', 'yaml']:
+    if fmt in ['json', 'yaml', 'yml']:
         elements = [dict(zip(columns, r)) for r in rows]
         if fmt == 'json':
             click.echo(json.dumps(elements))
-        elif fmt == 'yaml':
-            click.echo(yaml.safe_dump(elements, encoding=None, allow_unicode=True, width=200))
+        elif fmt in ('yaml', 'yml'):
+            click.echo(yaml.safe_dump(elements, encoding=None, default_flow_style=False, allow_unicode=True, width=200))
 
     if fmt == 'tsv':
         if columns is not None and header:
@@ -704,12 +704,12 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
 @ctl.command('list', help='List the Patroni members for a given Patroni')
 @click.argument('cluster_names', nargs=-1)
 @click.option('--extended', '-e', help='Show some extra information', is_flag=True)
-@click.option('--timestamp', '-t', help='Print timestamp', is_flag=True)
+@click.option('--timestamp', '-t', 'ts', help='Print timestamp', is_flag=True)
 @option_format
 @option_watch
 @option_watchrefresh
 @click.pass_obj
-def members(obj, cluster_names, fmt, watch, w, extended, timestamp):
+def members(obj, cluster_names, fmt, watch, w, extended, ts):
     if not cluster_names:
         if 'scope' in obj:
             cluster_names = [obj['scope']]
@@ -720,8 +720,8 @@ def members(obj, cluster_names, fmt, watch, w, extended, timestamp):
         dcs = get_dcs(obj, cluster_name)
 
         for _ in watching(w, watch):
-            if timestamp:
-                click.echo(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+            if ts:
+                click.echo(timestamp(0))
 
             cluster = dcs.get_cluster()
             output_members(cluster, cluster_name, extended, fmt)

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -7,7 +7,7 @@ import unittest
 from click.testing import CliRunner
 from datetime import datetime, timedelta
 from mock import patch, Mock
-from patroni.ctl import ctl, members, store_config, load_config, output_members, request_patroni, get_dcs, parse_dcs, \
+from patroni.ctl import ctl, store_config, load_config, output_members, request_patroni, get_dcs, parse_dcs, \
     get_all_members, get_any_member, get_cursor, query_member, configure, PatroniCtlException, apply_config_changes, \
     format_config_for_editing, show_diff, invoke_editor, format_pg_version
 from patroni.dcs.etcd import Client, Failover
@@ -33,7 +33,7 @@ def test_rw_config():
 
 
 @patch('patroni.ctl.load_config',
-       Mock(return_value={'postgresql': {'data_dir': '.', 'parameters': {}, 'retry_timeout': 5},
+       Mock(return_value={'scope': 'alpha', 'postgresql': {'data_dir': '.', 'parameters': {}, 'retry_timeout': 5},
                           'restapi': {'auth': 'u:p', 'listen': ''}, 'etcd': {'host': 'localhost:2379'}}))
 class TestCtl(unittest.TestCase):
 
@@ -346,9 +346,11 @@ class TestCtl(unittest.TestCase):
     @patch('patroni.ctl.get_dcs')
     def test_members(self, mock_get_dcs):
         mock_get_dcs.return_value.get_cluster = get_cluster_initialized_with_leader
-        result = self.runner.invoke(members, ['alpha'])
+        result = self.runner.invoke(ctl, ['list'])
         assert '127.0.0.1' in result.output
         assert result.exit_code == 0
+        with patch('patroni.ctl.load_config', Mock(return_value={})):
+            self.runner.invoke(ctl, ['list'])
 
     def test_configure(self):
         result = self.runner.invoke(configure, ['--dcs', 'abc', '-c', 'dummy', '-n', 'bla'])

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -861,6 +861,7 @@ class TestHa(unittest.TestCase):
 
     def test_shutdown(self):
         self.p.is_running = false
+        self.ha.has_lock = true
         self.ha.shutdown()
 
     @patch('time.sleep', Mock())


### PR DESCRIPTION
Make specifying cluster_name optional for some more commands.
If it is not specified, it's value would be taken from config file.