### PR TITLE
Fix several build problems with the Docker image for testing Kubernet…

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,17 +1,17 @@
-FROM postgres:9.6
+FROM postgres:10
 MAINTAINER Alexander Kukushkin <alexander.kukushkin@zalando.de>
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
     && apt-get update -y \
     && apt-get upgrade -y \
-    && apt-get install -y git curl jq python-psycopg2 python-yaml python-requests python-six python-pysocks \
+    && apt-get install -y git curl jq python-psycopg2 python-yaml python-requests python-six python-socks \
         python-dateutil python-pip python-prettytable python-wheel python-psutil python locales \
 
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
 
-    && pip install setuptools pip --upgrade \
+    && pip install setuptools \
     && pip install 'git+https://github.com/zalando/patroni.git#egg=patroni[kubernetes]' \
 
     && mkdir -p /home/postgres \

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -5,8 +5,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
     && apt-get update -y \
     && apt-get upgrade -y \
-    && apt-get install -y git curl jq python-psycopg2 python-yaml python-requests python-six python-socks \
-        python-dateutil python-pip python-prettytable python-wheel python-psutil python locales \
+    && apt-cache depends patroni | sed -n -e 's/.* Depends: \(python3-.\+\)$/\1/p' \
+            | grep -Ev '^python3-(sphinx|etcd|consul|kazoo|kubernetes)' \
+            | xargs apt-get install -y curl jq locales git python3-pip python3-wheel \
 
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
@@ -18,7 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && chown postgres:postgres /home/postgres \
 
     # Clean up
-    && apt-get remove -y git python-pip python-setuptools \
+    && apt-get remove -y git python-pip python-wheel \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /root/.cache


### PR DESCRIPTION
…es integration:

1. Update to Postgres 10
2. Replace pysocks module with socks module
3. Do *not* upgrade pip, as pip 10.0.1 is currently failing on Debian

With these changes, the dockerfile in kubernetes/ now works for testing a simple kubernetes config.