### PR TITLE
Change base port for acceptance tests from 5440 to 5360

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -84,7 +84,7 @@ class AbstractController(object):
 
 
 class PatroniController(AbstractController):
-    __PORT = 5440
+    __PORT = 5340
     PATRONI_CONFIG = '{}.yml'
     """ starts and stops individual patronis"""
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -84,7 +84,7 @@ class AbstractController(object):
 
 
 class PatroniController(AbstractController):
-    __PORT = 5340
+    __PORT = 5360
     PATRONI_CONFIG = '{}.yml'
     """ starts and stops individual patronis"""
 


### PR DESCRIPTION
This allows for enough room in order not to interfere with any possibly running
host instances.  On Debian/Ubuntu, host instances get ports assigned starting
from 5432, so in the (rare but possible) case that 9 instances are running on
the host, the acceptance tests would fail to startup their instances.

Using 5340 as base port will allow for more than 90 instances to be created
during the acceptance tests, which should be plenty considering that currenlty
around 20-25 are created.