### PR TITLE
Copy away output directories of failed acceptance tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ script:
             echo Running acceptance tests using python${pv}
             if ! PATH=.:/usr/lib/postgresql/9.6/bin:$PATH $TEST_SUITE; then
                 # output all log files when tests are failing
-                grep . features/output/*/*postgres?.*
+                grep . features/output/*_failed/*postgres?.*
                 exit 1
             fi
         fi

--- a/features/environment.py
+++ b/features/environment.py
@@ -611,8 +611,6 @@ class PatroniPoolController(object):
         feature_dir = os.path.join(self.patroni_path, 'features/output', feature_name.replace(' ', '_'))
         if os.path.exists(feature_dir):
             shutil.rmtree(feature_dir)
-        if os.path.exists(feature_dir + '_failed'):
-            shutil.rmtree(feature_dir + '_failed')
         os.makedirs(feature_dir)
         self._output_dir = feature_dir
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -823,3 +823,5 @@ def after_feature(context, feature):
     context.pctl.stop_all()
     shutil.rmtree(os.path.join(context.pctl.patroni_path, 'data'))
     context.dcs_ctl.cleanup_service_tree()
+    if feature.status == 'failed':
+        shutil.copytree(context.pctl.output_dir, context.pctl.output_dir + "_failed")

--- a/features/environment.py
+++ b/features/environment.py
@@ -611,6 +611,8 @@ class PatroniPoolController(object):
         feature_dir = os.path.join(self.patroni_path, 'features/output', feature_name.replace(' ', '_'))
         if os.path.exists(feature_dir):
             shutil.rmtree(feature_dir)
+        if os.path.exists(feature_dir + '_failed'):
+            shutil.rmtree(feature_dir + '_failed')
         os.makedirs(feature_dir)
         self._output_dir = feature_dir
 
@@ -824,4 +826,4 @@ def after_feature(context, feature):
     shutil.rmtree(os.path.join(context.pctl.patroni_path, 'data'))
     context.dcs_ctl.cleanup_service_tree()
     if feature.status == 'failed':
-        shutil.copytree(context.pctl.output_dir, context.pctl.output_dir + "_failed")
+        shutil.copytree(context.pctl.output_dir, context.pctl.output_dir + '_failed')


### PR DESCRIPTION
This is a (crude) patch we carry in the Debian/Ubuntu packaging in order to output the content of failed acceptance tests on `ci.debian.net` as we don't have shell access to the test runners.

This might not be acceptable for the main Patroni project, but I thought I'd give it a shot. Is there maybe some other `behave` option that allows to dump the logs on failure directly that we should use? 

I believe Travis right now just dumps everything on failure, so this could make wading through Travis log easier as well.