### PR TITLE
Remove unnecessary usage of relpath

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -299,7 +299,7 @@ class Consul(AbstractDCS):
             nodes = {}
             for node in results:
                 node['Value'] = (node['Value'] or b'').decode('utf-8')
-                nodes[os.path.relpath(node['Key'], path).replace('\\', '/')] = node
+                nodes[node['Key'][len(path):].lstrip('/')] = node
 
             # get initialize flag
             initialize = nodes.get(self._INITIALIZE)

--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -448,7 +448,7 @@ class Etcd(AbstractDCS):
     def _load_cluster(self):
         try:
             result = self.retry(self._client.read, self.client_path(''), recursive=True)
-            nodes = {os.path.relpath(node.key, result.key).replace('\\', '/'): node for node in result.leaves}
+            nodes = {node.key[len(result.key):].lstrip('/'): node for node in result.leaves}
 
             # get initialize flag
             initialize = nodes.get(self._INITIALIZE)


### PR DESCRIPTION
os.path.relpath depends on being able to resolve the working directory.
This will fail if Patroni is started in a directory that is later
unlinked from the filesystem, creating an unnecessary exception when
loading from DCS.