### PR TITLE
Do not check types of standby_cluster configuration

### DIFF
--- a/patroni/config.py
+++ b/patroni/config.py
@@ -48,7 +48,7 @@ class Config(object):
         'synchronous_mode': False,
         'synchronous_mode_strict': False,
         'standby_cluster': {
-            'create_replica_methods': '',
+            'create_replica_methods': [],
             'host': '',
             'port': '',
             'primary_slot_name': '',
@@ -198,7 +198,9 @@ class Config(object):
                 allowed_keys = self.__DEFAULT_CONFIG['standby_cluster'].keys()
                 expected = {
                     k: v for k, v in (value or {}).items()
-                    if (k in allowed_keys and isinstance(v, six.string_types))
+                    if (k in allowed_keys and (
+                        isinstance(v, six.string_types) or
+                        isinstance(v, list)))
                 }
                 config['standby_cluster'].update(expected)
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overriden from DCS

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import shutil
-import six
 import sys
 import tempfile
 import yaml
@@ -48,7 +47,7 @@ class Config(object):
         'synchronous_mode': False,
         'synchronous_mode_strict': False,
         'standby_cluster': {
-            'create_replica_methods': [],
+            'create_replica_methods': '',
             'host': '',
             'port': '',
             'primary_slot_name': '',
@@ -195,24 +194,9 @@ class Config(object):
                     elif name not in ('connect_address', 'listen', 'data_dir', 'pgpass', 'authentication'):
                         config['postgresql'][name] = deepcopy(value)
             elif name == 'standby_cluster':
-                def type_is_valid(option, value):
-                    if option != 'create_replica_methods':
-                        return isinstance(value, six.string_types)
-
-                    # checks for create_replica_methods
-                    if isinstance(value, six.string_types):
-                        return True
-                    if (isinstance(value, list) and
-                            all(isinstance(v, six.string_types) for v in value)):
-                        return True
-
-                allowed_keys = self.__DEFAULT_CONFIG['standby_cluster'].keys()
-                expected = {
-                    k: v for k, v in (value or {}).items()
-                    if (k in allowed_keys and type_is_valid(k, v))
-                }
-
-                config['standby_cluster'].update(expected)
+                for name, value in (value or {}).items():
+                    if name in self.__DEFAULT_CONFIG['standby_cluster']:
+                        config['standby_cluster'][name] = deepcopy(value)
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overriden from DCS
                 if name in ('synchronous_mode', 'synchronous_mode_strict'):
                     config[name] = value

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -195,13 +195,23 @@ class Config(object):
                     elif name not in ('connect_address', 'listen', 'data_dir', 'pgpass', 'authentication'):
                         config['postgresql'][name] = deepcopy(value)
             elif name == 'standby_cluster':
+                def type_is_valid(option, value):
+                    if option != 'create_replica_methods':
+                        return isinstance(value, six.string_types)
+
+                    # checks for create_replica_methods
+                    if isinstance(value, six.string_types):
+                        return True
+                    if (isinstance(value, list) and
+                        all(isinstance(v, six.string_types) for v in value)):
+                        return True
+
                 allowed_keys = self.__DEFAULT_CONFIG['standby_cluster'].keys()
                 expected = {
                     k: v for k, v in (value or {}).items()
-                    if (k in allowed_keys and (
-                        isinstance(v, six.string_types) or
-                        isinstance(v, list)))
+                    if (k in allowed_keys and type_is_valid(k, v))
                 }
+
                 config['standby_cluster'].update(expected)
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overriden from DCS
                 if name in ('synchronous_mode', 'synchronous_mode_strict'):

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -203,7 +203,7 @@ class Config(object):
                     if isinstance(value, six.string_types):
                         return True
                     if (isinstance(value, list) and
-                        all(isinstance(v, six.string_types) for v in value)):
+                            all(isinstance(v, six.string_types) for v in value)):
                         return True
 
                 allowed_keys = self.__DEFAULT_CONFIG['standby_cluster'].keys()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,3 +84,22 @@ class TestConfig(unittest.TestCase):
             self.config.save_cache()
         with patch('os.fdopen', MagicMock()):
             self.config.save_cache()
+
+    def test_standby_cluster_parameters(self):
+        dynamic_configuration = {
+            'standby_cluster': {
+                'create_replica_methods': ['wal_e', 'basebackup'],
+                'host': '',
+                'port': '',
+                'primary_slot_name': '',
+                'restore_command': '',
+                'archive_cleanup_command': '',
+                'recovery_min_apply_delay': ''
+            }
+        }
+        config = self.config._safe_copy_dynamic_configuration(dynamic_configuration)
+        for k in dynamic_configuration['standby_cluster'].keys():
+            self.assertEqual(
+                config['standby_cluster'][k],
+                dynamic_configuration['standby_cluster'][k]
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,17 +89,10 @@ class TestConfig(unittest.TestCase):
         dynamic_configuration = {
             'standby_cluster': {
                 'create_replica_methods': ['wal_e', 'basebackup'],
-                'host': '',
-                'port': '',
-                'primary_slot_name': '',
-                'restore_command': '',
-                'archive_cleanup_command': '',
-                'recovery_min_apply_delay': ''
+                'host': 'localhost',
+                'port': 5432
             }
         }
-        config = self.config._safe_copy_dynamic_configuration(dynamic_configuration)
-        for k in dynamic_configuration['standby_cluster'].keys():
-            self.assertEqual(
-                config['standby_cluster'][k],
-                dynamic_configuration['standby_cluster'][k]
-            )
+        self.config.set_dynamic_configuration(dynamic_configuration)
+        for name, value in dynamic_configuration['standby_cluster'].items():
+            self.assertEqual(self.config['standby_cluster'][name], value)


### PR DESCRIPTION
In the original implementation of standby cluster all allowed properties
were checked if they're strings or not. But for `create_replica_methods`
it's wrong since it's a list, so this options is skipped. Fortunately,
if this options is not set, it will be taken from postgresql config section,
but this issue needs to be fixed anyway.