### PR TITLE
Don't rediscover etcd cluster topology when watch timed out

### DIFF
--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -210,8 +210,11 @@ class Client(etcd.Client):
                 self._machines_cache = self.machines
                 if self._base_uri in self._machines_cache:
                     self._machines_cache.remove(self._base_uri)
-        except etcd.EtcdConnectionFailed:
-            self._update_machines_cache = True
+        except etcd.EtcdConnectionFailed as e:
+            if isinstance(e, etcd.EtcdWatchTimedOut) and self._machines_cache:
+                self._base_uri = self._next_server()
+            else:
+                self._update_machines_cache = True
             if not response:
                 raise
         return self._handle_server_response(response)

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -207,6 +207,7 @@ class TestClient(unittest.TestCase):
         mock_machines.__get__ = Mock(return_value=['http://localhost:2379'])
         self.client._machines_cache_updated = 0
         self.client.api_execute('/', 'POST', timeout=0)
+        self.client._machines_cache = [self.client._base_uri]
         self.assertRaises(etcd.EtcdWatchTimedOut, self.client.api_execute, '/timeout', 'POST', params={'wait': 'true'})
         self.assertRaises(etcd.EtcdException, self.client.api_execute, '/', '')
         self.client._update_machines_cache = True


### PR DESCRIPTION
but switch to the next node if it is possible.

Fixes https://github.com/zalando/patroni/issues/628