### PR TITLE
Log config change or not

### DIFF
--- a/patroni/config.py
+++ b/patroni/config.py
@@ -152,12 +152,17 @@ class Config(object):
             try:
                 configuration = self._load_config_file()
                 if not deep_compare(self._local_configuration, configuration):
+                    # This returns false postiive when local config item is removed but DCS config is same value
+                    # * In that case, there should be a "no items changed" message
+                    logger.info('Configuration items changed, reloading local configuration.')
                     new_configuration = self._build_effective_configuration(self._dynamic_configuration, configuration)
                     if dry_run:
                         return not deep_compare(new_configuration, self.__effective_configuration)
                     self._local_configuration = configuration
                     self.__effective_configuration = new_configuration
                     return True
+                else:
+                    logger.info('No configuration items changed, nothing to reload.')
             except Exception:
                 logger.exception('Exception when reloading local configuration from %s', self.config_file)
                 if dry_run:

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -152,8 +152,6 @@ class Config(object):
             try:
                 configuration = self._load_config_file()
                 if not deep_compare(self._local_configuration, configuration):
-                    # This returns false postiive when local config item is removed but DCS config is same value
-                    # * In that case, there should be a "no items changed" message
                     new_configuration = self._build_effective_configuration(self._dynamic_configuration, configuration)
                     if dry_run:
                         return not deep_compare(new_configuration, self.__effective_configuration)

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -154,7 +154,6 @@ class Config(object):
                 if not deep_compare(self._local_configuration, configuration):
                     # This returns false postiive when local config item is removed but DCS config is same value
                     # * In that case, there should be a "no items changed" message
-                    logger.info('Configuration items changed, reloading local configuration.')
                     new_configuration = self._build_effective_configuration(self._dynamic_configuration, configuration)
                     if dry_run:
                         return not deep_compare(new_configuration, self.__effective_configuration)

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -375,7 +375,10 @@ class Postgresql(object):
             self._replace_pg_hba()
 
         if conf_changed or hba_changed:
+            logger.info('Configuration items changed, reloading configuration.')
             self.reload()
+        else:
+            logger.info('No configuration items changed, nothing to reload.')
 
         self._is_leader_retry.deadline = self.retry.deadline = config['retry_timeout']/2.0
 


### PR DESCRIPTION
This adds INFO log messages that clearly state if configuration values were seen as changed by Patroni after SIGHUP/reload and warrant reloading (or if nothing was changed an no reloading is necessary).

This ended up being a lot simpler than I had imagined once I found postgresql.py:reload_config().

I add a log line in config.py:reload_local_configuration() since that function will short-circuit the process early if the local config wasn't changed. But the final determination of whether or not values have changed and need reloading is in postgresql.py:reload_config().