### PR TITLE
Make log level configurable from environment variables

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -11,6 +11,8 @@ Global/Universal
 -  **PATRONI\_NAME**: name of the node where the current instance of Patroni is running. Must be unique for the cluster.
 -  **PATRONI\_NAMESPACE**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service"
 -  **PATRONI\_SCOPE**: cluster name
+-  **PATRONI\_LOGLEVEL**: sets the general logging level (see `the docs for Python logging <https://docs.python.org/3.6/library/logging.html#levels>`_)
+-  **PATRONI\_REQUESTS_LOGLEVEL**: sets the logging level for all HTTP requests e.g. Kubernetes API calls (see `the docs for Python logging <https://docs.python.org/3.6/library/logging.html#levels>`_)
 
 Bootstrap configuration
 -----------------------

--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -135,8 +135,10 @@ class Patroni(object):
 
 def patroni_main():
     logformat = os.environ.get('PATRONI_LOGFORMAT', '%(asctime)s %(levelname)s: %(message)s')
-    logging.basicConfig(format=logformat, level=logging.INFO)
-    logging.getLogger('requests').setLevel(logging.WARNING)
+    loglevel = os.environ.get('PATRONI_LOGLEVEL', 'INFO')
+    requests_loglevel = os.environ.get('PATRONI_REQUESTS_LOGLEVEL', 'WARNING')
+    logging.basicConfig(format=logformat, level=logging.getLevelName(loglevel))
+    logging.getLogger('requests').setLevel(logging.getLevelName(requests_loglevel))
 
     patroni = Patroni()
     try:


### PR DESCRIPTION
Found this helpful when debugging some kubernetes issues - lets you turn up the logging levels on Patroni itself and the requests library.