### PR TITLE
A couple of small improvements in acceptance tests

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -298,9 +298,9 @@ class PatroniController(AbstractController):
     def backup_source(self):
         return 'postgres://{username}:{password}@{host}:{port}/{database}'.format(**self._replication)
 
-    def backup(self, dest='basebackup'):
+    def backup(self, dest='data/basebackup'):
         subprocess.call([PatroniPoolController.BACKUP_SCRIPT, '--walmethod=none',
-                         '--datadir=' + os.path.join(self._output_dir, dest),
+                         '--datadir=' + os.path.join(self._work_directory, dest),
                          '--dbname=' + self.backup_source])
 
 
@@ -637,7 +637,7 @@ class PatroniPoolController(object):
                 'parameters': {
                     'archive_mode': 'on',
                     'archive_command': 'mkdir -p {0} && test ! -f {0}/%f && cp %p {0}/%f'.format(
-                            os.path.join(self._output_dir, 'wal_archive'))
+                            os.path.join(self.patroni_path, 'data/wal_archive'))
                 },
                 'authentication': {
                     'superuser': {'password': 'zalando1'},
@@ -653,11 +653,12 @@ class PatroniPoolController(object):
             'bootstrap': {
                 'method': 'backup_restore',
                 'backup_restore': {
-                    'command': 'features/backup_restore.sh --sourcedir=' + os.path.join(self._output_dir, 'basebackup'),
+                    'command': 'features/backup_restore.sh --sourcedir=' + os.path.join(self.patroni_path,
+                                                                                        'data/basebackup'),
                     'recovery_conf': {
                         'recovery_target_action': 'promote',
                         'recovery_target_timeline': 'latest',
-                        'restore_command': 'cp {0}/wal_archive/%f %p'.format(self._output_dir)
+                        'restore_command': 'cp {0}/data/wal_archive/%f %p'.format(self.patroni_path)
                     }
                 }
             },

--- a/features/standby_cluster.feature
+++ b/features/standby_cluster.feature
@@ -9,6 +9,7 @@ Feature: standby cluster
     And I sleep for 3 seconds
     When I issue a PATCH request to http://127.0.0.1:8009/config with {"slots": {"test_logical": {"type": "logical", "database": "postgres", "plugin": "test_decoding"}}}
     Then I receive a response code 200
+    And I do a backup of postgres1
     When I start postgres0 with callback configured
     Then "members/postgres0" key in DCS has state=running after 10 seconds
     And replication works from postgres1 to postgres0 after 15 seconds

--- a/features/steps/standby_cluster.py
+++ b/features/steps/standby_cluster.py
@@ -28,7 +28,10 @@ def start_patroni(context, name, cluster_name):
     return context.pctl.start(name, custom_config={
         "scope": cluster_name,
         "postgresql": {
-            "callbacks": {c: callback + name for c in ('on_start', 'on_stop', 'on_restart', 'on_role_change')}
+            "callbacks": {c: callback + name for c in ('on_start', 'on_stop', 'on_restart', 'on_role_change')},
+            "backup_restore": {
+                "command": "features/backup_restore.sh --sourcedir=" + os.path.join(context.pctl.patroni_path,
+                                                                                    "data/basebackup")}
         }
     })
 
@@ -49,6 +52,7 @@ def start_patroni_standby_cluster(context, name, cluster_name, name2):
                     "host": "localhost",
                     "port": port,
                     "primary_slot_name": "pm_1",
+                    "create_replica_methods": ["backup_restore", "basebackup"]
                 }
             }
         },


### PR DESCRIPTION
* Keep basebackup and wal_archive next to PGDATA in the data directory
* Test bootstrap of standby cluster nodes with custom scripts