### PR TITLE
Make deleting recovery.conf optional.

### DIFF
--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -48,8 +48,8 @@ If a ``recovery_conf`` block is defined in the same section as the custom bootst
 ``recovery.conf`` before starting the newly bootstrapped instance. Typically, such recovery.conf should contain at least
 one of the ``recovery_target_*`` parameters, together with the ``recovery_target_timeline`` set to ``promote``.
 
-If ``keep_existing_recovery_conf`` is defined and set to ``True``, Patroni will not remove the existing recovery.conf file if it exists.
-This is useful when bootstrap from a backup with tools like pgBackRest that generate the appropriate recovery.conf for you.
+If ``keep_existing_recovery_conf`` is defined and set to ``True``, Patroni will not remove the existing ``recovery.conf`` file if it exists.
+This is useful when bootstrapping from a backup with tools like pgBackRest that generate the appropriate ``recovery.conf`` ``for you.
 
  .. note:: Bootstrap methods are neither chained, nor fallen-back to the default one in case the primary one fails
 

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -23,6 +23,7 @@ arguments to them, i.e. the name of the cluster and the path to the data directo
         method: <custom_bootstrap_method_name>
         <custom_bootstrap_method_name>:
             command: <path_to_custom_bootstrap_script> [param1 [, ...]]
+            keep_existing_recovery_conf: False
             recovery_conf:
                 recovery_target_action: promote
                 recovery_target_timeline: latest
@@ -46,6 +47,9 @@ cleans up after itself and releases the initialize lock to give another node the
 If a ``recovery_conf`` block is defined in the same section as the custom bootstrap method, Patroni will generate a
 ``recovery.conf`` before starting the newly bootstrapped instance. Typically, such recovery.conf should contain at least
 one of the ``recovery_target_*`` parameters, together with the ``recovery_target_timeline`` set to ``promote``.
+
+If ``keep_existing_recovery_conf`` is defined and set to ``True``, Patroni will not remove the existing recovery.conf file if it exists.
+This is useful when bootstrap from a backup with tools like pgBackRest that generate the appropriate recovery.conf for you.
 
  .. note:: Bootstrap methods are neither chained, nor fallen-back to the default one in case the primary one fails
 

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -49,7 +49,7 @@ If a ``recovery_conf`` block is defined in the same section as the custom bootst
 one of the ``recovery_target_*`` parameters, together with the ``recovery_target_timeline`` set to ``promote``.
 
 If ``keep_existing_recovery_conf`` is defined and set to ``True``, Patroni will not remove the existing ``recovery.conf`` file if it exists.
-This is useful when bootstrapping from a backup with tools like pgBackRest that generate the appropriate ``recovery.conf`` ``for you.
+This is useful when bootstrapping from a backup with tools like pgBackRest that generate the appropriate ``recovery.conf`` for you.
 
  .. note:: Bootstrap methods are neither chained, nor fallen-back to the default one in case the primary one fails
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -545,10 +545,6 @@ class Postgresql(object):
         self.set_state('running custom bootstrap script')
         params = ['--scope=' + self.scope, '--datadir=' + self._data_dir]
         try:
-            keep_existing_recovery_conf = config['keep_existing_recovery_conf']
-        except KeyError:
-            keep_existing_recovery_conf = False
-        try:
             logger.info('Running custom bootstrap script: %s', config['command'])
             if self.cancellable_subprocess_call(shlex.split(config['command']) + params) != 0:
                 self.set_state('custom bootstrap failed')
@@ -560,9 +556,9 @@ class Postgresql(object):
 
         if 'recovery_conf' in config:
             self.write_recovery_conf(config['recovery_conf'])
-        elif os.path.isfile(self._recovery_conf) or os.path.islink(self._recovery_conf):
-            if not keep_existing_recovery_conf:
-                os.unlink(self._recovery_conf)
+        elif (os.path.isfile(self._recovery_conf) or os.path.islink(self._recovery_conf)) and \
+                not config.get('keep_existing_recovery_conf'):
+            os.unlink(self._recovery_conf)
         return True
 
     def run_bootstrap_post_init(self, config):

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -545,6 +545,10 @@ class Postgresql(object):
         self.set_state('running custom bootstrap script')
         params = ['--scope=' + self.scope, '--datadir=' + self._data_dir]
         try:
+            keep_existing_recovery_conf = config['keep_existing_recovery_conf']
+        except KeyError:
+            keep_existing_recovery_conf = False
+        try:
             logger.info('Running custom bootstrap script: %s', config['command'])
             if self.cancellable_subprocess_call(shlex.split(config['command']) + params) != 0:
                 self.set_state('custom bootstrap failed')
@@ -556,7 +560,7 @@ class Postgresql(object):
 
         if 'recovery_conf' in config:
             self.write_recovery_conf(config['recovery_conf'])
-        elif os.path.isfile(self._recovery_conf) or os.path.islink(self._recovery_conf):
+        elif (os.path.isfile(self._recovery_conf) or os.path.islink(self._recovery_conf)) and not keep_existing_recovery_conf:
             os.unlink(self._recovery_conf)
         return True
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -560,8 +560,9 @@ class Postgresql(object):
 
         if 'recovery_conf' in config:
             self.write_recovery_conf(config['recovery_conf'])
-        elif (os.path.isfile(self._recovery_conf) or os.path.islink(self._recovery_conf)) and not keep_existing_recovery_conf:
-            os.unlink(self._recovery_conf)
+        elif os.path.isfile(self._recovery_conf) or os.path.islink(self._recovery_conf):
+            if not keep_existing_recovery_conf:
+                os.unlink(self._recovery_conf)
         return True
 
     def run_bootstrap_post_init(self, config):


### PR DESCRIPTION
https://github.com/zalando/patroni/issues/637

pgBackRest's restore command generates the appropriate recovery.conf based
on the parameters you provide to pgBackRest.  When calling pgBackRest's restore command
via Patroni's custom bootstrap, it deletes that recovery.conf.  Specifying the recovery.conf
information in the patroni.yml is less than ideal.  It prevent's leveraging pgBackRests
work to ensure recovery.conf files are properly generated.  It also can lead to transient
config data in the patroni.yml under certain restore cases, such as a PITR restore
of Cluster B to  Cluster A, where the restore_commnand in A needs to reference B.

The parameter is optional.  The default behavior is to delete the recovery.conf.