### PR TITLE
Add EnvironmentFile directive in sample systemd service file

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -11,6 +11,9 @@ Type=simple
 User=postgres
 Group=postgres
 
+# Read in configuration file if it exists, otherwise proceed
+EnvironmentFile=-/etc/patroni_env.conf
+
 WorkingDirectory=~
 
 # Where to send early-startup messages from the server


### PR DESCRIPTION
Add an EnvironmentFile directive to read in a configuration file with environment variables. The "-" prefix means it can proceed if the file doesn't exist.

This would alllow users to keep sensitive information like the SUPERUSER/REPLICATION passwords in the config file separate from a YAML file that might be deployed from source control.