### PR TITLE
fixed error "cannot deletecollection endpoints in the namespace..." b…

### DIFF
--- a/kubernetes/patroni_k8s.yaml
+++ b/kubernetes/patroni_k8s.yaml
@@ -159,8 +159,9 @@ rules:
   - patch
   - update
   - watch
-  # delete is required only for 'patronictl remove'
+  # delete and deletecollection are required only for 'patronictl remove'
   - delete
+  - deletecollection
 - apiGroups:
   - ""
   resources:
@@ -173,8 +174,9 @@ rules:
   - create
   - list
   - watch
-  # delete is required only for for 'patronictl remove'
+  # delete and deletecollection are required only for for 'patronictl remove'
   - delete
+  - deletecollection
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
…y adding verb "deletecollection"

This fixes: https://github.com/zalando/patroni/issues/1032

````
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"endpoints is forbidden: User "system:serviceaccount:XXXXX:postgresmaster" cannot deletecollection endpoints in the namespace "XXXXXX"","reason":"Forbidden","details":{"kind":"endpoints"},"code":403}
````

by adding missing verb 'deletecollection' to resources "configmaps" and "endpoints"