### PR TITLE
More standby cluster bugfixes

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -136,7 +136,7 @@ class Member(namedtuple('Member', 'index,name,session,data')):
         if conn_kwargs:
             conn_url = 'postgresql://{host}:{port}'.format(
                 host=conn_kwargs.get('host'),
-                port=conn_kwargs.get('port'),
+                port=conn_kwargs.get('port', 5432),
             )
             self.data['conn_url'] = conn_url
             return conn_url

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -251,12 +251,14 @@ class Ha(object):
             else:
                 return 'failed to acquire initialize lock'
         else:
-            if self.state_handler.can_create_replica_without_replication_connection():
+            create_replica_methods = self.get_standby_cluster_config().get('create_replica_methods', []) \
+                                     if self.is_standby_cluster() else None
+            if self.state_handler.can_create_replica_without_replication_connection(create_replica_methods):
                 msg = 'bootstrap (without leader)'
                 self._async_executor.schedule(msg)
                 self._async_executor.run_async(self.clone)
                 return 'trying to ' + msg
-            return 'waiting for leader to bootstrap'
+            return 'waiting for {0}leader to bootstrap'.format('standby_' if self.is_standby_cluster() else '')
 
     def bootstrap_standby_leader(self):
         """ If we found 'standby' key in the configuration, we need to bootstrap

--- a/patroni/postgresql.py
+++ b/patroni/postgresql.py
@@ -1307,6 +1307,8 @@ class Postgresql(object):
             yield cur
 
     def check_leader_is_not_in_recovery(self, **kwargs):
+        if not kwargs.get('database'):
+            kwargs['database'] = self._database
         try:
             with self._get_connection_cursor(connect_timeout=3, options='-c statement_timeout=2000', **kwargs) as cur:
                 cur.execute('SELECT pg_catalog.pg_is_in_recovery()')


### PR DESCRIPTION
1. use the default port is 5432 when only standby_cluster.host is defined
2. check that standby_cluster replica can be bootstrapped without connection to the standby_cluster leader against `create_replica_methods` defined in the `standby_cluster` config instead of the `postgresql` section.
3. Don't fallback to the create_replica_methods defined in the `postgresql` section when bootstrapping a member of the standby cluster.
4. Make sure we specify the database when connecting to the leader.