### PR TITLE
Fix Windows signals incompatibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ docs/source/_templates/
 
 #VSCode IDE
 .vscode/
+
+#Python VENV
+venv
+
+#Test data
+data

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - windows
+  - linux
+  
 sudo: true
 dist: trusty
 language: python
@@ -13,16 +17,16 @@ env:
   - BOTO_CONFIG=/doesnotexist
 matrix:
   include:
-  - python: "3.5"
+  - python: "3.6"
     env: TEST_SUITE="python setup.py"
-  - python: "3.6"
-    env: DCS="etcd" TEST_SUITE="behave"
-  - python: "3.6"
-    env: DCS="exhibitor" TEST_SUITE="behave"
-  - python: "3.6"
-    env: DCS="consul" TEST_SUITE="behave"
-  - python: "3.6"
-    env: DCS="kubernetes" TEST_SUITE="behave"
+#   - python: "3.6"
+#     env: DCS="etcd" TEST_SUITE="behave"
+#   - python: "3.6"
+#     env: DCS="exhibitor" TEST_SUITE="behave"
+#   - python: "3.6"
+#     env: DCS="consul" TEST_SUITE="behave"
+#   - python: "3.6"
+#     env: DCS="kubernetes" TEST_SUITE="behave"
 branches:
   only:
   - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+environment:
+ 
+ 
+  matrix:
+    - PYTHON: "C:\\Python36-x64"
+ 
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+ 
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python -m pip install --upgrade pip"
+  - "pip install -r requirements.txt --upgrade"
+  - "pip install psycopg2-binary behave codacy-coverage coverage coveralls flake8 mock pytest-cov pytest setuptools --upgrade"
+
+ 
+build: off
+ 
+test_script:
+  - "%PYTHON%\\python.exe setup.py test"
+ 
+after_test:
+#  - "python-codacy-coverage -r coverage.xml"
+ 
+artifacts:
+  - path: dist\*

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -511,7 +511,7 @@ class Postgresql(object):
             self.set_state('stopping')
 
         # Send signal to postmaster to stop
-        success = postmaster.signal_stop(mode)
+        success = postmaster.signal_stop(self.pgcommand('pg_ctl'), mode)
         if success is not None:
             if success and on_safepoint:
                 on_safepoint()

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -107,7 +107,7 @@ class PostmasterProcess(psutil.Process):
         :returns None if signaled, True if process is already gone, False if error
         """
         if self.is_single_user:
-            logger.warning("Cannot stop server; single-user server is running (PID: {0})".format(self.pid))
+            logger.warning("Cannot stop server; single-user server is running with PID %s)", self.pid)
             return False
         if os.name != "nt":
             try:
@@ -119,12 +119,12 @@ class PostmasterProcess(psutil.Process):
                 logger.warning("Could not send stop signal to PostgreSQL (error: {0})".format(e))
                 return False
         else:
-            if subprocess.call([pg_ctl, 'kill', STOP_SIGNALS[mode], self.pid]) == 0:
+            if subprocess.call([pg_ctl, 'kill', STOP_SIGNALS[mode], str(self.pid)]) == 0:
                 return None
             elif not self.is_running():
                 return True
             else:
-                logger.warning("Could not send stop signal to PostgreSQL with PID {0}".format(self.pid))
+                logger.warning("Could not send stop signal to PostgreSQL with PID %s", self.pid)
                 return False
 
     def wait_for_user_backends_to_close(self):

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -21,6 +21,7 @@ else:
         'immediate': 'QUIT',
     }
 
+
 def pg_ctl_start(conn, cmdline, env):
     if os.name != 'nt':
         os.setsid()
@@ -123,7 +124,7 @@ class PostmasterProcess(psutil.Process):
             elif not self.is_running():
                 return True
             else:
-                logger.warning("Could not send stop signal %s to postmaster with PID %s", STOP_SIGNALS[mode], self.pid)
+                logger.warning("Could not send stop signal to PostgreSQL with PID {0}".format(self.pid))
                 return False
 
     def wait_for_user_backends_to_close(self):

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 STOP_SIGNALS = {
     'smart': signal.SIGTERM,
-    'fast': signal.SIGINT,
-    'immediate': signal.SIGQUIT if os.name != 'nt' else signal.SIGABRT,
+    'fast': signal.SIGINT if os.name != 'nt' else signal.SIGTERM,
+    'immediate': signal.SIGQUIT if os.name != 'nt' else signal.SIGTERM,
 }
 
 

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -109,6 +109,7 @@ class PostmasterProcess(psutil.Process):
         if self.is_single_user:
             logger.warning("Cannot stop server; single-user server is running with PID %s)", self.pid)
             return False
+
         if os.name != "nt":
             try:
                 self.send_signal(STOP_SIGNALS[mode])
@@ -126,6 +127,7 @@ class PostmasterProcess(psutil.Process):
             else:
                 logger.warning("Could not send stop signal to PostgreSQL with PID %s", self.pid)
                 return False
+
 
     def wait_for_user_backends_to_close(self):
         # These regexps are cross checked against versions PostgreSQL 9.1 .. 11

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -101,7 +101,7 @@ class PostmasterProcess(psutil.Process):
         except psutil.NoSuchProcess:
             return None
 
-    def signal_stop(self, mode):
+    def signal_stop(self, pg_ctl, mode):
         """Signal postmaster process to stop
 
         :returns None if signaled, True if process is already gone, False if error
