### PR TITLE
Grant delete on endpoints and configmaps in RBAC.

### DIFF
--- a/kubernetes/patroni_k8s.yaml
+++ b/kubernetes/patroni_k8s.yaml
@@ -145,6 +145,8 @@ rules:
   - patch
   - update
   - watch
+  # delete is required only for 'patronictl remove'
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -157,6 +159,8 @@ rules:
   - create
   - list
   - watch
+  # delete is required only for for 'patronictl remove'
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
'patronictl remove' deletes the cluster configuration (stored either in
configmaps or endpoints) and cannot be run from the postgres pod w/o
'delete' on those objects being granted to the pod service account.