### PR TITLE
Replace self-execute with multiprocessing.Process

### DIFF
--- a/patroni/postmaster.py
+++ b/patroni/postmaster.py
@@ -19,7 +19,7 @@ def pg_ctl_start(conn, cmdline, env):
     if os.name != 'nt':
         os.setsid()
     try:
-        postmaster = subprocess.Popen(cmdline, env=env)
+        postmaster = subprocess.Popen(cmdline, close_fds=True, env=env)
         conn.send(postmaster.pid)
     except Exception:
         logger.exception('Failed to execute %s', cmdline)
@@ -170,7 +170,7 @@ class PostmasterProcess(psutil.Process):
             pass
         cmdline = [pgcommand, '-D', data_dir, '--config-file={}'.format(conf)] + options
         logger.debug("Starting postgres: %s", " ".join(cmdline))
-        parent_conn, child_conn = multiprocessing.Pipe()
+        parent_conn, child_conn = multiprocessing.Pipe(False)
         proc = multiprocessing.Process(target=pg_ctl_start, args=(child_conn, cmdline, env))
         proc.start()
         pid = parent_conn.recv()

--- a/patroni/postmaster.py
+++ b/patroni/postmaster.py
@@ -1,11 +1,10 @@
 import logging
+import multiprocessing
 import os
 import psutil
 import re
 import signal
 import subprocess
-
-from patroni import call_self
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +13,18 @@ STOP_SIGNALS = {
     'fast': signal.SIGINT,
     'immediate': signal.SIGQUIT if os.name != 'nt' else signal.SIGABRT,
 }
+
+
+def pg_ctl_start(conn, cmdline, env):
+    if os.name != 'nt':
+        os.setsid()
+    try:
+        postmaster = subprocess.Popen(cmdline, env=env)
+        conn.send(postmaster.pid)
+    except Exception:
+        logger.exception('Failed to execute %s', cmdline)
+        conn.send(None)
+    conn.close()
 
 
 class PostmasterProcess(psutil.Process):
@@ -159,10 +170,13 @@ class PostmasterProcess(psutil.Process):
             pass
         cmdline = [pgcommand, '-D', data_dir, '--config-file={}'.format(conf)] + options
         logger.debug("Starting postgres: %s", " ".join(cmdline))
-        proc = call_self(['pg_ctl_start'] + cmdline, close_fds=(os.name != 'nt'),
-                         stdout=subprocess.PIPE, env=env)
-        pid = int(proc.stdout.readline().strip())
-        proc.wait()
+        parent_conn, child_conn = multiprocessing.Pipe()
+        proc = multiprocessing.Process(target=pg_ctl_start, args=(child_conn, cmdline, env))
+        proc.start()
+        pid = parent_conn.recv()
+        proc.join()
+        if pid is None:
+            return
         logger.info('postmaster pid=%s', pid)
 
         # TODO: In an extremely unlikely case, the process could have exited and the pid reassigned. The start

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -67,15 +67,11 @@ class TestPatroni(unittest.TestCase):
                     patroni_main()
 
     @patch('os.getpid')
-    @patch('subprocess.Popen', )
+    @patch('multiprocessing.Process')
     @patch('patroni.patroni_main', Mock())
-    def test_patroni_main(self, mock_popen, mock_getpid):
+    def test_patroni_main(self, mock_process, mock_getpid):
         mock_getpid.return_value = 2
         _main()
-
-        with patch('sys.frozen', Mock(return_value=True), create=True), patch('os.setsid', Mock()):
-            sys.argv = ['/patroni', 'pg_ctl_start', 'postgres', '-D', '/data', '--max_connections=100']
-            _main()
 
         mock_getpid.return_value = 1
 
@@ -94,10 +90,10 @@ class TestPatroni(unittest.TestCase):
             if signo == signal.SIGHUP:
                 ref['passtochild'] = handler
 
-        def mock_wait():
+        def mock_join():
             ref['passtochild'](0, None)
 
-        mock_popen.return_value.wait = mock_wait
+        mock_process.return_value.join = mock_join
         with patch('signal.signal', mock_sighup), patch('os.kill', Mock()):
             self.assertIsNone(_main())
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -632,7 +632,7 @@ class TestPostgresql(unittest.TestCase):
         self.assertFalse(self.p.bootstrap(config))
 
         mock_cancellable_subprocess_call.return_value = 0
-        with patch('subprocess.Popen', Mock(side_effect=Exception("42"))),\
+        with patch('multiprocessing.Process', Mock(side_effect=Exception("42"))),\
                 patch('os.path.isfile', Mock(return_value=True)),\
                 patch('os.unlink', Mock()),\
                 patch.object(Postgresql, 'save_configuration_files', Mock()),\

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -87,12 +87,15 @@ class TestPostmasterProcess(unittest.TestCase):
     def test_start(self, mock_frompidfile, mock_frompid, mock_popen):
         mock_frompidfile.return_value._is_postmaster_process.return_value = False
         mock_frompid.return_value = "proc 123"
-        mock_popen.return_value.stdout.readline.return_value = '123'
+        mock_popen.return_value.pid = 123
         self.assertEqual(PostmasterProcess.start('true', '/tmp', '/tmp/test.conf', []), "proc 123")
         mock_frompid.assert_called_with(123)
 
         mock_frompidfile.side_effect = psutil.NoSuchProcess(123)
         self.assertEqual(PostmasterProcess.start('true', '/tmp', '/tmp/test.conf', []), "proc 123")
+
+        mock_popen.side_effect = Exception
+        self.assertIsNone(PostmasterProcess.start('true', '/tmp', '/tmp/test.conf', []))
 
     @patch('psutil.Process.__init__', Mock(side_effect=psutil.NoSuchProcess(123)))
     def test_read_postmaster_pidfile(self):


### PR DESCRIPTION
In addition to that transfer postmaster pid to Patroni process with the help of multiprocessing.Pipe instead of using stdin-stdout pipes.

Closes https://github.com/zalando/patroni/issues/992