### PR TITLE
Do crash recovery only when we sure that postgres was running as master

### DIFF
--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -15,8 +15,8 @@ from patroni.utils import tzutc
 from test_etcd import socket_getaddrinfo, etcd_read, etcd_write, requests_get
 from test_postgresql import psycopg2_connect, MockPostmaster
 
-
 SYSID = '12345678901'
+
 
 def true(*args, **kwargs):
     return True
@@ -206,15 +206,6 @@ class TestHa(unittest.TestCase):
         self.p.is_running = false
         self.ha.cluster = get_cluster_initialized_with_leader()
         self.assertEquals(self.ha.run_cycle(), 'running pg_rewind from leader')
-
-    @patch.object(Postgresql, 'can_rewind', PropertyMock(return_value=True))
-    @patch.object(Postgresql, 'fix_cluster_state', Mock())
-    def test_single_user_after_recover_failed(self):
-        self.p.controldata = lambda: {'Database cluster state': 'in recovery', 'Database system identifier': SYSID}
-        self.p.is_running = false
-        self.p.follow = false
-        self.assertEquals(self.ha.run_cycle(), 'starting as a secondary')
-        self.assertEquals(self.ha.run_cycle(), 'fixing cluster state in a single user mode')
 
     @patch('sys.exit', return_value=1)
     @patch('patroni.ha.Ha.sysid_valid', MagicMock(return_value=True))


### PR DESCRIPTION
pg_controldata reports in this case:
* 'in production'
* 'shutting down'
* 'in crash recovery'