### PR TITLE
Improve stability of acceptance tests

### DIFF
--- a/features/basic_replication.feature
+++ b/features/basic_replication.feature
@@ -14,12 +14,13 @@ Feature: basic replication
     Then table foo is present on postgres2 after 20 seconds
 
   Scenario: check restart of sync replica
-    Given I run patronictl.py restart batman postgres2 --force
-    And "sync" key in DCS has sync_standby=postgres1 after 2 seconds
-    And I run patronictl.py restart batman postgres1 --force
-    Then I receive a response returncode 0
-    And "sync" key in DCS has sync_standby=postgres2 after 10 seconds
-    And I sleep for 2 seconds
+    Given I shut down postgres2
+    Then "sync" key in DCS has sync_standby=postgres1 after 5 seconds
+    When I start postgres2
+    And I shut down postgres1
+    Then "sync" key in DCS has sync_standby=postgres2 after 10 seconds
+    When I start postgres1
+    And "members/postgres1" key in DCS has state=running after 10 seconds
     When I issue a GET request to http://127.0.0.1:8010/sync
     Then I receive a response code 200
     When I issue a GET request to http://127.0.0.1:8009/async


### PR DESCRIPTION
last time tests were failing due to postgres/patroni slowness in picking sync standby