### PR TITLE
Added setting state to "stopped" when a member is stopped in Ha.shutdown

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1168,7 +1168,6 @@ class Ha(object):
             if not self.state_handler.is_running():
                 if self.has_lock():
                     self.dcs.delete_leader()
-                self.state_handler.set_state('stopped')
                 self.touch_member()
             else:
                 # XXX: what about when Patroni is started as the wrong user that has access to the watchdog device

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1168,6 +1168,8 @@ class Ha(object):
             if not self.state_handler.is_running():
                 if self.has_lock():
                     self.dcs.delete_leader()
+                self.state_handler.set_state('stopped')
+                self.touch_member()
             else:
                 # XXX: what about when Patroni is started as the wrong user that has access to the watchdog device
                 # but cannot shut down PostgreSQL. Root would be the obvious example. Would be nice to not kill the


### PR DESCRIPTION
This will allow the member to show as "stopped" when viewed through a "patronictl list" command.