### PR TITLE
Make pyscopg2 version parsing more robust

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -173,10 +173,17 @@ def check_psycopg2():
     min_psycopg2 = (2, 5, 4)
     min_psycopg2_str = '.'.join(map(str, min_psycopg2))
 
+    def parse_version(version):
+        for e in version.split('.'):
+            try:
+                yield int(e)
+            except ValueError:
+                break
+
     try:
         import psycopg2
         version_str = psycopg2.__version__.split(' ')[0]
-        version = tuple(map(int, version_str.split('.')))
+        version = tuple(parse_version(version_str))
         if version < min_psycopg2:
             fatal('Patroni requires psycopg2>={0}, but only {1} is available', min_psycopg2_str, version_str)
     except ImportError:

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -159,5 +159,5 @@ class TestPatroni(unittest.TestCase):
     def test_check_psycopg2(self):
         with patch.object(builtins, '__import__', Mock(side_effect=ImportError)):
             self.assertRaises(SystemExit, check_psycopg2)
-        with patch.object(psycopg2, '__version__', return_value='2.5.3 a b c'):
+        with patch.object(psycopg2, '__version__', return_value='2.5.3.dev1 a b c'):
             self.assertRaises(SystemExit, check_psycopg2)


### PR DESCRIPTION
non-released version can have unparsable suffixes, for example 2.8.3.dev0