### PR TITLE
Compatibility with postgres 9.3

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1243,7 +1243,8 @@ class Postgresql(object):
     @contextmanager
     def _get_replication_connection_cursor(self, host='localhost', port=5432, database=None, **kwargs):
         database = database or self._database
-        with self._get_connection_cursor(host=host, port=int(port), database=database, replication='database',
+        replication = 'database' if self._major_version >= 90400 else 1
+        with self._get_connection_cursor(host=host, port=int(port), database=database, replication=replication,
                                          user=self._replication['username'], password=self._replication['password'],
                                          connect_timeout=3, options='-c statement_timeout=2000') as cur:
             yield cur


### PR DESCRIPTION
Use replication=1 instead of replication='database' when opening replication connection, 9.3 doesn't understand it.