### PR TITLE
Set role to demoted if postgres isn't running and no recovery.conf

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -179,6 +179,8 @@ class Postgresql(object):
             self._write_postgresql_conf()  # we are "joining" already running postgres
             if self._replace_pg_hba():
                 self.reload()
+        elif self.role == 'master':
+            self.set_role('demoted')
 
     @property
     def _create_replica_methods(self):


### PR DESCRIPTION
In really rare cases it was causing following behavior:
```
2018-07-31 10:35:30,302 INFO: starting as a secondary
2018-07-31 10:35:30,309 INFO: Lock owner: postgresql0; I am postgresql1
2018-07-31 10:35:30,310 INFO: Demoting master during restarting after failure
2018-07-31 10:35:30,381 INFO: postmaster pid=17709
2018-07-31 10:35:30,386 INFO: lost leader lock during restarting after failure
2018-07-31 10:35:30,388 ERROR: Exception during CHECKPOINT
```