### PR TITLE
BUGFIX: postmaster start can fail if pid from postmaster.pid is alive

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -141,7 +141,6 @@ class Postgresql(object):
         self._postgresql_base_conf = os.path.join(self._config_dir, self._postgresql_base_conf_name)
         self._pg_hba_conf = os.path.join(self._config_dir, 'pg_hba.conf')
         self._recovery_conf = os.path.join(self._data_dir, 'recovery.conf')
-        self._postmaster_pid = os.path.join(self._data_dir, 'postmaster.pid')
         self._trigger_file = config.get('recovery_conf', {}).get('trigger_file') or 'promote'
         self._trigger_file = os.path.abspath(os.path.join(self._data_dir, self._trigger_file))
 
@@ -732,20 +731,8 @@ class Postgresql(object):
                 return self._postmaster_proc
             self._postmaster_proc = None
 
-        self._postmaster_proc = PostmasterProcess.from_pidfile(self._read_pid_file())
+        self._postmaster_proc = PostmasterProcess.from_pidfile(self._data_dir)
         return self._postmaster_proc
-
-    def _read_pid_file(self):
-        """Reads and parses postmaster.pid from the data directory
-
-        :returns dictionary of values if successful, empty dictionary otherwise
-        """
-        pid_line_names = ['pid', 'data_dir', 'start_time', 'port', 'socket_dir', 'listen_addr', 'shmem_key']
-        try:
-            with open(self._postmaster_pid) as f:
-                return {name: line.rstrip("\n") for name, line in zip(pid_line_names, f)}
-        except IOError:
-            return {}
 
     @property
     def cb_called(self):

