### PR TITLE
Add "cluster_unlocked" field

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -415,10 +415,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
     def get_postgresql_status(self, retry=False):
         try:
-            cluster = (
-                self.server.patroni.dcs.cluster or
-                self.server.patroni.dcs.get_cluster()
-            )
+            cluster = self.server.patroni.dcs.cluster
 
             if self.server.patroni.postgresql.state not in ('running', 'restarting', 'starting'):
                 raise RetryFailedError('')
@@ -444,7 +441,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 'postmaster_start_time': row[0],
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': self.server.patroni.postgresql.server_version,
-                'cluster_unlocked': not cluster or cluster.is_unlocked(),
+                'cluster_unlocked': bool(not cluster or cluster.is_unlocked()),
                 'xlog': ({
                     'received_location': row[3],
                     'replayed_location': row[4],

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -444,7 +444,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 'postmaster_start_time': row[0],
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': self.server.patroni.postgresql.server_version,
-                'cluster_unlocked': cluster.is_unlocked(),
+                'cluster_unlocked': not cluster or cluster.is_unlocked(),
                 'xlog': ({
                     'received_location': row[3],
                     'replayed_location': row[4],

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -454,7 +454,6 @@ class RestApiHandler(BaseHTTPRequestHandler):
             if row[1] > 0:
                 result['timeline'] = row[1]
             else:
-                cluster = self.server.patroni.dcs.cluster
                 leader_timeline = None if not cluster or cluster.is_unlocked() else cluster.leader.timeline
                 result['timeline'] = self.server.patroni.postgresql.replica_cached_timeline(leader_timeline)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,6 +46,20 @@ class MockWatchdog(object):
     is_healthy = False
 
 
+class MockCluster(object):
+    leader = Mock()
+    sync = Mock()
+
+    def is_unlocked(self):
+        return False
+
+
+class MockDCS(object):
+    cluster = MockCluster()
+
+    def get_cluster(self):
+        return self.cluster
+
 class MockHa(object):
 
     state_handler = MockPostgresql()
@@ -97,7 +111,7 @@ class MockPatroni(object):
     ha = MockHa()
     config = Mock()
     postgresql = ha.state_handler
-    dcs = Mock()
+    dcs = MockDCS()
     tags = {}
     version = '0.00'
     noloadbalance = PropertyMock(return_value=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,20 +46,6 @@ class MockWatchdog(object):
     is_healthy = False
 
 
-class MockCluster(object):
-    leader = Mock()
-    sync = Mock()
-
-    def is_unlocked(self):
-        return False
-
-
-class MockDCS(object):
-    cluster = MockCluster()
-
-    def get_cluster(self):
-        return self.cluster
-
 class MockHa(object):
 
     state_handler = MockPostgresql()
@@ -111,7 +97,7 @@ class MockPatroni(object):
     ha = MockHa()
     config = Mock()
     postgresql = ha.state_handler
-    dcs = MockDCS()
+    dcs = Mock()
     tags = {}
     version = '0.00'
     noloadbalance = PropertyMock(return_value=False)


### PR DESCRIPTION
Add "cluster_unlocked" field for patroni api to be able to figure out if a
master is there from patroni point of view. It can be useful, when you have an
alert, based on Auto Scaling Groups, and then ASG decided to shutdown the
current master, spin up a new instance but the current master shutdown is
stuck. In this situation the current master is no longer a part of ASG, but
patroni and Postgres are still alive on the instance, which means a new replica
will not be promoted yet - this will lead to a false alert, saying that your
cluster doesn't have any master node.