### PR TITLE
Enable debug logging for GET/OPTIONS API calls together with latency

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -86,6 +86,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
     def do_GET(self, write_status_code_only=False):
         """Default method for processing all GET requests which can not be routed to other methods"""
 
+        time_start = time.time()
+        request_type = 'OPTIONS' if write_status_code_only else 'GET'
+
         path = '/master' if self.path == '/' else self.path
         response = self.get_postgresql_status()
 
@@ -123,6 +126,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
             self.wfile.write('{0} {1} {2}\r\n'.format(self.protocol_version, status_code, message).encode('utf-8'))
         else:
             self._write_status_response(status_code, response)
+
+        time_end = time.time()
+        self.log_message('%s %s %s latency: %s ms', request_type, path,
+                         status_code, (time_end - time_start) * 1000)
 
     def do_OPTIONS(self):
         self.do_GET(write_status_code_only=True)


### PR DESCRIPTION
This PR utilizes the `log_message` function within the API thread to log (debug level) all GET/OPTIONS API calls. It also measures the latency.
The purpose of this change is to help with debugging of health-checks performed by HAProxy, consul or other tooling that decides which node is master/replica. Previously, no logging of API calls has been present.

It produces logs like these (when DEBUG verbosity level is turned on):
```
Jun 19 13:34:06 patroni01a patroni[684]: 2019-06-19 13:34:06,715 DEBUG: API thread: 127.0.0.1 - - [19/Jun/2019 13:34:06] GET /master 503 latency: 1.13201141357 ms
Jun 19 13:34:06 patroni01a patroni[684]: 2019-06-19 13:34:06,716 DEBUG: API thread: xxx.xxx.xxx.xxx - - [19/Jun/2019 13:34:06] OPTIONS /replica 200 latency: 3.5080909729 ms
Jun 19 13:34:06 patroni01a patroni[684]: 2019-06-19 13:34:06,716 DEBUG: API thread: 127.0.0.1 - - [19/Jun/2019 13:34:06] GET /replica 200 latency: 1.90997123718 ms
Jun 19 13:34:06 patroni01a patroni[684]: 2019-06-19 13:34:06,722 DEBUG: API thread: xxx.xxx.xxx.xxx - - [19/Jun/2019 13:34:06] OPTIONS /master 503 latency: 0.797033309937 ms
Jun 19 13:34:06 patroni01a patroni[684]: 2019-06-19 13:34:06,723 DEBUG: API thread: xxx.xxx.xxx.xxx - - [19/Jun/2019 13:34:06] OPTIONS /master 503 latency: 1.2800693512 ms
```

Thanks!