@@ -119,7 +119,7 @@ class PostmasterProcess(psutil.Process):
                 logger.warning("Could not send stop signal to PostgreSQL (error: {0})".format(e))
                 return False
         else:
-            if subprocess.call(['pg_ctl', 'kill', STOP_SIGNALS[mode], self.pid]) == 0:
+            if subprocess.call([pg_ctl, 'kill', STOP_SIGNALS[mode], self.pid]) == 0:
                 return None
             elif not self.is_running():
                 return True

--- a/patronictl.spec
+++ b/patronictl.spec
@@ -1,0 +1,32 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+
+a = Analysis(['patronictl.py'],
+             pathex=['C:\\Users\\pasha\\code\\patroni'],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='patronictl',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          runtime_tmpdir=None,
+          console=True )

--- a/postgres-win0.yml
+++ b/postgres-win0.yml
@@ -1,0 +1,99 @@
+scope: batman
+#namespace: /service/
+name: postgresql0
+
+restapi:
+  listen: 127.0.0.1:8008
+  connect_address: 127.0.0.1:8008
+#  certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
+#  keyfile: /etc/ssl/private/ssl-cert-snakeoil.key
+#  authentication:
+#    username: username
+#    password: password
+
+# ctl:
+#   insecure: false # Allow connections to SSL sites without certs
+#   certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
+#   cacert: /etc/ssl/certs/ssl-cacert-snakeoil.pem
+
+etcd:
+  host: 127.0.0.1:2379
+
+bootstrap:
+  # this section will be written into Etcd:/<namespace>/<scope>/config after initializing new cluster
+  # and all other cluster members will use it as a `global configuration`
+  dcs:
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+    maximum_lag_on_failover: 1048576
+#    master_start_timeout: 300
+#    synchronous_mode: false
+    #standby_cluster:
+      #host: 127.0.0.1
+      #port: 1111
+      #primary_slot_name: patroni
+    postgresql:
+      use_pg_rewind: true
+#      use_slots: true
+      parameters:
+#        wal_level: hot_standby
+#        hot_standby: "on"
+#        wal_keep_segments: 8
+#        max_wal_senders: 10
+#        max_replication_slots: 10
+#        wal_log_hints: "on"
+#        archive_mode: "on"
+#        archive_timeout: 1800s
+#        archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f
+#      recovery_conf:
+#        restore_command: cp ../wal_archive/%f %p
+
+  # some desired options for 'initdb'
+  initdb:  # Note: It needs to be a list (some options need values, others are switches)
+  - encoding: UTF8
+  - data-checksums
+
+  pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
+  - host replication replicator 127.0.0.1/32 md5
+  - host all all 0.0.0.0/0 md5
+#  - hostssl all all 0.0.0.0/0 md5
+
+  # Additional script to be launched after initial cluster creation (will be passed the connection URL as parameter)
+# post_init: /usr/local/bin/setup_cluster.sh
+
+  # Some additional users users which needs to be created after initializing new cluster
+  users:
+    admin:
+      password: admin
+      options:
+        - createrole
+        - createdb
+
+postgresql:
+  listen: 127.0.0.1:5432
+  connect_address: 127.0.0.1:5432
+  data_dir: data/postgresql0
+  bin_dir: ../pgsql/bin
+#  config_dir:
+  pgpass: data/pgpass0
+  authentication:
+    replication:
+      username: replicator
+      password: rep-pass
+    superuser:
+      username: postgres
+      password: zalando
+  parameters:
+    unix_socket_directories: '.'
+
+#watchdog:
+#  mode: automatic # Allowed values: off, automatic, required
+#  device: /dev/watchdog
+#  safety_margin: 5
+
+tags:
+    nofailover: false
+    noloadbalance: false
+    clonefrom: false
+    nosync: false

