### PR TITLE
Apply 5 second backoff when loading global config on start

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -50,6 +50,7 @@ class Patroni(object):
                 break
             except DCSError:
                 logger.warning('Can not get cluster from dcs')
+                time.sleep(5)
 
     def get_tags(self):
         return {tag: value for tag, value in self.config.get('tags', {}).items()


### PR DESCRIPTION
It doesn't make much sense to hammer DCS when we just starting up.
Fixes https://github.com/zalando/patroni/issues/919