### PR TITLE
Take and apply some parameters from controldata when starting as replica

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -612,6 +612,13 @@ class PatroniPoolController(object):
                 'method': 'pg_basebackup',
                 'pg_basebackup': {
                     'command': self.BACKUP_SCRIPT + ' --walmethod=stream --dbname=' + f.backup_source
+                },
+                'dcs': {
+                    'postgresql': {
+                        'parameters': {
+                            'max_connections': 101
+                        }
+                    }
                 }
             },
             'postgresql': {

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -819,6 +819,15 @@ class Postgresql(object):
         return False
 
     def _build_effective_configuration(self):
+        """It might happen that the current value of one (or more) below parameters stored in
+        the controldata is higher than the value stored in the global cluster configuration.
+
+        Example: max_connections in global configuration is 100, but in controldata
+        `Current max_connections setting: 200`. If we try to start postgres with
+        max_connections=100, it will immediately exit.
+        As a workaround we will start it with the values from controldata and set `pending_restart`
+        to true as an indicator that current values of parameters are not matching expectations."""
+
         OPTIONS_MAPPING = {
             'max_connections': 'max_connections setting',
             'max_worker_processes': 'max_worker_processes setting',


### PR DESCRIPTION
https://www.postgresql.org/docs/10/static/hot-standby.html#HOT-STANDBY-ADMIN
There is set of parameters which value on the replica must be not smaller than on the primary, otherwise replica will refuse to start:
* max_connections
* max_prepared_transactions
* max_locks_per_transaction
* max_worker_processes

It might happen that values of these parameters in the global configuration are not set high enough, what makes impossible to start a replica without human intervention. Usually it happens when we bootstrap a new cluster from the basebackup.

As a solution to this problem we will take values of above parameters from the pg_controldata output and in case if the values in the global configuration are not high enough, apply values taken from pg_controldata and set `pending_restart` flag.