### PR TITLE
Honor remove_data_directory_on_rewind_failure if pg_rewind can't be used

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -954,7 +954,7 @@ class Postgresql(object):
                 return cur.execute('CHECKPOINT')
         except psycopg2.Error as e:
             logger.exception('Exception during CHECKPOINT')
-            if str(e).strip()  == 'fe_sendauth: no password supplied':
+            if str(e).strip() == 'fe_sendauth: no password supplied':
                 return 'no password'
             else:
                 return 'not accessible or not healty'


### PR DESCRIPTION
If the checkpoint prior to running `pg_rewind` cannot be issued (e.g. because no password is set for `postgres`), still honor `remove_data_directory_on_rewind_failure` and re-clone from the primary instead of giving up.

This results in the following log:

```
Feb 08 16:30:09 pg2 patroni[8671]: 2019-02-08 16:30:09,991 INFO: running pg_rewind from pg1
Feb 08 16:30:15 pg2 patroni[8671]: 2019-02-08 16:30:15,061 ERROR: Exception during CHECKPOINT
Feb 08 16:30:15 pg2 patroni[8671]: Traceback (most recent call last):
Feb 08 16:30:15 pg2 patroni[8671]:   File "/usr/lib/python3/dist-packages/patroni/postgresql.py", line 948, in checkpoint
Feb 08 16:30:15 pg2 patroni[8671]:     with self._get_connection_cursor(**connect_kwargs) as cur:
Feb 08 16:30:15 pg2 patroni[8671]:   File "/usr/lib/python3.7/contextlib.py", line 112, in __enter__
Feb 08 16:30:15 pg2 patroni[8671]:     return next(self.gen)
Feb 08 16:30:15 pg2 patroni[8671]:   File "/usr/lib/python3/dist-packages/patroni/postgresql.py", line 1250, in _get_connection_cursor
Feb 08 16:30:15 pg2 patroni[8671]:     with psycopg2.connect(**kwargs) as conn:
Feb 08 16:30:15 pg2 patroni[8671]:   File "/usr/lib/python3/dist-packages/psycopg2/__init__.py", line 130, in connect
Feb 08 16:30:15 pg2 patroni[8671]:     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
Feb 08 16:30:15 pg2 patroni[8671]: psycopg2.OperationalError: fe_sendauth: no password supplied
Feb 08 16:30:15 pg2 patroni[8671]: 2019-02-08 16:30:15,064 WARNING: Can not use pg1 for rewind: not accessible or not healty
Feb 08 16:30:15 pg2 patroni[8671]: 2019-02-08 16:30:15,064 WARNING: remove_data_directory_on_rewind_failure is set. removing...
Feb 08 16:30:15 pg2 patroni[8671]: 2019-02-08 16:30:15,064 INFO: Removing data directory: /var/lib/postgresql/11/test
Feb 08 16:30:15 pg2 patroni[8671]: 2019-02-08 16:30:15,102 INFO: Lock owner: pg1; I am pg2
Feb 08 16:30:15 pg2 patroni[8671]: 2019-02-08 16:30:15,104 INFO: trying to bootstrap from leader 'pg1'
```

instead of:

```
Feb 08 15:55:09 pg3 patroni[9315]: 2019-02-08 15:55:09,632 INFO: running pg_rewind from pg1
Feb 08 15:55:09 pg3 patroni[9315]: 2019-02-08 15:55:09,636 ERROR: Exception during CHECKPOINT
Feb 08 15:55:09 pg3 patroni[9315]: Traceback (most recent call last):
Feb 08 15:55:09 pg3 patroni[9315]:   File "/usr/lib/python3/dist-packages/patroni/postgresql.py", line 948, in checkpoint
Feb 08 15:55:09 pg3 patroni[9315]:     with self._get_connection_cursor(**connect_kwargs) as cur:
Feb 08 15:55:09 pg3 patroni[9315]:   File "/usr/lib/python3.7/contextlib.py", line 112, in __enter__
Feb 08 15:55:09 pg3 patroni[9315]:     return next(self.gen)
Feb 08 15:55:09 pg3 patroni[9315]:   File "/usr/lib/python3/dist-packages/patroni/postgresql.py", line 1250, in _get_connection_cursor
Feb 08 15:55:09 pg3 patroni[9315]:     with psycopg2.connect(**kwargs) as conn:
Feb 08 15:55:09 pg3 patroni[9315]:   File "/usr/lib/python3/dist-packages/psycopg2/__init__.py", line 130, in connect
Feb 08 15:55:09 pg3 patroni[9315]:     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
Feb 08 15:55:09 pg3 patroni[9315]: psycopg2.OperationalError: fe_sendauth: no password supplied
Feb 08 15:55:09 pg3 patroni[9315]: 2019-02-08 15:55:09,636 WARNING: Can not use pg1 for rewind: not accessible or not healty
```

and a cluster member in an unrecoverable state.