### PR TITLE
Always use replication=1, otherwise it is considered a logical walsender

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1250,9 +1250,7 @@ class Postgresql(object):
 
     @contextmanager
     def _get_replication_connection_cursor(self, host='localhost', port=5432, database=None, **kwargs):
-        database = database or self._database
-        replication = 'database' if self._major_version >= 90400 else 1
-        with self._get_connection_cursor(host=host, port=int(port), database=database, replication=replication,
+        with self._get_connection_cursor(host=host, port=int(port), database=database or self._database, replication=1,
                                          user=self._replication['username'], password=self._replication['password'],
                                          connect_timeout=3, options='-c statement_timeout=2000') as cur:
             yield cur


### PR DESCRIPTION
Fixes: https://github.com/zalando/patroni/issues/894
Fixes: https://github.com/zalando/patroni/issues/951