### PR TITLE
Adding systemd reload functionality

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -19,6 +19,9 @@ WorkingDirectory=~
 
 ExecStart=/bin/patroni /etc/patroni.yml
 
+# Send HUP to reload from patroni.yml
+ExecReload=/bin/kill -s HUP $MAINPID
+
 # only kill the patroni process, not it's children, so it will gracefully stop postgres
 KillMode=process
 


### PR DESCRIPTION
This allows the config to be reloaded via `systemctl reload patroni`, sending SIGHUP to the patroni process. Tested on CentOS.