### PR TITLE
Single quotes are mandatory around each host in PATRONI_ETCD_HOSTS

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -42,7 +42,7 @@ Consul
 Etcd
 ----
 -  **PATRONI\_ETCD\_HOST**: the host:port for the etcd endpoint.
--  **PATRONI\_ETCD\_HOSTS**: list of etcd endpoints in format host1:port1,host2:port2,etc...
+-  **PATRONI\_ETCD\_HOSTS**: list of etcd endpoints in format 'host1:port1','host2:port2',etc...
 -  **PATRONI\_ETCD\_URL**: url for the etcd, in format: http(s)://(username:password@)host:port
 -  **PATRONI\_ETCD\_PROXY**: proxy url for the etcd. If you are connecting to the etcd using proxy, use this parameter instead of **PATRONI\_ETCD\_URL**
 -  **PATRONI\_ETCD\_SRV**: Domain to search the SRV record(s) for cluster autodiscovery.
@@ -81,7 +81,7 @@ PostgreSQL
 -  **PATRONI\_SUPERUSER\_PASSWORD**: password for the superuser, set during initialization (initdb).
 
 REST API
--------- 
+--------
 -  **PATRONI\_RESTAPI\_CONNECT\_ADDRESS**: IP address and port to access the REST API.
 -  **PATRONI\_RESTAPI\_LISTEN**: IP address and port that Patroni will listen to, to provide health-check information for HAProxy.
 -  **PATRONI\_RESTAPI\_USERNAME**: Basic-auth username to protect unsafe REST API endpoints.


### PR DESCRIPTION
I got confused by the documentation lacking the single quotes but zalando/patroni#843 helped me understand the issue. The error message from Patroni was rather unclear when missing the single quote:

