### PR TITLE
Pass dict object to touch_member instead of json encoded string

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -786,7 +786,7 @@ def touch_member(config, dcs):
         'role': p.role
     }
 
-    return dcs.touch_member(json.dumps(data, separators=(',', ':')), permanent=True)
+    return dcs.touch_member(data, permanent=True)
 
 
 def set_defaults(config, cluster_name):


### PR DESCRIPTION
DCS implementation will take care about encoding it.
Fixes https://github.com/zalando/patroni/issues/642