### PR TITLE
Add PATRONICTL_CONFIG_FILE Environment Variable

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -111,7 +111,8 @@ option_insecure = click.option('-k', '--insecure', is_flag=True, help='Allow con
 
 
 @click.group()
-@click.option('--config-file', '-c', help='Configuration file', envvar='PATRONICTL_CONFIG_FILE', default=CONFIG_FILE_PATH)
+@click.option('--config-file', '-c', help='Configuration file',
+              envvar='PATRONICTL_CONFIG_FILE', default=CONFIG_FILE_PATH)
 @click.option('--dcs', '-d', help='Use this DCS', envvar='DCS')
 @option_insecure
 @click.pass_context

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -111,7 +111,7 @@ option_insecure = click.option('-k', '--insecure', is_flag=True, help='Allow con
 
 
 @click.group()
-@click.option('--config-file', '-c', help='Configuration file', default=CONFIG_FILE_PATH)
+@click.option('--config-file', '-c', help='Configuration file', envvar='PATRONICTL_CONFIG_FILE', default=CONFIG_FILE_PATH)
 @click.option('--dcs', '-d', help='Use this DCS', envvar='DCS')
 @option_insecure
 @click.pass_context


### PR DESCRIPTION
This PR adds a `PATRONICTL_CONFIG_FILE` environment variable, which allows configuring the `--config-file` flag from the environment.

This is especially helpful when running patroni inside a Kubernetes cluster, e.g. via [postgres-operator](https://github.com/zalando/postgres-operator) and interacting with `patronictl` inside a pod.

As the default location is not working here, setting the correct location as environment variable in the pod will allow us to use `patronictl` without specifying the config file option with every command.

According to https://github.com/pallets/click/pull/874 this change will be non breaking, as first the cli option, then the environment variable, and finally the default will be evaluated.

Let me know if you need anything else and thanks for this awesome project!