### PR TITLE
Pass statement_timeout=0 in PGOPTIONS when doing pg_rewind

### DIFF
--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -146,6 +146,7 @@ class Rewind(object):
     def pg_rewind(self, r):
         # prepare pg_rewind connection
         env = self._postgresql.write_pgpass(r)
+        env['PGOPTIONS'] = '-c statement_timeout=0'
         dsn_attrs = [
             ('user', r.get('user')),
             ('host', r.get('host')),


### PR DESCRIPTION
It might happen that statement_timeout on the server is set to some small value and one of the statements executed by pg_rewind is canceled.

I already proposed a patch fixing the pg_rewind itself, but it also would be good to have a workaround in Patroni.