### PR TITLE
Add pre-command to start watchdog

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -18,8 +18,14 @@ WorkingDirectory=~
 
 # Where to send early-startup messages from the server
 # This is normally controlled by the global default set by systemd
-# StandardOutput=syslog
+#StandardOutput=syslog
 
+# Pre-commands to start watchdog device
+# Uncomment if watchdog is part of your patroni setup
+#ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
+#ExecStartPre=-/usr/bin/sudo /bin/chown postgres /dev/watchdog
+
+# Start the patroni process
 ExecStart=/bin/patroni /etc/patroni.yml
 
 # Send HUP to reload from patroni.yml


### PR DESCRIPTION
Add `ExecStartPre` commands to help start watchdog devices.
Commands are commented to make it inline with the YAML: https://github.com/zalando/patroni/blob/master/postgres0.yml#L90-#L93