### PR TITLE
check if output lines of controldata are possible to split

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1216,7 +1216,8 @@ class Postgresql(object):
                 if data:
                     data = data.decode('utf-8').splitlines()
                     # pg_controldata output depends on major verion. Some of parameters are prefixed by 'Current '
-                    result = {l.split(':')[0].replace('Current ', '', 1): l.split(':', 1)[1].strip() for l in data if l}
+                    result = {l.split(':')[0].replace('Current ', '', 1): l.split(':', 1)[1].strip() for l in data
+                              if l and ':' in l}
             except subprocess.CalledProcessError:
                 logger.exception("Error when calling pg_controldata")
         return result


### PR DESCRIPTION
Guys, hi !
Faced next error on patroni start-up:

https://gist.github.com/anikin-aa/f7767888324a1b4f0a15e9ef6db199b8

This is because, ive got not usual structure of pgcontroldata output, that starts with

```
WARNING: Calculated CRC checksum does not match value stored in file.                                                                                                                                                                                
Either the file is corrupt, or it has a different layout than this program                                                                                                                                                                           
is expecting.  The results below are untrustworthy.  

Database system identifier:           6594712486295408697                                                                                                                                                                                            
Database cluster state:               in archive recovery    
```

So, patroni fails on splitting of lines. There are two possible cases with warnings:

- https://github.com/greenplum-db/gpdb/blob/master/src/bin/pg_controldata/pg_controldata.c#L168
- https://github.com/greenplum-db/gpdb/blob/master/src/bin/pg_controldata/pg_controldata.c#L198

My small fix is just excluding lines without ':', so its possible to split them.