### PR TITLE
Convert query params from list to dict

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -91,6 +91,8 @@ class HTTPClient(object):
                     data = '{' + ttl + '}'
                 else:
                     data = data[:-1] + ', ' + ttl + '}'
+            if isinstance(params, list):  # starting from v1.1.0 python-consul switched from `dict` to `list` for params
+                params = {k: v for k, v in params}
             kwargs = {'retries': 0, 'preload_content': False, 'body': data}
             if method == 'get' and isinstance(params, dict) and 'index' in params:
                 kwargs['timeout'] = (float(params['wait'][:-1]) if 'wait' in params else 300) + 1


### PR DESCRIPTION
Patroni is relying on params to determine timeout and amount of retries when executing api requests to consul.
Starting from v1.1.0 python-consul changed internal API and started using `list` instead of `dict` to pass query parameters. Such change broke "watch" functionality.

Fixes https://github.com/zalando/patroni/issues/742 and https://github.com/zalando/patroni/issues/734