### PR TITLE
Change the pip definition in Dockerfile to use master now

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -12,7 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
 
     && pip install setuptools pip --upgrade \
-    && pip install 'git+https://github.com/zalando/patroni.git@feature/k8s#egg=patroni[kubernetes]' \
+    && pip install 'git+https://github.com/zalando/patroni.git#egg=patroni[kubernetes]' \
 
     && mkdir -p /home/postgres \
     && chown postgres:postgres /home/postgres \


### PR DESCRIPTION
I've noticed that while building the docker image for patroni we're pointing to the feature/k8s branch still, which prevents from using the fixes that land in master, like https://github.com/zalando/patroni/pull/611 

@jberkus fyi