### PR TITLE
Don't wait until the previous callback finish is kill failed

### DIFF
--- a/patroni/callback_executor.py
+++ b/patroni/callback_executor.py
@@ -24,8 +24,6 @@ class CallbackExecutor(Thread):
                     logger.warning('Killed the old callback process because it was still running: %s', self._cmd)
                 except OSError:
                     logger.exception('Failed to kill the old callback')
-                    logger.warning('Wait until callback end')
-                    self._process.wait()
         self._cmd = cmd
         self._callback_event.set()
 

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -18,7 +18,7 @@ class TestCallbackExecutor(unittest.TestCase):
         self.assertIsNone(ce.call([]))
 
         mock_popen.return_value.kill.side_effect = OSError
-        self.assertRaises(Exception, ce.call, [])
+        self.assertIsNone(ce.call([]))
 
         mock_popen.side_effect = Exception
         ce = CallbackExecutor()


### PR DESCRIPTION
Such wait was happening in the main thread and blocking HA loop.