### PR TITLE
possibility to set `logdatefmt` via env.

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -145,8 +145,7 @@ def patroni_main():
     logdatefmt = os.environ.get('PATRONI_LOGDATEFMT', '%Y-%m-%d %H:%M:%S')
 
     if not logdir:
-        logging.basicConfig(format=logformat, level=loglevel,
-                            logdatefmt=logdatefmt)
+        logging.basicConfig(format=logformat, level=loglevel, datefmt=logdatefmt)
     else:
         logsize = os.environ.get('PATRONI_FILE_LOG_SIZE', 25000000)
         lognum = os.environ.get('PATRONI_FILE_LOG_NUM', 4)
@@ -155,7 +154,7 @@ def patroni_main():
         root_logger.setLevel(loglevel)
         handler = RotatingFileHandler(os.path.join(logdir, 'patroni.log'), mode='a', maxBytes=logsize,
                                       backupCount=lognum)
-        handler.setFormatter(logging.Formatter(logformat))
+        handler.setFormatter(logging.Formatter(logformat, logdatefmt))
         root_logger.addHandler(handler)
 
     patroni = Patroni()

--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -142,9 +142,11 @@ def patroni_main():
     logdir = os.environ.get('PATRONI_FILE_LOG_DIR', None)
     logformat = os.environ.get('PATRONI_LOGFORMAT', '%(asctime)s %(levelname)s: %(message)s')
     loglevel = os.environ.get('PATRONI_LOGLEVEL', 'INFO')
+    logdatefmt = os.environ.get('PATRONI_LOGDATEFMT', '%Y-%m-%d %H:%M:%S')
 
     if not logdir:
-        logging.basicConfig(format=logformat, level=loglevel)
+        logging.basicConfig(format=logformat, level=loglevel,
+                            logdatefmt=logdatefmt)
     else:
         logsize = os.environ.get('PATRONI_FILE_LOG_SIZE', 25000000)
         lognum = os.environ.get('PATRONI_FILE_LOG_NUM', 4)


### PR DESCRIPTION
Guys, hi !
I've faced some issue with log date format in case of integration with Graylog. In some cases Graylog can not parse date with spaces.
So, i added new env variable `PATRONI_LOGDATEFMT` for configuration of logdatefmt.