### PR TITLE
Respond 200 to master health-check only if update_lock was successful

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -92,7 +92,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             return response.get('role') == 'replica' and not patroni.noloadbalance
 
         if cluster:  # dcs available
-            if cluster.leader and cluster.leader.name == patroni.postgresql.name:  # is_leader
+            if patroni.ha.is_leader():
                 status_code = 200 if 'master' in path else 503
             elif 'role' not in response:
                 status_code = 503

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1161,8 +1161,7 @@ class Ha(object):
             return 'Error communicating with PostgreSQL. Will try again later'
         finally:
             if not dcs_failed:
-                if not self.touch_member() and not self.is_leader():
-                    self.dcs.reset_cluster()
+                self.touch_member()
 
     def run_cycle(self):
         with self._async_executor:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,6 +52,10 @@ class MockHa(object):
     watchdog = MockWatchdog()
 
     @staticmethod
+    def is_leader():
+        return False
+
+    @staticmethod
     def reinitialize(_):
         return 'reinitialize'
 
@@ -152,7 +156,7 @@ class TestRestApiHandler(unittest.TestCase):
             MockRestApiServer(RestApiHandler, 'GET /synchronous')
         with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'role': 'replica'})):
             MockRestApiServer(RestApiHandler, 'GET /asynchronous')
-        MockPatroni.dcs.cluster.leader.name = MockPostgresql.name
+        MockPatroni.ha.is_leader = Mock(return_value=True)
         MockRestApiServer(RestApiHandler, 'GET /replica')
         MockPatroni.dcs.cluster = None
         with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'role': 'master'})):

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -103,6 +103,7 @@ class TestPatroni(unittest.TestCase):
 
     @patch('patroni.config.Config.save_cache', Mock())
     @patch('patroni.config.Config.reload_local_configuration', Mock(return_value=True))
+    @patch('patroni.ha.Ha.is_leader', Mock(return_value=True))
     @patch.object(Postgresql, 'state', PropertyMock(return_value='running'))
     @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=False))
     def test_run(self):


### PR DESCRIPTION
If Patroni gets partitioned it starts receiving stale information from DCS.
We can't use this information to determine that we have the leader key.
Instead, we will record in Ha object the actual state of acquire/update lock and report as a leader only if it was successful.

P.S. despite responding with 200 on `GET /master` postgres was still running read-only.