--- a/postgres-win1.yml
+++ b/postgres-win1.yml
@@ -1,0 +1,99 @@
+scope: batman
+#namespace: /service/
+name: postgresql1
+
+restapi:
+  listen: 127.0.0.1:8009
+  connect_address: 127.0.0.1:8009
+#  certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
+#  keyfile: /etc/ssl/private/ssl-cert-snakeoil.key
+#  authentication:
+#    username: username
+#    password: password
+
+# ctl:
+#   insecure: false # Allow connections to SSL sites without certs
+#   certfile: /etc/ssl/certs/ssl-cert-snakeoil.pem
+#   cacert: /etc/ssl/certs/ssl-cacert-snakeoil.pem
+
+etcd:
+  host: 127.0.0.1:2379
+
+bootstrap:
+  # this section will be written into Etcd:/<namespace>/<scope>/config after initializing new cluster
+  # and all other cluster members will use it as a `global configuration`
+  dcs:
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+    maximum_lag_on_failover: 1048576
+#    master_start_timeout: 300
+#    synchronous_mode: false
+    #standby_cluster:
+      #host: 127.0.0.1
+      #port: 1111
+      #primary_slot_name: patroni
+    postgresql:
+      use_pg_rewind: true
+#      use_slots: true
+      parameters:
+#        wal_level: hot_standby
+#        hot_standby: "on"
+#        wal_keep_segments: 8
+#        max_wal_senders: 10
+#        max_replication_slots: 10
+#        wal_log_hints: "on"
+#        archive_mode: "on"
+#        archive_timeout: 1800s
+#        archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f
+#      recovery_conf:
+#        restore_command: cp ../wal_archive/%f %p
+
+  # some desired options for 'initdb'
+  initdb:  # Note: It needs to be a list (some options need values, others are switches)
+  - encoding: UTF8
+  - data-checksums
+
+  pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
+  - host replication replicator 127.0.0.1/32 md5
+  - host all all 0.0.0.0/0 md5
+#  - hostssl all all 0.0.0.0/0 md5
+
+  # Additional script to be launched after initial cluster creation (will be passed the connection URL as parameter)
+# post_init: /usr/local/bin/setup_cluster.sh
+
+  # Some additional users users which needs to be created after initializing new cluster
+  users:
+    admin:
+      password: admin
+      options:
+        - createrole
+        - createdb
+
+postgresql:
+  listen: 127.0.0.1:5433
+  connect_address: 127.0.0.1:5433
+  data_dir: data/postgresql1
+  bin_dir: ../pgsql/bin
+#  config_dir:
+  pgpass: data/pgpass1
+  authentication:
+    replication:
+      username: replicator
+      password: rep-pass
+    superuser:
+      username: postgres
+      password: zalando
+  parameters:
+    unix_socket_directories: '.'
+
+#watchdog:
+#  mode: automatic # Allowed values: off, automatic, required
+#  device: /dev/watchdog
+#  safety_margin: 5
+
+tags:
+    nofailover: false
+    noloadbalance: false
+    clonefrom: false
+    nosync: false

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -65,6 +65,8 @@ class TestPostmasterProcess(unittest.TestCase):
     @patch('psutil.Process.__init__', Mock())
     @patch('psutil.Process.send_signal')
     @patch('psutil.Process.pid', Mock(return_value=123))
+    @patch('subprocess.call', Mock(side_effect = [0, 1, 2]))
+    @patch('psutil.Process.is_running', Mock(side_effect=[False, True]))
     def test_signal_stop(self, mock_send_signal):
         proc = PostmasterProcess(-123)
         self.assertEqual(proc.signal_stop('immediate'), False)

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -69,13 +69,13 @@ class TestPostmasterProcess(unittest.TestCase):
     @patch('psutil.Process.is_running', Mock(side_effect=[False, True]))
     def test_signal_stop(self, mock_send_signal):
         proc = PostmasterProcess(-123)
-        self.assertEqual(proc.signal_stop('immediate'), False)
+        self.assertEqual(proc.signal_stop('pg_ctl', 'immediate'), False)
 
         mock_send_signal.side_effect = [None, psutil.NoSuchProcess(123), psutil.AccessDenied()]
         proc = PostmasterProcess(123)
-        self.assertEqual(proc.signal_stop('immediate'), None)
-        self.assertEqual(proc.signal_stop('immediate'), True)
-        self.assertEqual(proc.signal_stop('immediate'), False)
+        self.assertEqual(proc.signal_stop('pg_ctl', 'immediate'), None)
+        self.assertEqual(proc.signal_stop('pg_ctl', 'immediate'), True)
+        self.assertEqual(proc.signal_stop('pg_ctl', 'immediate'), False)
 
     @patch('psutil.Process.__init__', Mock())
     @patch('psutil.wait_procs')


### PR DESCRIPTION
On Windows only SIGTERM, CTRL_C_EVENT and CTRL_BREAK_EVENT signals are supported. However, sending Ctrl+Break requires already being attached to the same console as the target. Note that the target isn't necessarily a single process that's attached to the console. Sending a control event is implemented by calling WinAPI GenerateConsoleCtrlEvent, which targets process group identifiers (i.e. like Unix killpg), not process identifiers (i.e. not like Unix kill). 

So the only sane solution is to send SIGTERM for all modes supported.