### PR TITLE
A few bugfixes in the "standby cluster" workflow

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -87,7 +87,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         replica_status_code = 200 if not patroni.noloadbalance and response.get('role') == 'replica' else 503
         status_code = 503
 
-        if patroni.config.is_standby_cluster and ('standby_leader' in path or 'standby-leader' in path):
+        if patroni.ha.is_standby_cluster() and ('standby_leader' in path or 'standby-leader' in path):
             status_code = 200 if patroni.ha.is_leader() else 503
         elif 'master' in path or 'leader' in path or 'primary' in path:
             status_code = 200 if patroni.ha.is_leader() else 503

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -9,7 +9,7 @@ import yaml
 
 from collections import defaultdict
 from copy import deepcopy
-from patroni.dcs import ClusterConfig, is_standby_cluster
+from patroni.dcs import ClusterConfig
 from patroni.postgresql import Postgresql
 from patroni.utils import deep_compare, parse_bool, parse_int, patch_config
 from requests.structures import CaseInsensitiveDict
@@ -98,10 +98,6 @@ class Config(object):
     @property
     def dynamic_configuration(self):
         return deepcopy(self._dynamic_configuration)
-
-    @property
-    def is_standby_cluster(self):
-        return is_standby_cluster(self._dynamic_configuration.get('standby_cluster'))
 
     def check_mode(self, mode):
         return bool(parse_bool(self._dynamic_configuration.get(mode)))

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -189,13 +189,12 @@ class RemoteMember(Member):
                 'create_replica_methods',
                 'restore_command',
                 'archive_cleanup_command',
-                'recovery_min_apply_delay')
+                'recovery_min_apply_delay',
+                'no_replication_slot')
 
     def __getattr__(self, name):
-        if name not in RemoteMember.allowed_keys():
-            return
-
-        return self.data.get(name)
+        if name in RemoteMember.allowed_keys():
+            return self.data.get(name)
 
 
 class Leader(namedtuple('Leader', 'index,session,member')):

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -397,9 +397,6 @@ class Cluster(namedtuple('Cluster', 'initialize,config,leader,last_leader_operat
     def is_synchronous_mode(self):
         return self.check_mode('synchronous_mode')
 
-    def is_standby_cluster(self):
-        return is_standby_cluster(self.config and self.config.data.get('standby_cluster'))
-
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractDCS(object):
@@ -653,14 +650,3 @@ class AbstractDCS(object):
 
         self.event.wait(timeout)
         return self.event.isSet()
-
-
-def is_standby_cluster(config):
-    """ Check whether or not provided configuration describes a standby cluster.
-        Config can be both patroni config or cluster.config.data
-    """
-    return isinstance(config, dict) and (
-        config.get('host') or
-        config.get('port') or
-        config.get('restore_command')
-    )

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1204,7 +1204,7 @@ class Postgresql(object):
             ('user', r.get('user')),
             ('host', r.get('host')),
             ('port', r.get('port')),
-            ('dbname', r.get('database')),
+            ('dbname', r.get('database') or self._database),
             ('sslmode', 'prefer'),
             ('sslcompression', '1'),
         ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,6 +95,10 @@ class MockHa(object):
     def is_paused():
         return True
 
+    @staticmethod
+    def is_standby_cluster():
+        return False
+
 
 class MockPatroni(object):
 
@@ -167,8 +171,8 @@ class TestRestApiHandler(unittest.TestCase):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /master'))
         with patch.object(RestApiServer, 'query', Mock(return_value=[('', 1, '', '', '', '', False, '')])):
             self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /patroni'))
-        MockPatroni.config.is_standby_cluster = PropertyMock(return_value=True)
-        MockRestApiServer(RestApiHandler, 'GET /standby_leader')
+        with patch.object(MockHa, 'is_standby_cluster', Mock(return_value=True)):
+            MockRestApiServer(RestApiHandler, 'GET /standby_leader')
 
     def test_do_OPTIONS(self):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'OPTIONS / HTTP/1.0'))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -5,7 +5,6 @@ import unittest
 import sys
 
 from mock import Mock, MagicMock, PropertyMock, patch
