### PR TITLE
Enabling kerberos support

### DIFF
--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1264,15 +1264,10 @@ class Postgresql(object):
 
     @contextmanager
     def _get_replication_connection_cursor(self, host='localhost', port=5432, database=None, **kwargs):
-        if self._replication.get('username', None) and self._replication.get('password', None):
-            with self._get_connection_cursor(host=host, port=int(port), database=database or self._database, replication=1,
-                                             user=self._replication['username'], password=self._replication['password'],
-                                             connect_timeout=3, options='-c statement_timeout=2000') as cur:
-                yield cur
-        else:
-            with self._get_connection_cursor(host=host, port=int(port), database=database or self._database, replication=1,
-                                             connect_timeout=3, options='-c statement_timeout=2000') as cur:
-                yield cur
+        with self._get_connection_cursor(host=host, port=int(port), database=database or self._database, replication=1,
+                                         user=self._replication['username'], password=self._replication.get('password'),
+                                         connect_timeout=3, options='-c statement_timeout=2000') as cur:
+            yield cur
 
     def check_leader_is_not_in_recovery(self, **kwargs):
         try:

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1550,17 +1550,16 @@ class Postgresql(object):
             params.extend([password, password])
 
         sql = """DO $$
-            BEGIN
-                SET local synchronous_commit = 'local';
-                PERFORM * FROM pg_authid WHERE rolname = %s;
-                IF FOUND THEN
-                    ALTER ROLE "{0}" WITH {1};
-                ELSE
-                    CREATE ROLE "{0}" WITH {1};
-                END IF;
-            END;
-            $$""".format(name, ' '.join(options))
-            self.query(sql, *params)
+BEGIN
+    SET local synchronous_commit = 'local';
+    PERFORM * FROM pg_authid WHERE rolname = %s;
+    IF FOUND THEN
+        ALTER ROLE "{0}" WITH {1};
+    ELSE
+        CREATE ROLE "{0}" WITH {1};
+    END IF;
+END;$$""".format(name, ' '.join(options))
+        self.query(sql, *params)
 
     def timeline_wal_position(self):
         # This method could be called from different threads (simultaneously with some other `_query` calls).

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1189,7 +1189,7 @@ class Postgresql(object):
             return None
         r = member.conn_kwargs(self._replication)
         r.update(application_name=self.name, sslmode='prefer', sslcompression='1', krbsrvname=self._krbsrvname)
-        keywords = 'host port sslmode sslcompression application_name krbsrvname'.split()
+        keywords = 'user password host port sslmode sslcompression application_name krbsrvname'.split()
         return ' '.join('{0}={{{0}}}'.format(kw) for kw in keywords if r.get(kw)).format(**r)
 
     def check_recovery_conf(self, member):

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -35,6 +35,9 @@ bootstrap:
       #primary_slot_name: patroni
     postgresql:
       use_pg_rewind: true
+      # Fully qualified kerberos ticket file for the running user
+      # same as KRB5CCNAME used by the GSS
+#     krb_server_keyfile: /var/spool/ketabs/postgres
 #      use_slots: true
       parameters:
 #        wal_level: hot_standby
@@ -71,6 +74,8 @@ bootstrap:
         - createdb
 
 postgresql:
+  # Server side kerberos spn
+#  krbsrvname: postgres
   listen: 127.0.0.1:5432
   connect_address: 127.0.0.1:5432
   data_dir: data/postgresql0

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -58,6 +58,9 @@ bootstrap:
   - data-checksums
 
   pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
+  # For kerberos gss based connectivity (discard @.*$)
+  #- host replication replicator 127.0.0.1/32 gss include_realm=0
+  #- host all all 0.0.0.0/0 gss include_realm=0
   - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
 #  - hostssl all all 0.0.0.0/0 md5

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -35,9 +35,6 @@ bootstrap:
       #primary_slot_name: patroni
     postgresql:
       use_pg_rewind: true
-      # Fully qualified kerberos ticket file for the running user
-      # same as KRB5CCNAME used by the GSS
-#     krb_server_keyfile: /var/spool/ketabs/postgres
 #      use_slots: true
       parameters:
 #        wal_level: hot_standby
@@ -77,6 +74,10 @@ bootstrap:
         - createdb
 
 postgresql:
+  # Fully qualified kerberos ticket file for the running user
+  # same as KRB5CCNAME used by the GSS
+#  krb_server_keyfile: /var/spool/keytabs/postgres
+
   # Server side kerberos spn
 #  krbsrvname: postgres
   listen: 127.0.0.1:5432

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -31,9 +31,6 @@ bootstrap:
       use_pg_rewind: true
 #      use_slots: true
       parameters:
-        # Fully qualified kerberos ticket file for the running user
-        # same as KRB5CCNAME used by the GSS
-#        krb_server_keyfile: /var/spool/ketabs/postgres
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
@@ -71,6 +68,10 @@ bootstrap:
         - createdb
 
 postgresql:
+  # Fully qualified kerberos ticket file for the running user
+  # same as KRB5CCNAME used by the GSS
+#  krb_server_keyfile: /var/spool/keytabs/postgres
+
   # Server side kerberos spn
 #  krbsrvname: postgres
   listen: 127.0.0.1:5433

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -31,6 +31,9 @@ bootstrap:
       use_pg_rewind: true
 #      use_slots: true
       parameters:
+        # Fully qualified kerberos ticket file for the running user
+        # same as KRB5CCNAME used by the GSS
+#        krb_server_keyfile: /var/spool/ketabs/postgres
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
@@ -65,6 +68,8 @@ bootstrap:
         - createdb
 
 postgresql:
+  # Server side kerberos spn
+#  krbsrvname: postgres
   listen: 127.0.0.1:5433
   connect_address: 127.0.0.1:5433
   data_dir: data/postgresql1

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -52,6 +52,9 @@ bootstrap:
   - data-checksums
 
   pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
+  # For kerberos gss based connectivity (discard @.*$)
+  #- host replication replicator 127.0.0.1/32 gss include_realm=0
+  #- host all all 0.0.0.0/0 gss include_realm=0
   - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
 #  - hostssl all all 0.0.0.0/0 md5

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -31,6 +31,9 @@ bootstrap:
       use_pg_rewind: true
 #      use_slots: true
       parameters:
+        # Fully qualified kerberos ticket file for the running user
+        # same as KRB5CCNAME used by the GSS
+#        krb_server_keyfile: /var/spool/ketabs/postgres
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
@@ -62,6 +65,8 @@ bootstrap:
         - createdb
 
 postgresql:
+  # Server side kerberos spn
+#  krbsrvname: postgres
   listen: 127.0.0.1:5434
   connect_address: 127.0.0.1:5434
   data_dir: data/postgresql2

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -31,9 +31,6 @@ bootstrap:
       use_pg_rewind: true
 #      use_slots: true
       parameters:
-        # Fully qualified kerberos ticket file for the running user
-        # same as KRB5CCNAME used by the GSS
-#        krb_server_keyfile: /var/spool/ketabs/postgres
 #        wal_level: hot_standby
 #        hot_standby: "on"
 #        wal_keep_segments: 8
@@ -68,6 +65,10 @@ bootstrap:
         - createdb
 
 postgresql:
+  # Fully qualified kerberos ticket file for the running user
+  # same as KRB5CCNAME used by the GSS
+#  krb_server_keyfile: /var/spool/keytabs/postgres
+
   # Server side kerberos spn
 #  krbsrvname: postgres
   listen: 127.0.0.1:5434

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -52,6 +52,9 @@ bootstrap:
   - data-checksums
 
   pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
+  # For kerberos gss based connectivity (discard @.*$)
+  #- host replication replicator 127.0.0.1/32 gss include_realm=0
+  #- host all all 0.0.0.0/0 gss include_realm=0
   - host replication replicator 127.0.0.1/32 md5
   - host all all 0.0.0.0/0 md5
 #  - hostssl all all 0.0.0.0/0 md5


### PR DESCRIPTION
If config file has user (super, replication and others) but with no passwords, assume these are for kerberos (gss) access.
User will be created without passwords.
Connect will require the kerberos spn and kerberos key file.