### PR TITLE
Reload Consul config on SIGHUP

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -122,7 +122,7 @@ class ConsulClient(base.Consul):
     def __init__(self, *args, **kwargs):
         self._cert = kwargs.pop('cert', None)
         self._ca_cert = kwargs.pop('ca_cert', None)
-        self._token = kwargs.get('token')
+        self.token = kwargs.get('token')
         super(ConsulClient, self).__init__(*args, **kwargs)
 
     def connect(self, *args, **kwargs):
@@ -136,8 +136,9 @@ class ConsulClient(base.Consul):
         return HTTPClient(**kwargs)
 
     def set_token(self, token):
-        self._token = token
-        self._client.http.token = self._token
+        if token:
+            self.token = token
+            self.http.token = self.token
 
 def catch_consul_errors(func):
     def wrapper(*args, **kwargs):
@@ -236,9 +237,7 @@ class Consul(AbstractDCS):
                 time.sleep(5)
 
     def reload_config(self, config):
-        if config['token']:
-            self._client.set_token(config['token'])
-
+        self._client.set_token(config.get('token'))
         super(Consul, self).reload_config(config)
 
     def set_ttl(self, ttl):

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -232,6 +232,9 @@ class Consul(AbstractDCS):
                 logger.info('waiting on consul')
                 time.sleep(5)
 
+    def reload_config(self, config):
+        self.token = config['token']
+
     def set_ttl(self, ttl):
         if self._client.http.set_ttl(ttl/2.0):  # Consul multiplies the TTL by 2x
             self._session = None

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -237,7 +237,10 @@ class Consul(AbstractDCS):
                 time.sleep(5)
 
     def reload_config(self, config):
-        self._client.set_token(config.get('token'))
+        consul = config.get('consul')
+        if consul:
+            self._client.set_token(consul.get('token'))
+
         super(Consul, self).reload_config(config)
 
     def set_ttl(self, ttl):

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -135,6 +135,9 @@ class ConsulClient(base.Consul):
             kwargs['token'] = self._token
         return HTTPClient(**kwargs)
 
+    def set_token(self, token):
+        self._token = token
+        self._client.http.token = self._token
 
 def catch_consul_errors(func):
     def wrapper(*args, **kwargs):
@@ -233,7 +236,10 @@ class Consul(AbstractDCS):
                 time.sleep(5)
 
     def reload_config(self, config):
-        self.token = config['token']
+        if config['token']:
+            self._client.set_token(config['token'])
+
+        super(Consul, self).reload_config(config)
 
     def set_ttl(self, ttl):
         if self._client.http.set_ttl(ttl/2.0):  # Consul multiplies the TTL by 2x

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -131,14 +131,14 @@ class ConsulClient(base.Consul):
             kwargs['cert'] = self._cert
         if self._ca_cert:
             kwargs['ca_cert'] = self._ca_cert
-        if self._token:
-            kwargs['token'] = self._token
+        if self.token:
+            kwargs['token'] = self.token
         return HTTPClient(**kwargs)
 
     def set_token(self, token):
-        if token:
-            self.token = token
-            self.http.token = self.token
+        self.token = token
+        self.http.token = self.token
+
 
 def catch_consul_errors(func):
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
This isn't necessarily complete, I just haven't written much Python and wanted to submit this so devs can point out early if I'm in the wrong place.

Aim is to reload the [Consul-specific config](https://patroni.readthedocs.io/en/latest/SETTINGS.html#consul) on SIGHUP.

I can't think of a realistic use case for changing the Consul server addr or DC as an on-the-fly thing. Seems to me like if you're changing that, it's probably bigger surgery than just regenerating config and sending a reload signal.

Right now this PR only addresses the `token` property but if the devs want me to cover any other uses cases, let me know. I'm also not sure if I need to call `super(Consul, self).reload_config(config)` or do something similar