### PR TITLE
Run coverage as python -m coverage

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -143,7 +143,6 @@ class PatroniController(AbstractController):
         if isinstance(self._context.dcs_ctl, KubernetesController):
             self._context.dcs_ctl.create_pod(self._name[8:], self._scope)
             os.environ['PATRONI_KUBERNETES_POD_IP'] = '10.0.0.' + self._name[-1]
-
         return subprocess.Popen([sys.executable, '-m', 'coverage', 'run',
                                 '--source=patroni', '-p', 'patroni.py', self._config],
                                 stdout=self._log, stderr=subprocess.STDOUT, cwd=self._work_directory)
@@ -812,7 +811,6 @@ def before_all(context):
 
 def after_all(context):
     context.dcs_ctl.stop()
-
     subprocess.call([sys.executable, '-m', 'coverage', 'combine'])
     subprocess.call([sys.executable, '-m', 'coverage', 'report'])
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,7 +1,6 @@
 import abc
 import consul
 import datetime
-import distutils.spawn
 import etcd
 import kazoo.client
 import kazoo.exceptions
@@ -13,6 +12,7 @@ import shutil
 import signal
 import six
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -144,11 +144,8 @@ class PatroniController(AbstractController):
             self._context.dcs_ctl.create_pod(self._name[8:], self._scope)
             os.environ['PATRONI_KUBERNETES_POD_IP'] = '10.0.0.' + self._name[-1]
 
