### PR TITLE
fixes that a TypeError is raised if a patroni pod is restarting.

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -744,8 +744,11 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
             lag = round((xlog_location_cluster - xlog_location)/1024/1024)
 
         host = m.conn_kwargs()['host']
-        if append_port:
-            host += ':{0}'.format(m.conn_kwargs()['port'])
+        try:
+            if append_port:
+                host += ':{0}'.format(m.conn_kwargs()['port'])
+        except TypeError:
+            host = ''
 
         row = [name, m.name, host, role, m.data.get('state', ''), m.data.get('timeline', ''), lag]
 


### PR DESCRIPTION
We are running patroni on kubernetes. When a pod is deleted, there is a small timeslot where 'TypeError' is raised when trying to list memberes of the cluster, e.g.
````
$ patronictl -c ~/patroni.yml list
Traceback (most recent call last):
  File "/usr/bin/patronictl", line 10, in <module>
    sys.exit(ctl())
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib64/python3.6/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/patroni/ctl.py", line 810, in members
    output_members(cluster, cluster_name, extended, fmt)
  File "/usr/lib/python3.6/site-packages/patroni/ctl.py", line 741, in output_members
    host += ':{0}'.format(m.conn_kwargs()['port'])
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
````

With this fix the oputput will look like this:
````
$ patronictl -c ~/patroni.yml list
+--------------------+--------------+------------------+--------+---------+----+-----------+
|      Cluster       |    Member    |       Host       |  Role  |  State  | TL | Lag in MB |
+--------------------+--------------+------------------+--------+---------+----+-----------+
| postgresql-cluster | postgresql-0 | 10.1.1.100:64000 | Leader | running |  1 |         0 |
| postgresql-cluster | postgresql-1 |                  |        |         |    |   unknown |
+--------------------+--------------+------------------+--------+---------+----+-----------+
```` 