### PR TITLE
Use enforced minimums in postgresX.yml files

### DIFF
--- a/postgres0.yml
+++ b/postgres0.yml
@@ -31,8 +31,8 @@ bootstrap:
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
-#        max_wal_senders: 5
-#        max_replication_slots: 5
+#        max_wal_senders: 10
+#        max_replication_slots: 10
 #        wal_log_hints: "on"
 #        archive_mode: "on"
 #        archive_timeout: 1800s

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -29,8 +29,8 @@ bootstrap:
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
-#        max_wal_senders: 5
-#        max_replication_slots: 5
+#        max_wal_senders: 10
+#        max_replication_slots: 10
 #        wal_log_hints: "on"
 #        archive_mode: "on"
 #        archive_timeout: 1800s

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -29,8 +29,8 @@ bootstrap:
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
-#        max_wal_senders: 5
-#        max_replication_slots: 5
+#        max_wal_senders: 10
+#        max_replication_slots: 10
 #        wal_log_hints: "on"
 #        archive_mode: "on"
 #        archive_timeout: 1800s


### PR DESCRIPTION
The 3 postgresX.yml files have max_wal_senders and max_replication_slots set as 5. Yes they are commented out, but the postgresql.py file would bump this to the minimum of 10, so I think it would be a better practice to have the example values at least at the minimum.