### PR TITLE
K8s: Change API request timeout

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -37,7 +37,7 @@ class CoreV1ApiProxy(object):
         self._use_endpoints = use_endpoints
 
     def set_timeout(self, timeout):
-        self._request_timeout = (1, timeout / 3.0)
+        self._request_timeout = timeout / 2.0
 
     def __getattr__(self, func):
         if func.endswith('_kind'):


### PR DESCRIPTION
Set k8s API request timeout to `retry_timeout / 2.0` instead of hardcoded
connection timeout as `1` and read timeout as `retry_timeout / 3.0`. I think there is no need to distinguish connection timeout from read timeout in k8s dcs requests. Also `retry_timeout / 3.0` in my opinion is too small, especially with `retry_timeout == 10` set by default.  