### PR TITLE
None changed to empty string

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -321,7 +321,7 @@ class Kubernetes(AbstractDCS):
         """Unused"""
 
     def manual_failover(self, leader, candidate, scheduled_at=None, index=None):
-        annotations = {'leader': leader or None, 'member': candidate or None, 'scheduled_at': scheduled_at}
+        annotations = {'leader': leader or '', 'member': candidate or '', 'scheduled_at': scheduled_at or ''}
         patch = bool(self.cluster and isinstance(self.cluster.failover, Failover) and self.cluster.failover.index)
         return self.patch_or_create(self.failover_path, annotations, index, bool(index or patch), False)
 


### PR DESCRIPTION
`None` is change to `null` when dict is converted to json via `json.dumps(data)`. Kubernetes can't handle `null` as a value in annotations.

so, `None` is change to empty string.


https://github.com/zalando/patroni/issues/775

