### PR TITLE
Add API route /health (#119)

### DIFF
--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -8,6 +8,8 @@ Scenario: check API requests on a stand-alone server
 	Then I receive a response code 200
 	And I receive a response state running
 	And I receive a response role master
+	When I issue a GET request to http://127.0.0.1:8008/health
+	Then I receive a response code 200
 	When I issue a GET request to http://127.0.0.1:8008/replica
 	Then I receive a response code 503
 	When I run patronictl.py reinit batman postgres0 --force

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -102,6 +102,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
             status_code = replica_status_code
         elif 'read-only' in path:
             status_code = 200 if primary_status_code == 200 else replica_status_code
+        elif 'health' in path:
+            status_code = 200 if response.get('state') == 'running' else 503
         elif cluster:  # dcs is available
             is_synchronous = cluster.is_synchronous_mode() and cluster.sync \
                     and cluster.sync.sync_standby == patroni.postgresql.name

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,6 +154,8 @@ class TestRestApiHandler(unittest.TestCase):
             MockRestApiServer(RestApiHandler, 'GET /replica')
         with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'role': 'master'})):
             MockRestApiServer(RestApiHandler, 'GET /replica')
+        with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'state': 'running'})):
+            MockRestApiServer(RestApiHandler, 'GET /health')
         MockRestApiServer(RestApiHandler, 'GET /master')
         MockPatroni.dcs.cluster.sync.sync_standby = MockPostgresql.name
         MockPatroni.dcs.cluster.is_synchronous_mode = Mock(return_value=True)


### PR DESCRIPTION
According to the documented feature I don't think it is necessary: https://github.com/zalando/patroni/blob/master/features/patroni_api.feature#L7

We can simply GET http://127.0.0.1:8008/ and we will receive a return code 200 if the state of postgresql == running.

If feel like it is more explicit to have an API route /health.