### PR TITLE
Relax kubernetes module version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ tzlocal
 python-dateutil
 psutil
 cdiff
-kubernetes==3.0.0
+kubernetes>=2.0.0,<=6.0.0,!=4.0.*,!=5.0.*


### PR DESCRIPTION
Patroni is proven to work with 2.0.0, 3.0.0 and 6.0.0