### PR TITLE
Fix condition for the replica start due to pg_rewind in paused state.

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1113,8 +1113,8 @@ class Ha(object):
                         self.dcs.delete_leader()
                         self.dcs.reset_cluster()
                         return 'removed leader lock because postgres is not running'
-                    elif not (self.state_handler.rewind_executed or
-                              self.state_handler.need_rewind and self.state_handler.can_rewind):
+                    elif (self.state_handler.rewind_executed or
+                          not (self.state_handler.need_rewind and self.state_handler.can_rewind)):
                         return 'postgres is not running'
 
                 # try to start dead postgres

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1113,7 +1113,12 @@ class Ha(object):
                         self.dcs.delete_leader()
                         self.dcs.reset_cluster()
                         return 'removed leader lock because postgres is not running'
-                    elif (self.state_handler.rewind_executed or
+                    # Normally we don't start Postgres in a paused state. We make an exception for the demoted primary
+                    # that needs to be started after it had been stopped by demote. When there is no need to call rewind
+                    # the demote code follows through to starting Postgres right away, however, in the rewind case
+                    # it returns from demote and reaches this point to start PostgreSQL again after rewind. In that
+                    # case it makes no sense to continue to recover() unless rewind has finished successfully.
+                    elif (self.state_handler.rewind_failed or
                           not (self.state_handler.need_rewind and self.state_handler.can_rewind)):
                         return 'postgres is not running'
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1398,6 +1398,10 @@ class Postgresql(object):
     def rewind_executed(self):
         return self._rewind_state > REWIND_STATUS.NOT_NEED
 
+    @property
+    def rewind_failed(self):
+        return self._rewind_state == REWIND_STATUS.FAILED
+
     def follow(self, member, timeout=None):
         primary_conninfo = self.primary_conninfo(member)
         change_role = self.role in ('master', 'demoted')


### PR DESCRIPTION
Avoid starting the replica that had already executed pg_rewind before.

Described in #753 