### PR TITLE
Use SSLContext to wrap REST API socket

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -542,7 +542,9 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
         # Sometime it's also needed to pass reference to a 'keyfile'.
         if self.__ssl_options.get('certfile'):
             import ssl
-            self.socket = ssl.wrap_socket(self.socket, server_side=True, **self.__ssl_options)
+            ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ctx.load_cert_chain(**self.__ssl_options)
+            self.socket = ctx.wrap_socket(self.socket, server_side=True)
             self.__protocol = 'https'
         return True
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,7 +141,8 @@ class MockRestApiServer(RestApiServer):
         Handler(MockRequest(request), ('0.0.0.0', 8080), self)
 
 
-@patch('ssl.wrap_socket', Mock(return_value=0))
+@patch('ssl.SSLContext.load_cert_chain', Mock())
+@patch('ssl.SSLContext.wrap_socket', Mock(return_value=0))
 @patch.object(BaseHTTPServer.HTTPServer, '__init__', Mock())
 class TestRestApiHandler(unittest.TestCase):
 
@@ -391,7 +392,8 @@ class TestRestApiHandler(unittest.TestCase):
         MockRestApiServer(RestApiHandler, post + '37\n\n{"candidate":"2","scheduled_at": "1"}')
 
 
-@patch('ssl.wrap_socket', Mock(return_value=0))
+@patch('ssl.SSLContext.load_cert_chain', Mock())
+@patch('ssl.SSLContext.wrap_socket', Mock(return_value=0))
 @patch.object(BaseHTTPServer.HTTPServer, '__init__', Mock())
 class TestRestApiServer(unittest.TestCase):
 


### PR DESCRIPTION
Security is important and also a requirement for some environments like PCI-DSS for example. This commit adds a way to support an explicit list of SSL/TLS protocols. It also adds a way to support OpenSSL ciphers.