-from patroni.async_executor import CriticalTask
 from patroni.config import Config
 from patroni.dcs import Cluster, ClusterConfig, Failover, Leader, Member, get_dcs, SyncState, TimelineHistory
 from patroni.dcs.etcd import Client
@@ -60,17 +59,6 @@ def get_cluster_initialized_with_leader(failover=None, sync=None):
 def get_cluster_initialized_with_only_leader(failover=None, cluster_config=None):
     leader = get_cluster_initialized_without_leader(leader=True, failover=failover).leader
     return get_cluster(True, leader, [leader], failover, None, cluster_config)
-
-
-def get_cluster_not_initialized_standby(failover=None, sync=None):
-    return get_cluster_not_initialized_without_leader(
-        cluster_config=ClusterConfig(1, {
-            "standby_cluster": {
-                "host": "localhost",
-                "port": 5432,
-                "primary_slot_name": "",
-            }}, 1)
-    )
 
 
 def get_standby_cluster_initialized_with_only_leader(failover=None, sync=None):
@@ -214,17 +202,10 @@ class TestHa(unittest.TestCase):
     @patch('patroni.dcs.etcd.Etcd.initialize', return_value=True)
     def test_start_as_standby_leader(self, initialize):
         self.p.data_directory_empty = true
-        self.ha.cluster = get_cluster_not_initialized_standby()
+        self.ha.cluster = get_cluster_not_initialized_without_leader(cluster_config=ClusterConfig(0, {}, 0))
         self.ha.cluster.is_unlocked = true
-        self.ha.patroni.config._dynamic_configuration = {"standby_cluster": {
-            "host": "localhost",
-            "port": 5432,
-            "primary_slot_name": "",
-        }}
-        self.assertEqual(
-            self.ha.run_cycle(),
-            'trying to bootstrap a new standby leader'
-        )
+        self.ha.patroni.config._dynamic_configuration = {"standby_cluster": {"port": 5432}}
+        self.assertEqual(self.ha.run_cycle(), 'trying to bootstrap a new standby leader')
 
     @patch.object(Cluster, 'get_clone_member',
                   Mock(return_value=Member(0, 'test', 1, {'api_url': 'http://127.0.0.1:8011/patroni'})))
@@ -233,27 +214,7 @@ class TestHa(unittest.TestCase):
         self.p.data_directory_empty = true
         self.ha.cluster = get_standby_cluster_initialized_with_only_leader()
         self.ha.cluster.is_unlocked = false
-        self.ha.patroni.config._dynamic_configuration = {"standby_cluster": {
-            "host": "localhost",
-            "port": 5432,
-            "primary_slot_name": "",
-        }}
-        self.assertEqual(
-            self.ha.run_cycle(),
-            "trying to bootstrap from replica 'test'"
-        )
-
-    @patch.object(Postgresql, 'create_replica', Mock(return_value=0))
-    def test_bootstrap_standby_leader(self):
-        self.ha.cluster = get_cluster_not_initialized_standby()
-        self.ha.cluster.is_unlocked = true
-        self.ha.patroni.config._dynamic_configuration = {"standby_cluster": {
-            "host": "localhost",
-            "port": 5432,
-            "primary_slot_name": "",
-        }}
-        self.ha._post_bootstrap_task = CriticalTask()
-        self.assertEqual(self.ha.bootstrap_standby_leader(), True)
+        self.assertEqual(self.ha.run_cycle(), "trying to bootstrap from replica 'test'")
 
     def test_recover_replica_failed(self):
         self.p.controldata = lambda: {'Database cluster state': 'in recovery', 'Database system identifier': SYSID}


### PR DESCRIPTION
* Always run `pg_rewind` against the remote master
* Always use the remote master as the source when "recovering" stopped standby leader
* Use remote master as the source when "recovering" the node in the unhealthy cluster
* Use the local dbname as the fallback when doing `pg_rewind` from the remote master
*  `no_replication_slot` is the allowed key in the `RemoteMember` object
* Make it possible to "bootstrap" the new `standby_cluster` with existing (and valid) data directory. There is one prerequisite though, there should be no `patroni.dynamic.json` file in it!