-        COVERAGE_BIN = distutils.spawn.find_executable('coverage')
-        if not COVERAGE_BIN:
-            COVERAGE_BIN = distutils.spawn.find_executable('python3-coverage')
-
-        return subprocess.Popen([COVERAGE_BIN, 'run', '--source=patroni', '-p', 'patroni.py', self._config],
+        return subprocess.Popen([sys.executable, '-m', 'coverage', 'run',
+                                '--source=patroni', '-p', 'patroni.py', self._config],
                                 stdout=self._log, stderr=subprocess.STDOUT, cwd=self._work_directory)
 
     def stop(self, kill=False, timeout=15, postgres=False):
@@ -816,12 +813,8 @@ def before_all(context):
 def after_all(context):
     context.dcs_ctl.stop()
 
-    COVERAGE_BIN = distutils.spawn.find_executable('coverage')
-    if not COVERAGE_BIN:
-        COVERAGE_BIN = distutils.spawn.find_executable('python3-coverage')
-
-    subprocess.call([COVERAGE_BIN, 'combine'])
-    subprocess.call([COVERAGE_BIN, 'report'])
+    subprocess.call([sys.executable, '-m', 'coverage', 'combine'])
+    subprocess.call([sys.executable, '-m', 'coverage', 'report'])
 
 
 def before_feature(context, feature):

--- a/features/environment.py
+++ b/features/environment.py
@@ -142,7 +142,12 @@ class PatroniController(AbstractController):
         if isinstance(self._context.dcs_ctl, KubernetesController):
             self._context.dcs_ctl.create_pod(self._name[8:], self._scope)
             os.environ['PATRONI_KUBERNETES_POD_IP'] = '10.0.0.' + self._name[-1]
-        return subprocess.Popen(['coverage', 'run', '--source=patroni', '-p', 'patroni.py', self._config],
+
+        COVERAGE_BIN=shutil.which('coverage')
+        if not COVERAGE_BIN:
+            COVERAGE_BIN=shutil.which('python3-coverage')
+
+        return subprocess.Popen([COVERAGE_BIN, 'run', '--source=patroni', '-p', 'patroni.py', self._config],
                                 stdout=self._log, stderr=subprocess.STDOUT, cwd=self._work_directory)
 
     def stop(self, kill=False, timeout=15, postgres=False):
@@ -809,8 +814,13 @@ def before_all(context):
 
 def after_all(context):
     context.dcs_ctl.stop()
-    subprocess.call(['coverage', 'combine'])
-    subprocess.call(['coverage', 'report'])
+
+    COVERAGE_BIN=shutil.which('coverage')
+    if not COVERAGE_BIN:
+        COVERAGE_BIN=shutil.which('python3-coverage')
+
+    subprocess.call([COVERAGE_BIN, 'combine'])
+    subprocess.call([COVERAGE_BIN, 'report'])
 
 
 def before_feature(context, feature):

--- a/features/steps/patroni_api.py
+++ b/features/steps/patroni_api.py
@@ -1,10 +1,10 @@
 import base64
+import distutils.spawn
 import json
 import os
 import parse
 import requests
 import shlex
-import shutil
 import subprocess
 import time
 import yaml
@@ -96,9 +96,9 @@ def do_request(context, request_method, url, data):
 
 @step('I run {cmd}')
 def do_run(context, cmd):
-    COVERAGE_BIN=shutil.which('coverage')
+    COVERAGE_BIN = distutils.spawn.find_executable('coverage')
     if not COVERAGE_BIN:
-        COVERAGE_BIN=shutil.which('python3-coverage')
+        COVERAGE_BIN = distutils.spawn.find_executable('python3-coverage')
 
     cmd = [COVERAGE_BIN, 'run', '--source=patroni', '-p'] + shlex.split(cmd)
     try:

--- a/features/steps/patroni_api.py
+++ b/features/steps/patroni_api.py
@@ -1,11 +1,11 @@
 import base64
-import distutils.spawn
 import json
 import os
 import parse
 import requests
 import shlex
 import subprocess
+import sys
 import time
 import yaml
 
@@ -96,11 +96,8 @@ def do_request(context, request_method, url, data):
 
 @step('I run {cmd}')
 def do_run(context, cmd):
-    COVERAGE_BIN = distutils.spawn.find_executable('coverage')
-    if not COVERAGE_BIN:
-        COVERAGE_BIN = distutils.spawn.find_executable('python3-coverage')
 
-    cmd = [COVERAGE_BIN, 'run', '--source=patroni', '-p'] + shlex.split(cmd)
+    cmd = [sys.executable, '-m', 'coverage', 'run', '--source=patroni', '-p'] + shlex.split(cmd)
     try:
         # XXX: Dirty hack! We need to take name/passwd from the config!
         env = os.environ.copy()

--- a/features/steps/patroni_api.py
+++ b/features/steps/patroni_api.py
@@ -4,6 +4,7 @@ import os
 import parse
 import requests
 import shlex
+import shutil
 import subprocess
 import time
 import yaml
@@ -95,7 +96,11 @@ def do_request(context, request_method, url, data):
 
 @step('I run {cmd}')
 def do_run(context, cmd):
-    cmd = ['coverage', 'run', '--source=patroni', '-p'] + shlex.split(cmd)
+    COVERAGE_BIN=shutil.which('coverage')
+    if not COVERAGE_BIN:
+        COVERAGE_BIN=shutil.which('python3-coverage')
+
+    cmd = [COVERAGE_BIN, 'run', '--source=patroni', '-p'] + shlex.split(cmd)
     try:
         # XXX: Dirty hack! We need to take name/passwd from the config!
         env = os.environ.copy()

--- a/features/steps/patroni_api.py
+++ b/features/steps/patroni_api.py
@@ -96,7 +96,6 @@ def do_request(context, request_method, url, data):
 
 @step('I run {cmd}')
 def do_run(context, cmd):
-
     cmd = [sys.executable, '-m', 'coverage', 'run', '--source=patroni', '-p'] + shlex.split(cmd)
     try:
         # XXX: Dirty hack! We need to take name/passwd from the config!


### PR DESCRIPTION
On Debian/Ubuntu, there is no `/usr/bin/coverage` binary, it is called
`/usr/bin/python3-coverage`.  In order to handle both, check which one is
available and use the `COVERAGE_BIN` variable in order to run that.