### PR TITLE
Kubernets DCS leader subsets return None instead of EmptyList

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -161,7 +161,7 @@ class Kubernetes(AbstractDCS):
             leader = nodes.get(self.leader_path)
             metadata = leader and leader.metadata
             self._leader_resource_version = metadata.resource_version if metadata else None
-            self._leader_observed_subsets = leader.subsets if self.__subsets and leader else []
+            self._leader_observed_subsets = leader.subsets if self.__subsets and leader and leader.subsets else []
             annotations = metadata and metadata.annotations or {}
 
             # get last leader operation


### PR DESCRIPTION
On Kubernetes 1.10.0 I experienced an issue where calls to `patch_or_create` were failing when bootstraping a cluster. The call was failing because `self._leader_observed_subsets` was `None` instead of `[]`.

I traced this issued to the `nodes.get(self.leader_path)` call in `_load_cluster()`. The leader object that is returned is:

```python
{'api_version': None,
 'kind': None,
 'metadata': {'annotations': None,
              'cluster_name': None,
              'creation_timestamp': datetime.datetime(2018, 4, 25, 21, 24, 57, tzinfo=tzlocal()),
              'deletion_grace_period_seconds': None,
              'deletion_timestamp': None,
              'finalizers': None,
              'generate_name': None,
              'generation': None,
              'initializers': None,
              'labels': {'app': 'test-app',
                         'cluster-name': 'test-db',
                         'component': 'postgres',
                         'heritage': 'Tiller',
                         'release': 'test'},
              'name': 'test-db',
              'namespace': 'default',
              'owner_references': None,
              'resource_version': '11689',
              'self_link': '/api/v1/namespaces/default/endpoints/test-db',
              'uid': '1a710b93-48cf-11e8-b7f9-468ada70ed14'},
 'subsets': None}
```

Since `subsets` is `None`, `self._leader_observed_subets` gets set to `None` instead of `[]`.

This PR adds an additional check for `leader.subsets`.

I found a couple related issues for the Kubernetes python client:

https://github.com/kubernetes-client/python/issues/376
https://github.com/kubernetes-client/python/issues/463

Also, you'll probably notice that the Kind is none in the response as well. That may possibly be related to: https://github.com/kubernetes-client/python/issues/429