### PR TITLE
Redirect HTTPServer exceptions to logger (#900)

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -3,6 +3,7 @@ import json
 import logging
 import psycopg2
 import time
+import traceback
 import dateutil.parser
 import datetime
 import os
@@ -547,3 +548,9 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
                 and self.__initialize(config):
             self.start()
         self.__set_config_parameters(config)
+
+    @staticmethod
+    def handle_error(request, client_address):
+        address, port = client_address
+        logger.warning('Exception happened during processing of request from {}:{}'.format(address, port))
+        logger.warning(traceback.format_exc())


### PR DESCRIPTION
Using HAProxy, we have a lot of non-critical exceptions like `ConnectionResetError` on the HTTP API. By default, such exception is logged on standard output messing with regular logs. This commit overrides `handle_error` method of `HTTPServer` class to print the traceback to logger on debug level. It implements #900 and reduces messages of #857 and #393.