### PR TITLE
[WIP] Add debugging mode

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -19,6 +19,8 @@ Global/Universal
 -  **PATRONI\_LOG\_FILE\_NUM**: The number of application logs to retain.
 -  **PATRONI\_LOG\_FILE\_SIZE**: Size of patroni.log file (in bytes) that triggers a log rolling.
 -  **PATRONI\_LOG\_LOGGERS**: Redefine logging level per python module. Example ``PATRONI_LOG_LOGGERS="{patroni.postmaster: WARNING, urllib3: DEBUG}"``
+-  **PATRONI\_DEBUG\_MODE**: When set to a non-empty value, makes Patroni run in the special debug mode that enables stepping with a debugger through some execution paths within Patroni `
+Example ``PATRONI_DEBUG_MODE="on"``
 
 Bootstrap configuration
 -----------------------

--- a/patroni.py
+++ b/patroni.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 from patroni import main
 
+import os
 
 if __name__ == '__main__':
+
+    if os.getenv("PATRONI_DEBUG_MODE"):
+        # XXX Visual Code specific https://github.com/microsoft/ptvsd/issues/1443
+        # create processes by spawning new Python interpreters instead of forking the current one 
+        import multiprocessing
+        multiprocessing.set_start_method('spawn', True)
+
     main()

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -332,6 +332,11 @@ class Config(object):
                         config['postgresql'][name] = deepcopy(value)
             elif name not in config or name in ['watchdog']:
                 config[name] = deepcopy(value) if value else {}
+        
+        if os.getenv("PATRONI_DEBUG_MODE"):
+            config['ttl'] = 24 * 60 * 60 # practical infinity for a debugging session
+            config['loop_wait'] = -1
+
 
         # restapi server expects to get restapi.auth = 'username:password'
         if 'authentication' in config['restapi']:


### PR DESCRIPTION
I stumbled upon  #1173 #1174 #1175 by stepping through the code with a debugger and decided a debug mode I quickly hacked for resuming work on #1099 is worth contributing.

The main idea is to "stop the world" from the Patroni viewpoint by disabling most important timeouts, namely  TTL for keys (they never expire) and the HA loop rescheduling (happens immediately).

These measures enable stepping through most of the Patroni HA loop code as in normal execution. So far I traced master startup, execution and shutdown. I am currently tracing replica execution and failover and will update the PR with the results.

Please provide feedback
