### PR TITLE
Python 3.6 and 3.7 are now supported, too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 


### PR DESCRIPTION
Follow-up to #751: update supported Python versions in `setup.py`.