### PR TITLE
Wait for callback end if it could not be killed

### DIFF
--- a/patroni/callback_executor.py
+++ b/patroni/callback_executor.py
@@ -19,8 +19,13 @@ class CallbackExecutor(Thread):
     def call(self, cmd):
         with self._lock:
             if self._process and self._process.poll() is None:
-                self._process.kill()
-                logger.warning('Killed the old callback process because it was still running: %s', self._cmd)
+                try:
+                    self._process.kill()
+                    logger.warning('Killed the old callback process because it was still running: %s', self._cmd)
+                except OSError:
+                    logger.exception('Failed to kill the old callback')
+                    logger.warning('Wait until callback end')
+                    self._process.wait()
         self._cmd = cmd
         self._callback_event.set()
 


### PR DESCRIPTION
Hi,

We plan to use patroni callbacks to setup a virtual IP on the master node according to its current role. The callback script is called with `sudo`. It seems to work fine unless when the callback script takes a long time to run, we can see this backtrace when patroni is started :
```
Traceback (most recent call last):
  File "/opt/patroni/lib/python2.7/site-packages/patroni/postgresql.py", line 793, in call_nowait
    self._callback_executor.call(cmd)
  File "/opt/patroni/lib/python2.7/site-packages/patroni/callback_executor.py", line 22, in call
    self._process.kill()
  File "/usr/lib64/python2.7/subprocess.py", line 1556, in kill
    self.send_signal(signal.SIGKILL)
  File "/usr/lib64/python2.7/subprocess.py", line 1546, in send_signal
    os.kill(self.pid, sig)
OSError: [Errno 1] Operation not permitted
```

This is a totally normal behavior as long as the callback script is ran with `sudo` privileges, so the child process can't be killed. But, in this case, `call()` method of `CallbackExecutor` is aborted because this exception is not caught, and finally, the callback is not recalled further making our VIP not setup.

This PR fixed it.