### PR TITLE
Register service in consul

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -356,7 +356,7 @@ class Consul(AbstractDCS):
 
     @catch_consul_errors
     def register_service(self, service_name, **kwargs):
-        logger.info('Register service {}, params {}'.format(service_name, kwargs))
+        logger.info('Register service %s, params %s', service_name, kwargs)
         return self.retry(self._client.agent.service.register, service_name, **kwargs)
 
     def _update_service(self, data):

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -181,17 +181,18 @@ class TestConsul(unittest.TestCase):
     def test_set_history_value(self):
         self.assertTrue(self.c.set_history_value('{}'))
 
-    @patch.object(consul.Consul.Agent.Service, 'register', Mock(return_value=True))
+    @patch.object(consul.Consul.Agent.Service, 'register', Mock(side_effect=(False, True)))
     @patch.object(consul.Consul.Agent.Service, 'deregister', Mock(return_value=True))
     def test_update_service(self):
         d = {'role': 'replica', 'api_url': 'http://a/t', 'conn_url': 'pg://c:1', 'state': 'running'}
-        self.assertFalse(self.c.update_service({}, {}))
-        self.assertTrue(self.c.update_service({}, d))
+        self.assertIsNone(self.c.update_service({}, {}))
+        self.assertFalse(self.c.update_service({}, d))
+        self.assertTrue(self.c.update_service(d, d))
         self.assertIsNone(self.c.update_service(d, d))
         d['state'] = 'stopped'
         self.assertTrue(self.c.update_service(d, d, force=True))
         d['state'] = 'unknown'
-        self.assertFalse(self.c.update_service({}, d))
+        self.assertIsNone(self.c.update_service({}, d))
         d['state'] = 'running'
         d['role'] = 'bla'
-        self.assertFalse(self.c.update_service({}, d))
+        self.assertIsNone(self.c.update_service({}, d))

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -74,10 +74,12 @@ class TestConsul(unittest.TestCase):
     @patch.object(consul.Consul.KV, 'delete', Mock())
     def setUp(self):
         Consul({'ttl': 30, 'scope': 't', 'name': 'p', 'url': 'https://l:1', 'retry_timeout': 10,
-                'verify': 'on', 'key': 'foo', 'cert': 'bar', 'cacert': 'buz', 'token': 'asd', 'dc': 'dc1'})
-        Consul({'ttl': 30, 'scope': 't', 'name': 'p', 'url': 'https://l:1', 'retry_timeout': 10,
-                'verify': 'on', 'cert': 'bar', 'cacert': 'buz'})
-        self.c = Consul({'ttl': 30, 'scope': 'test', 'name': 'postgresql1', 'host': 'localhost:1', 'retry_timeout': 10})
+                'verify': 'on', 'key': 'foo', 'cert': 'bar', 'cacert': 'buz', 'token': 'asd', 'dc': 'dc1',
+                'register_service': True})
+        Consul({'ttl': 30, 'scope': 't_', 'name': 'p', 'url': 'https://l:1', 'retry_timeout': 10,
+                'verify': 'on', 'cert': 'bar', 'cacert': 'buz', 'register_service': True})
+        self.c = Consul({'ttl': 30, 'scope': 'test', 'name': 'postgresql1', 'host': 'localhost:1', 'retry_timeout': 10,
+                         'register_service': True})
         self.c._base_path = '/service/good'
         self.c._load_cluster()
 
@@ -111,6 +113,7 @@ class TestConsul(unittest.TestCase):
     @patch.object(consul.Consul.KV, 'delete', Mock(side_effect=[ConsulException, True, True]))
     @patch.object(consul.Consul.KV, 'put', Mock(side_effect=[True, ConsulException]))
     def test_touch_member(self):
+        self.c._register_service = True
         self.c.refresh_session = Mock(return_value=True)
         self.c.touch_member({'balbla': 'blabla'})
         self.c.touch_member({'balbla': 'blabla'})
@@ -176,3 +179,12 @@ class TestConsul(unittest.TestCase):
     @patch.object(consul.Consul.KV, 'put', Mock(return_value=True))
     def test_set_history_value(self):
         self.assertTrue(self.c.set_history_value('{}'))
+
+    @patch.object(consul.Consul.Agent.Service, 'register', Mock(return_value=True))
+    def test_update_service(self):
+        d = {'role': 'replica', 'api_url': 'http://a/t', 'conn_url': 'pg://c:1'}
+        self.assertFalse(self.c.update_service({}, {}))
+        self.assertTrue(self.c.update_service({}, d))
+        self.assertIsNone(self.c.update_service(d, d))
+        d['role'] = 'bla'
+        self.assertFalse(self.c.update_service({}, d))

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -181,10 +181,16 @@ class TestConsul(unittest.TestCase):
         self.assertTrue(self.c.set_history_value('{}'))
 
     @patch.object(consul.Consul.Agent.Service, 'register', Mock(return_value=True))
+    @patch.object(consul.Consul.Agent.Service, 'deregister', Mock(return_value=True))
     def test_update_service(self):
-        d = {'role': 'replica', 'api_url': 'http://a/t', 'conn_url': 'pg://c:1'}
+        d = {'role': 'replica', 'api_url': 'http://a/t', 'conn_url': 'pg://c:1', 'state': 'running'}
         self.assertFalse(self.c.update_service({}, {}))
         self.assertTrue(self.c.update_service({}, d))
         self.assertIsNone(self.c.update_service(d, d))
+        d['state'] = 'stopped'
+        self.assertTrue(self.c.update_service(d, d, force=True))
+        d['state'] = 'unknown'
+        self.assertFalse(self.c.update_service({}, d))
+        d['state'] = 'running'
         d['role'] = 'bla'
         self.assertFalse(self.c.update_service({}, d))


### PR DESCRIPTION
Implementation of https://github.com/zalando/patroni/issues/771, but a bit different, register service 'scope_name' with tag 'master' or 'replica'

example with scope 'pgsql-pgpi'
```[root@pgpi1 ~]# host -t SRV pgsql-pgpi.service.consul. 127.0.0.1
Using domain server:
Name: 127.0.0.1
Address: 127.0.0.1#53
Aliases:

pgsql-pgpi.service.consul has SRV record 1 1 5432 pgpi1.node.dc.consul.
pgsql-pgpi.service.consul has SRV record 1 1 5432 pgpi2.node.dc.consul.
[root@pgpi1 ~]# host -t SRV master.pgsql-pgpi.service.consul. 127.0.0.1
Using domain server:
Name: 127.0.0.1
Address: 127.0.0.1#53
Aliases:

master.pgsql-pgpi.service.consul has SRV record 1 1 5432 pgpi2.node.dc.consul.
[root@pgpi1 ~]# host -t SRV replica.pgsql-pgpi.service.consul. 127.0.0.1
Using domain server:
Name: 127.0.0.1
Address: 127.0.0.1#53
Aliases:

replica.pgsql-pgpi.service.consul has SRV record 1 1 5432 pgpi1.node.dc.consul.```