```
2019-01-14 09:11:52.711087838 +0100 CET [postgresql-2] """)
2019-01-14 09:11:52.711083045 +0100 CET [postgresql-2] /usr/local/lib/python2.7/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: &lt;http://initd.org/psycopg/docs/install.html#binary-install-from-pypi&gt;.
2019-01-14 09:11:52.652506168 +0100 CET [postgresql-2] ----&gt; PostgreSQL version: postgres (PostgreSQL) 10.6 (Debian 10.6-1.pgdg90+1)
2019-01-14 09:11:52.881638308 +0100 CET [postgresql-2] return load(stream, SafeLoader)
2019-01-14 09:11:52.881639042 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/__init__.py", line 71, in load
2019-01-14 09:11:52.881639852 +0100 CET [postgresql-2] return loader.get_single_data()
2019-01-14 09:11:52.881680531 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/constructor.py", line 37, in get_single_data
2019-01-14 09:11:52.881636725 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/patroni/config.py", line 259, in _parse_list
2019-01-14 09:11:52.881637304 +0100 CET [postgresql-2] return yaml.safe_load(value)
2019-01-14 09:11:52.881637764 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/__init__.py", line 93, in safe_load
2019-01-14 09:11:52.881635940 +0100 CET [postgresql-2] Traceback (most recent call last):
2019-01-14 09:11:52.881631011 +0100 CET [postgresql-2] 2019-01-14 08:11:52,880 ERROR: Exception when parsing list [172.17.0.1:2381,172.17.0.1:2383]
2019-01-14 09:11:52.881682210 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/composer.py", line 35, in get_single_node
2019-01-14 09:11:52.881682813 +0100 CET [postgresql-2] if not self.check_event(StreamEndEvent):
2019-01-14 09:11:52.881699560 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/parser.py", line 98, in check_event
2019-01-14 09:11:52.881700462 +0100 CET [postgresql-2] self.current_event = self.state()
2019-01-14 09:11:52.881782884 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/parser.py", line 143, in parse_implicit_document_start
2019-01-14 09:11:52.881784379 +0100 CET [postgresql-2] StreamEndToken):
2019-01-14 09:11:52.881785090 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/scanner.py", line 116, in check_token
2019-01-14 09:11:52.881785692 +0100 CET [postgresql-2] self.fetch_more_tokens()
2019-01-14 09:11:52.881786219 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/scanner.py", line 252, in fetch_more_tokens
2019-01-14 09:11:52.881786774 +0100 CET [postgresql-2] return self.fetch_plain()
2019-01-14 09:11:52.881810306 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/scanner.py", line 676, in fetch_plain
2019-01-14 09:11:52.881811270 +0100 CET [postgresql-2] self.tokens.append(self.scan_plain())
2019-01-14 09:11:52.881853373 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/yaml/scanner.py", line 1305, in scan_plain
2019-01-14 09:11:52.881854787 +0100 CET [postgresql-2] "Please check http://pyyaml.org/wiki/YAMLColonInFlowContext for details.")
2019-01-14 09:11:52.881866620 +0100 CET [postgresql-2] ScannerError: while scanning a plain scalar
2019-01-14 09:11:52.881907305 +0100 CET [postgresql-2] [172.17.0.1:2381,172.17.0.1:2383]
2019-01-14 09:11:52.881867510 +0100 CET [postgresql-2] in "&lt;string&gt;", line 1, column 2:
2019-01-14 09:11:52.881909261 +0100 CET [postgresql-2] ^
2019-01-14 09:11:52.881910047 +0100 CET [postgresql-2] found unexpected ':'
2019-01-14 09:11:52.881912508 +0100 CET [postgresql-2] in "&lt;string&gt;", line 1, column 12:
2019-01-14 09:11:52.881950486 +0100 CET [postgresql-2] [172.17.0.1:2381,172.17.0.1:2383]
2019-01-14 09:11:52.881951904 +0100 CET [postgresql-2] Please check http://pyyaml.org/wiki/YAMLColonInFlowContext for details.
2019-01-14 09:11:52.881951488 +0100 CET [postgresql-2] ^
2019-01-14 09:11:52.900518363 +0100 CET [postgresql-2] 2019-01-14 08:11:52,900 INFO: Failed to import patroni.dcs.exhibitor
2019-01-14 09:11:52.889660244 +0100 CET [postgresql-2] 2019-01-14 08:11:52,889 INFO: Failed to import patroni.dcs.consul
2019-01-14 09:11:52.901120897 +0100 CET [postgresql-2] 2019-01-14 08:11:52,900 INFO: Failed to import patroni.dcs.kubernetes
2019-01-14 09:11:52.901452254 +0100 CET [postgresql-2] 2019-01-14 08:11:52,901 INFO: Failed to import patroni.dcs.zookeeper
2019-01-14 09:11:52.901601007 +0100 CET [postgresql-2] Traceback (most recent call last):
2019-01-14 09:11:52.901602904 +0100 CET [postgresql-2] File "/usr/local/bin/patroni", line 11, in &lt;module&gt;
2019-01-14 09:11:52.901603596 +0100 CET [postgresql-2] sys.exit(main())
2019-01-14 09:11:52.901604165 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/patroni/__init__.py", line 182, in main
2019-01-14 09:11:52.901604718 +0100 CET [postgresql-2] return patroni_main()
2019-01-14 09:11:52.901605260 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/patroni/__init__.py", line 147, in patroni_main
2019-01-14 09:11:52.901614565 +0100 CET [postgresql-2] patroni = Patroni()
2019-01-14 09:11:52.901616062 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/patroni/__init__.py", line 25, in __init__
2019-01-14 09:11:52.901657380 +0100 CET [postgresql-2] self.dcs = get_dcs(self.config)
2019-01-14 09:11:52.901708568 +0100 CET [postgresql-2] Available implementations: """ + ', '.join(available_implementations))
2019-01-14 09:11:52.901714027 +0100 CET [postgresql-2] patroni.exceptions.PatroniException: 'Can not find suitable configuration of distributed configuration store\nAvailable implementations: etcd'
2019-01-14 09:11:52.881681615 +0100 CET [postgresql-2] node = self.get_single_node()
2019-01-14 09:11:52.901658711 +0100 CET [postgresql-2] File "/usr/local/lib/python2.7/dist-packages/patroni/dcs/__init__.py", line 94, in get_dcs
```