### PR TITLE
Explicitly secure rw perms for recovery.conf at creation time

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1185,7 +1185,7 @@ class Postgresql(object):
         return not primary_conninfo
 
     def write_recovery_conf(self, recovery_params):
-        with open(self._recovery_conf, 'w') as f:
+        with open(os.open(self._recovery_conf, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600), 'w') as f:
             for name, value in recovery_params.items():
                 f.write("{0} = '{1}'\n".format(name, value))
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -5,6 +5,7 @@ import re
 import shlex
 import shutil
 import socket
+import stat
 import subprocess
 import tempfile
 import time
@@ -1185,7 +1186,8 @@ class Postgresql(object):
         return not primary_conninfo
 
     def write_recovery_conf(self, recovery_params):
-        with open(os.open(self._recovery_conf, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600), 'w') as f:
+        with open(self._recovery_conf, 'w') as f:
+            os.chmod(f.fileno(), stat.S_IWRITE | stat.S_IREAD)
             for name, value in recovery_params.items():
                 f.write("{0} = '{1}'\n".format(name, value))
 

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1187,7 +1187,7 @@ class Postgresql(object):
 
     def write_recovery_conf(self, recovery_params):
         with open(self._recovery_conf, 'w') as f:
-            os.chmod(f.fileno(), stat.S_IWRITE | stat.S_IREAD)
+            os.chmod(self._recovery_conf, stat.S_IWRITE | stat.S_IREAD)
             for name, value in recovery_params.items():
                 f.write("{0} = '{1}'\n".format(name, value))
 


### PR DESCRIPTION
During my testing of base deploys of PG with Patroni, I discovered the recovery.conf file to be world-readable despite containing the replication connection information. I believe it would be  a good idea to explicitly lock this file down at the time of creation since I believe it is a correct assumption that nobody but the user running patroni/postgres should need to read said file.

My initial approach was to use os.open() to set the file mode during creation. However, that approach was not compatible with python 2.7. Per python docs, os.chmod using `stat.S_IWRITE | stat.S_IREAD` should work across all platforms

~~O_CREAT O_TRUNC and O_WRONLY are listed as windows compatible.~~