### PR TITLE
Consider node not healthy if it is not on the latest timeline

### DIFF
--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -76,6 +76,7 @@ Also, the following Patroni configuration options can be changed only dynamicall
 - loop_wait: 10
 - retry_timeouts: 10
 - maximum_lag_on_failover: 1048576
+- check_timeline: false
 - postgresql.use_slots: true
 
 Upon changing these options, Patroni will read the relevant section of the configuration stored in DCS and change its

--- a/docs/replication_modes.rst
+++ b/docs/replication_modes.rst
@@ -13,6 +13,8 @@ In asynchronous mode the cluster is allowed to lose some committed transactions 
 
 The amount of transactions that can be lost is controlled via ``maximum_lag_on_failover`` parameter. Because the primary transaction log position is not sampled in real time, in reality the amount of lost data on failover is worst case bounded by  ``maximum_lag_on_failover`` bytes of transaction log plus the amount that is written in the last ``ttl`` seconds (``loop_wait``/2 seconds in the average case). However typical steady state replication delay is well under a second.
 
+By default, when running leader elections, Patroni does not take into account the current timeline of replicas, what in some cases could be undesirable behavior. You can prevent the node not having the same timeline as a former master become the new leader by changing the value of ``check_timeline`` parameter to ``true``.
+
 PostgreSQL synchronous replication
 ----------------------------------
 

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -44,6 +44,7 @@ class Config(object):
     __DEFAULT_CONFIG = {
         'ttl': 30, 'loop_wait': 10, 'retry_timeout': 10,
         'maximum_lag_on_failover': 1048576,
+        'check_timeline': False,
         'master_start_timeout': 300,
         'synchronous_mode': False,
         'synchronous_mode_strict': False,
@@ -340,7 +341,7 @@ class Config(object):
             'scope',
             'retry_timeout',
             'synchronous_mode',
-            'maximum_lag_on_failover'
+            'synchronous_mode_strict',
         )
 
         pg_config.update({p: config[p] for p in updated_fields if p in config})

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -486,6 +486,14 @@ class Cluster(namedtuple('Cluster', 'initialize,config,leader,last_leader_operat
 
     @property
     def timeline(self):
+        """
+        >>> Cluster(0, 0, 0, 0, 0, 0, 0, 0).timeline
+        0
+        >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[]')).timeline
+        1
+        >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[["a"]]')).timeline
+        0
+        """
         if self.history:
             if self.history.lines:
                 try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,7 +73,7 @@ class MockHa(object):
 
     @staticmethod
     def fetch_nodes_statuses(members):
-        return [_MemberStatus(None, True, None, None, {}, False)]
+        return [_MemberStatus(None, True, None, 0, None, {}, False)]
 
     @staticmethod
     def schedule_future_restart(data):

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -31,7 +31,7 @@ def get_cluster(initialize, leader, members, failover, sync, cluster_config=None
     t = datetime.datetime.now().isoformat()
     history = TimelineHistory(1, '[[1,67197376,"no recovery target specified","' + t + '"]]',
                               [(1, 67197376, 'no recovery target specified', t)])
-    cluster_config = cluster_config or ClusterConfig(1, {1: 2}, 1)
+    cluster_config = cluster_config or ClusterConfig(1, {'check_timeline': True}, 1)
     return Cluster(initialize, cluster_config, leader, 10, members, failover, sync, history)
 
 
@@ -118,6 +118,7 @@ zookeeper:
         sys.argv = sys.argv[:1]
 
         self.config = Config()
+        self.config.set_dynamic_configuration({'maximum_lag_on_failover': 5})
         self.postgresql = p
         self.dcs = d
         self.api = Mock()
@@ -170,7 +171,6 @@ class TestHa(unittest.TestCase):
             mock_machines.__get__ = Mock(return_value=['http://remotehost:2379'])
             self.p = Postgresql({'name': 'postgresql0', 'scope': 'dummy', 'listen': '127.0.0.1:5432',
                                  'data_dir': 'data/postgresql0', 'retry_timeout': 10,
-                                 'maximum_lag_on_failover': 5,
                                  'authentication': {'superuser': {'username': 'foo', 'password': 'bar'},
                                                     'replication': {'username': '', 'password': ''}},
                                  'parameters': {'wal_level': 'hot_standby', 'max_replication_slots': 5, 'foo': 'bar',

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -465,6 +465,8 @@ class TestHa(unittest.TestCase):
         self.assertEqual(self.ha.run_cycle(), 'no action.  i am the leader with the lock')
         self.ha.fetch_node_status = get_node_status(watchdog_failed=True)
         self.assertEqual(self.ha.run_cycle(), 'no action.  i am the leader with the lock')
+        self.ha.fetch_node_status = get_node_status(timeline=1)
+        self.assertEqual(self.ha.run_cycle(), 'no action.  i am the leader with the lock')
         self.ha.fetch_node_status = get_node_status(wal_position=1)
         self.assertEqual(self.ha.run_cycle(), 'no action.  i am the leader with the lock')
         # manual failover from the previous leader to us won't happen if we hold the nofailover flag
@@ -575,6 +577,8 @@ class TestHa(unittest.TestCase):
         self.ha.fetch_node_status = get_node_status(wal_position=11)  # accessible, in_recovery, wal position ahead
         self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))
         with patch('patroni.postgresql.Postgresql.timeline_wal_position', return_value=(1, 1)):
+            self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))
+        with patch('patroni.postgresql.Postgresql.replica_cached_timeline', return_value=1):
             self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))
         self.ha.patroni.nofailover = True
         self.assertFalse(self.ha._is_healthiest_node(self.ha.old_cluster.members))


### PR DESCRIPTION
The latest timeline is calculated from the `/history` key in DCS. In case there is no such key or it contains some garbage we consider the node healthy.

Hopefully fixes https://github.com/zalando/patroni/issues/890