### PR TITLE
Fix kubernetes demo files

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -8,22 +8,17 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-cache depends patroni | sed -n -e 's/.* Depends: \(python3-.\+\)$/\1/p' \
             | grep -Ev '^python3-(sphinx|etcd|consul|kazoo|kubernetes)' \
             | xargs apt-get install -y curl jq locales git python3-pip python3-wheel \
-
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-
     && pip3 install setuptools \
     && pip3 install 'git+https://github.com/zalando/patroni.git#egg=patroni[kubernetes]' \
-
     && PGHOME=/home/postgres \
     && mkdir -p $PGHOME \
     && chown postgres $PGHOME \
     && sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
-
     # Set permissions for OpenShift
     && chmod 775 $PGHOME \
     && chmod 664 /etc/passwd \
-
     # Clean up
     && apt-get remove -y git python3-pip python3-wheel \
     && apt-get autoremove -y \

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -7,7 +7,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get upgrade -y \
     && apt-cache depends patroni | sed -n -e 's/.* Depends: \(python3-.\+\)$/\1/p' \
             | grep -Ev '^python3-(sphinx|etcd|consul|kazoo|kubernetes)' \
-            | xargs apt-get install -y curl jq locales git python3-pip python3-wheel \
+            | xargs apt-get install -y vim-tiny curl jq locales git python3-pip python3-wheel \
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && pip3 install setuptools \
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 ADD entrypoint.sh /
 
 EXPOSE 5432 8008
-ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 EDITOR=/usr/bin/editor
 USER postgres
 WORKDIR /home/postgres
 CMD ["/bin/bash", "/entrypoint.sh"]

--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10
+FROM postgres:11
 MAINTAINER Alexander Kukushkin <alexander.kukushkin@zalando.de>
 
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/kubernetes/entrypoint.sh
+++ b/kubernetes/entrypoint.sh
@@ -20,11 +20,11 @@ bootstrap:
   - data-checksums
   pg_hba:
   - host all all 0.0.0.0/0 md5
-  - host replication ${PATRONI_REPLICATION_USERNAME} ${POD_IP}/16    md5
+  - host replication ${PATRONI_REPLICATION_USERNAME} ${PATRONI_KUBERNETES_POD_IP}/16 md5
 restapi:
-  connect_address: '${POD_IP}:8008'
+  connect_address: '${PATRONI_KUBERNETES_POD_IP}:8008'
 postgresql:
-  connect_address: '${POD_IP}:5432'
+  connect_address: '${PATRONI_KUBERNETES_POD_IP}:5432'
   authentication:
     superuser:
       password: '${PATRONI_SUPERUSER_PASSWORD}'

--- a/kubernetes/openshift-example/templates/template_patroni_ephemeral.yml
+++ b/kubernetes/openshift-example/templates/template_patroni_ephemeral.yml
@@ -108,7 +108,7 @@ objects:
       spec:
         containers:
         - env:
-          - name: POD_IP
+          - name: PATRONI_KUBERNETES_POD_IP
             valueFrom:
               fieldRef:
                 apiVersion: v1

--- a/kubernetes/openshift-example/templates/template_patroni_persistent.yaml
+++ b/kubernetes/openshift-example/templates/template_patroni_persistent.yaml
@@ -108,7 +108,7 @@ objects:
       spec:
         containers:
         - env:
-          - name: POD_IP
+          - name: PATRONI_KUBERNETES_POD_IP
             valueFrom:
               fieldRef:
                 apiVersion: v1

--- a/kubernetes/patroni_k8s.yaml
+++ b/kubernetes/patroni_k8s.yaml
@@ -28,7 +28,7 @@ spec:
         - mountPath: /home/postgres/pgdata
           name: pgdata
         env:
-        - name: POD_IP
+        - name: PATRONI_KUBERNETES_POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP


### PR DESCRIPTION
- Update postgres docker image to the latest 11 version.

- Remove empty lines inside the `RUN` command to make the Dockerfile compatible with future docker versions.

- Set the `PATRONI_KUBERNETES_POD_IP` environment variable, which is required when _use_endpoints_ is enabled. Otherwise, the `KeyError` is raised [here](https://github.com/zalando/patroni/blob/e684ca66e5d66a10feef52e3513813fbcaab9581/patroni/dcs/kubernetes.py#L95).

- Set `EDITOR` environment variable to make configuration changes via `patronictl edit-config`.