--- a/patroni/postmaster.py
+++ b/patroni/postmaster.py
@@ -17,6 +17,7 @@ STOP_SIGNALS = {
 
 
 class PostmasterProcess(psutil.Process):
+
     def __init__(self, pid):
         self.is_single_user = False
         if pid < 0:
@@ -24,32 +25,55 @@ class PostmasterProcess(psutil.Process):
             self.is_single_user = True
         super(PostmasterProcess, self).__init__(pid)
 
-    @classmethod
-    def from_pidfile(cls, pidfile):
-        try:
-            pid = int(pidfile.get('pid', 0))
-            if not pid:
-                return None
-        except ValueError:
-            return None
+    @staticmethod
+    def _read_postmaster_pidfile(data_dir):
+        """Reads and parses postmaster.pid from the data directory
 
+        :returns dictionary of values if successful, empty dictionary otherwise
+        """
+        pid_line_names = ['pid', 'data_dir', 'start_time', 'port', 'socket_dir', 'listen_addr', 'shmem_key']
         try:
-            proc = cls(pid)
-        except psutil.NoSuchProcess:
-            return None
+            with open(os.path.join(data_dir, 'postmaster.pid')) as f:
+                return {name: line.rstrip('\n') for name, line in zip(pid_line_names, f)}
+        except IOError:
+            return {}
 
+    def _is_postmaster_process(self):
         try:
-            start_time = int(pidfile.get('start_time', 0))
-            if start_time and abs(proc.create_time() - start_time) > 3:
-                return None
+            start_time = int(self._postmaster_pid.get('start_time', 0))
+            if start_time and abs(self.create_time() - start_time) > 3:
+                logger.info('Too much difference between %s and %s', self.create_time(), start_time)
+                return False
         except ValueError:
-            logger.warning("Garbage start time value in pid file: %r", pidfile.get('start_time'))
+            logger.warning('Garbage start time value in pid file: %r', self._postmaster_pid.get('start_time'))
 
         # Extra safety check. The process can't be ourselves, our parent or our direct child.
-        if proc.pid == os.getpid() or proc.pid == os.getppid() or proc.parent() == os.getpid():
-            return None
+        if self.pid == os.getpid() or self.pid == os.getppid() or self.ppid() == os.getpid():
+            logger.info('Patroni (pid=%s, ppid=%s), "fake postmaster" (pid=%s, ppid=%s)',
+                        os.getpid(), os.getppid(), self.pid, self.ppid())
+            return False
 
-        return proc
+        return True
+
+    @classmethod
+    def _from_pidfile(cls, data_dir):
+        postmaster_pid = PostmasterProcess._read_postmaster_pidfile(data_dir)
+        try:
+            pid = int(postmaster_pid.get('pid', 0))
+            if pid:
+                proc = cls(pid)
+                proc._postmaster_pid = postmaster_pid
+                return proc
+        except ValueError:
+            pass
+
+    @staticmethod
+    def from_pidfile(data_dir):
+        try:
+            proc = PostmasterProcess._from_pidfile(data_dir)
+            return proc if proc and proc._is_postmaster_process() else None
+        except psutil.NoSuchProcess:
+            return None
 
     @classmethod
     def from_pid(cls, pid):
@@ -100,8 +124,8 @@ class PostmasterProcess(psutil.Process):
         except psutil.Error:
             logger.exception('wait_for_user_backends_to_close')
 
-    @classmethod
-    def start(cls, pgcommand, data_dir, conf, options):
+    @staticmethod
+    def start(pgcommand, data_dir, conf, options):
         # Unfortunately `pg_ctl start` does not return postmaster pid to us. Without this information
         # it is hard to know the current state of postgres startup, so we had to reimplement pg_ctl start
         # in python. It will start postgres, wait for port to be open and wait until postgres will start
@@ -113,10 +137,24 @@ class PostmasterProcess(psutil.Process):
         # of init process to take care about postmaster.
         # In order to make everything portable we can't use fork&exec approach here, so  we will call
         # ourselves and pass list of arguments which must be used to start postgres.
+        env = {p: os.environ[p] for p in ('PATH', 'LC_ALL', 'LANG') if p in os.environ}
+        try:
+            proc = PostmasterProcess._from_pidfile(data_dir)
+            if proc and not proc._is_postmaster_process():
+                # Upon start postmaster process performs various safety checks if there is a postmaster.pid
+                # file in the data directory. Although Patroni already detected that the running process
+                # corresponding to the postmaster.pid is not a postmaster, the new postmaster might fail
+                # to start, because it thinks that postmaster.pid is already locked.
+                # Important!!! Unlink of postmaster.pid isn't an option, because it has a lot of nasty race conditions.
+                # Luckily there is a workaround to this problem, we can pass the pid from postmaster.pid
+                # in the `PG_GRANDPARENT_PID` environment variable and postmaster will ignore it.
+                env['PG_GRANDPARENT_PID'] = str(proc.pid)
+        except psutil.NoSuchProcess:
+            pass
+
         proc = call_self(['pg_ctl_start', pgcommand, '-D', data_dir,
                           '--config-file={}'.format(conf)] + options, close_fds=True,
-                         preexec_fn=os.setsid, stdout=subprocess.PIPE,
-                         env={p: os.environ[p] for p in ('PATH', 'LC_ALL', 'LANG') if p in os.environ})
+                         preexec_fn=os.setsid, stdout=subprocess.PIPE, env=env)
         pid = int(proc.stdout.readline().strip())
         proc.wait()
         logger.info('postmaster pid=%s', pid)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -808,16 +808,6 @@ class TestPostgresql(unittest.TestCase):
             self.p._state = 'starting'
             self.assertIsNone(self.p.wait_for_startup())
 
-    def test_read_pid_file(self):
-        pidfile = os.path.join(self.data_dir, 'postmaster.pid')
-        if os.path.exists(pidfile):
-            os.remove(pidfile)
-        self.assertEquals(self.p._read_pid_file(), {})
-        with open(pidfile, 'w') as fd:
-            fd.write("123\n/foo/bar\n123456789\n5432")
-        self.assertEquals(self.p._read_pid_file(), {"pid": "123", "data_dir": "/foo/bar",
-                                                    "start_time": "123456789", "port": "5432"})
-
     def test_pick_sync_standby(self):
         cluster = Cluster(True, None, self.leader, 0, [self.me, self.other, self.leadermem], None,
                           SyncState(0, self.me.name, self.leadermem.name), None)


### PR DESCRIPTION
Upon start postmaster process performs various safety checks if there is a postmaster.pid file in the data directory. Although Patroni already detected that the running process corresponding to the postmaster.pid is not a postmaster, the new postmaster might fail to start, because it thinks that postmaster.pid is already locked.
Important!!! Unlink of postmaster.pid isn't an option in this case, because it has a lot of nasty race conditions.
Luckily there is a workaround to this problem, we can pass the pid from postmaster.pid in the `PG_GRANDPARENT_PID` environment variable and postmaster will ignore it.

More likely to hit such problem if you run Patroni and postgres in the docker container.