### PR TITLE
Compatibility with kazoo-2.6.0

### DIFF
--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -37,7 +37,9 @@ class PatroniSequentialThreadingHandler(SequentialThreadingHandler):
                      `connect_timeout` (negotiated session timeout) as the second element."""
 
         args = list(args)
-        if len(args) == 1:
+        if len(args) == 0:  # kazoo 2.6.0 slightly changed the way how it calls create_connection method
+            kwargs['timeout'] = max(self._connect_timeout, kwargs.get('timeout', self._connect_timeout*10)/10.0)
+        elif len(args) == 1:
             args.append(self._connect_timeout)
         else:
             args[1] = max(self._connect_timeout, args[1]/10.0)

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -113,6 +113,7 @@ class TestPatroniSequentialThreadingHandler(unittest.TestCase):
     def test_create_connection(self):
         self.assertIsNotNone(self.handler.create_connection(()))
         self.assertIsNotNone(self.handler.create_connection((), 40))
+        self.assertIsNotNone(self.handler.create_connection(timeout=40))
 
 
 class TestZooKeeper(unittest.TestCase):


### PR DESCRIPTION
Recently 2.6.0 was release which changes the way how create_connection method is called. Before it was passing two arguments, and in the new version all argument names are specified explicitly.