### PR TITLE
Add WorkingDirectory to systemd sample config.

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -11,6 +11,8 @@ Type=simple
 User=postgres
 Group=postgres
 
+WorkingDirectory=~
+
 # Where to send early-startup messages from the server
 # This is normally controlled by the global default set by systemd
 # StandardOutput=syslog


### PR DESCRIPTION
Otherwise `initdb` fails because it tries to create the data directory
in the root directory where the postgres user has no permissions.