### PR TITLE
Synchronous commit is disabled for rewind user GRANTs

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -344,8 +344,12 @@ END;$$""".format(name, ' '.join(options))
                     self.create_or_update_role(rewind['username'], rewind.get('password'), [])
                     for f in ('pg_ls_dir(text, boolean, boolean)', 'pg_stat_file(text, boolean)',
                               'pg_read_binary_file(text)', 'pg_read_binary_file(text, bigint, bigint, boolean)'):
-                        postgresql.query('GRANT EXECUTE ON function pg_catalog.{0} TO "{1}"'
-                                         .format(f, rewind['username']))
+                        sql = """DO $$
+BEGIN
+    SET local synchronous_commit = 'local';
+    GRANT EXECUTE ON function pg_catalog.{0} TO "{1}";
+END;$$""".format(f, rewind['username'])
+                        postgresql.query(sql)
 
                 for name, value in (config.get('users') or {}).items():
                     if all(name != a.get('username') for a in (superuser, replication, rewind)):


### PR DESCRIPTION
Currently if a cluster is bootstrapped with
```yml
postgresql:
  parameters:
    synchronous_commit: "on"
    synchronous_standby_names: "*"
```
then it will stuck in `post_bootstrap` mode:
```
2019-08-12 17:31:16,318 INFO: Lock owner: None; I am postgresql0
2019-08-12 17:31:16,319 INFO: not healthy enough for leader race
2019-08-12 17:31:16,322 INFO: post_bootstrap in progress
2019-08-12 17:31:26,317 INFO: Lock owner: None; I am postgresql0
2019-08-12 17:31:26,317 INFO: not healthy enough for leader race
2019-08-12 17:31:26,320 INFO: post_bootstrap in progress
```
```
postgres=# SELECT pid, age(clock_timestamp(), query_start), usename, query 
postgres-# FROM pg_stat_activity 
postgres-# WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%' 
postgres-# ORDER BY query_start desc;
  pid  |       age       | usename  |                                          query                                          
-------+-----------------+----------+-----------------------------------------------------------------------------------------
 18712 |                 |          | 
 18714 |                 | postgres | 
 18710 |                 |          | 
 18709 |                 |          | 
 18711 |                 |          | 
 18719 | 00:02:11.117663 | postgres | GRANT EXECUTE ON function pg_catalog.pg_ls_dir(text, boolean, boolean) TO "rewind_user"
(6 rows)
```
It happens because the `synchronous_commit` option isn't disabled for `GRANT EXECUTE ...`, so the postgresql node waits forever for replication, but doesn't allow any other node to connect because it is still not ready yet.
Notice, that in the `create_or_update_role` function the option is properly disabled.

I'm not sure that formatting is ok for that SQL request, I just mirrored it from the `create_or_update_role` function.