### PR TITLE
Compatibility with python3

### DIFF
--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import select
 import time
 
 from kazoo.client import KazooClient, KazooState, KazooRetry
@@ -44,6 +45,13 @@ class PatroniSequentialThreadingHandler(SequentialThreadingHandler):
         else:
             args[1] = max(self._connect_timeout, args[1]/10.0)
         return super(PatroniSequentialThreadingHandler, self).create_connection(*args, **kwargs)
+
+    def select(self, *args, **kwargs):
+        """Python3 raises `ValueError` if socket is closed, because fd == -1"""
+        try:
+            return super(PatroniSequentialThreadingHandler, self).select(*args, **kwargs)
+        except ValueError as e:
+            raise select.error(9, str(e))
 
 
 class ZooKeeper(AbstractDCS):

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -1,3 +1,4 @@
+import select
 import six
 import unittest
 
@@ -114,6 +115,10 @@ class TestPatroniSequentialThreadingHandler(unittest.TestCase):
         self.assertIsNotNone(self.handler.create_connection(()))
         self.assertIsNotNone(self.handler.create_connection((), 40))
         self.assertIsNotNone(self.handler.create_connection(timeout=40))
+
+    @patch.object(SequentialThreadingHandler, 'select', Mock(side_effect=ValueError))
+    def test_select(self):
+        self.assertRaises(select.error, self.handler.select)
 
 
 class TestZooKeeper(unittest.TestCase):


### PR DESCRIPTION
Change of `loop_wait` was causing Patroni to disconnect from zookeeper and never reconnect back. The error was happening only with python3 due to a difference in implementation of `select.select` function.