### PR TITLE
Expose pause state of every member to DCS and via REST

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -70,6 +70,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
             response['scheduled_restart']['schedule'] = (response['scheduled_restart']['schedule']).isoformat()
         if not patroni.ha.watchdog.is_healthy:
             response['watchdog_failed'] = True
+        if patroni.ha.is_paused():
+            response['pause'] = True
         self._write_json_response(status_code, response)
 
     def do_GET(self, write_status_code_only=False):

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -133,6 +133,9 @@ class Ha(object):
                 scheduled_restart_data['schedule'] = scheduled_restart_data['schedule'].isoformat()
                 data['scheduled_restart'] = scheduled_restart_data
 
+            if self.is_paused():
+                data['pause'] = True
+
             return self.dcs.touch_member(data)
 
     def clone(self, clone_member=None, msg='(without leader)'):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,6 +83,10 @@ class MockHa(object):
     def wakeup():
         pass
 
+    @staticmethod
+    def is_paused():
+        return True
+
 
 class MockPatroni(object):
 

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -39,6 +39,7 @@ def get_cluster_initialized_without_leader(leader=False, failover=None, sync=Non
     m2 = Member(0, 'other', 28, {'conn_url': 'postgres://replicator:rep-pass@127.0.0.1:5436/postgres',
                                  'api_url': 'http://127.0.0.1:8011/patroni',
                                  'state': 'running',
+                                 'pause': True,
                                  'tags': {'clonefrom': True},
                                  'scheduled_restart': {'schedule': "2100-01-01 10:53:07.560445+00:00",
                                                        'postgres_version': '99.0.0'}})


### PR DESCRIPTION
and implement patronictl pause|resume --wait on top of that

Fixes https://github.com/zalando/patroni/issues/349