### PR TITLE
Allow postgres stderr to output use the same file handles

### DIFF
--- a/patroni/postmaster.py
+++ b/patroni/postmaster.py
@@ -157,7 +157,7 @@ class PostmasterProcess(psutil.Process):
         cmdline = [pgcommand, '-D', data_dir, '--config-file={}'.format(conf)] + options
         logger.debug("Starting postgres: %s", " ".join(cmdline))
         proc = call_self(['pg_ctl_start'] + cmdline, close_fds=(os.name != 'nt'),
-                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+                         stdout=subprocess.PIPE, env=env)
         pid = int(proc.stdout.readline().strip())
         proc.wait()
         logger.info('postmaster pid=%s', pid)


### PR DESCRIPTION
Starting in Patroni 1.5.0 the "pg_ctl_start" process started to pipe stderr to stdout. In previous versions,  the "pg_ctl_start" process and Postgres both inherited stderr from the main Patroni process

Inheriting stderr from the main Patroni process allows all Postgres logs to be seen along with all patroni logs. This is very useful in a container environment as Patroni and Postgres logs may be consumed using standard tools (docker logs, kubectl, etc).

This PR removes the pipe from stderr to stdout.