### PR TITLE
Reverse logic around checkpoint_after_promote

### DIFF
--- a/patroni/config.py
+++ b/patroni/config.py
@@ -262,7 +262,7 @@ class Config(object):
             ret['restapi']['authentication'] = restapi_auth
 
         authentication = {}
-        for user_type in ('replication', 'superuser'):
+        for user_type in ('replication', 'superuser', 'rewind'):
             entry = _get_auth(user_type)
             if entry:
                 authentication[user_type] = entry

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -248,7 +248,7 @@ class Leader(namedtuple('Leader', 'index,session,member')):
         if version:
             try:
                 if tuple(map(int, version.split('.'))) >= (1, 5, 6):
-                    return bool(self.member.data.get('checkpoint_after_promote'))
+                    return self.member.data['role'] == 'master' and 'checkpoint_after_promote' not in self.member.data
             except Exception:
                 logger.debug('Failed to parse Patroni version %s', version)
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -184,8 +184,8 @@ class Ha(object):
             # following two lines are mainly necessary for consul, to avoid creation of master service
             if data['role'] == 'master' and not self.is_leader():
                 data['role'] = 'promoted'
-            if self.is_leader():
-                data['checkpoint_after_promote'] = self._rewind.checkpoint_after_promote()
+            if self.is_leader() and not self._rewind.checkpoint_after_promote():
+                data['checkpoint_after_promote'] = False
             tags = self.get_effective_tags()
             if tags:
                 data['tags'] = tags

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -8,8 +8,8 @@ from patroni.postgresql.misc import parse_history, parse_lsn
 
 logger = logging.getLogger(__name__)
 
-REWIND_STATUS = type('Enum', (), {'INITIAL': 0, 'CHECKPOINT': 1, 'CHECK': 1, 'NEED': 2,
-                                  'NOT_NEED': 3, 'SUCCESS': 4, 'FAILED': 5})
+REWIND_STATUS = type('Enum', (), {'INITIAL': 0, 'CHECKPOINT': 1, 'CHECK': 2, 'NEED': 3,
+                                  'NOT_NEED': 4, 'SUCCESS': 5, 'FAILED': 6})
 
 
 class Rewind(object):

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -62,10 +62,10 @@ class TestRewind(BaseTestPostgresql):
             self.r.trigger_check_diverged_lsn()
             self.r.execute(self.leader)
 
-        self.leader.member.data.update(version='1.5.7', checkpoint_after_promote=False)
+        self.leader.member.data.update(version='1.5.7', checkpoint_after_promote=False, role='master')
         self.assertIsNone(self.r.execute(self.leader))
 
-        self.leader.member.data['checkpoint_after_promote'] = True
+        del self.leader.member.data['checkpoint_after_promote']
         with patch.object(Rewind, 'check_leader_is_not_in_recovery', Mock(return_value=False)):
             self.assertIsNone(self.r.execute(self.leader))
 


### PR DESCRIPTION
It will be set to false in the JSON only until the checkpoint actually happened.

The next improvement of https://github.com/zalando/patroni/commit/bba9066315f8dda23e0a28909790a5a3d48d1842