### PR TITLE
Search new sync candidate amoung potential and async standbys

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1733,7 +1733,7 @@ $$""".format(name, ' '.join(options)), name, password, password)
             if sync_state == 'potential' and app_name == current:
                 # Prefer current even if not the best one any more to avoid indecisivness and spurious swaps.
                 return current, False
-            if sync_state == 'async':
+            if sync_state in ('async', 'potential'):
                 candidates.append(app_name)
 
         if candidates:


### PR DESCRIPTION
In synchronos_mode_strict we put '*' into synchronos_standby_names, what makes one connection 'sync' and other connections 'potential'.
The code picking up the correct sync standby didn't consider 'potential' as a good candidates.

Fixes: https://github.com/zalando/patroni/issues/789