### PR TITLE
patronictl checks if --config value exists (#736)

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -68,7 +68,10 @@ def parse_dcs(dcs):
 
 
 def load_config(path, dcs):
-    logging.debug('Loading configuration from file %s', path)
+    if not (os.path.exists(path) and os.access(path, os.R_OK)):
+        logging.debug('Ignoring configuration file "%s". It does not exists or is not readable.', path)
+    else:
+        logging.debug('Loading configuration from file %s', path)
     config = {}
     old_argv = list(sys.argv)
     try:


### PR DESCRIPTION
Adding this check allow patronictl ~~to return an error instead of ignoring silently the filename passed~~ to be verbose about non-existing file (or unreadable).
I've put the check in patronictl because it was simplier than modifying the [__init__ of Config object](https://github.com/zalando/patroni/blob/master/patroni/config.py#L76). I can move it if you want.

~~We can also change PatroniCtlException by a logging.warning to not modifying the behavior. Again I can happily edit this PR.~~