### PR TITLE
Fix logger shutdown behavior

### DIFF
--- a/patroni/log.py
+++ b/patroni/log.py
@@ -59,7 +59,6 @@ class PatroniLogger(Thread):
 
     def __init__(self):
         super(PatroniLogger, self).__init__()
-        self.daemon = True
         self._queue_handler = QueueHandler()
         self._root_logger = logging.getLogger()
         self._root_logger.addHandler(self._queue_handler)

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -39,13 +39,13 @@ class MockFrozenImporter(object):
 @patch.object(AsyncExecutor, 'run', Mock())
 @patch.object(etcd.Client, 'write', etcd_write)
 @patch.object(etcd.Client, 'read', etcd_read)
-@patch.object(Thread, 'start', Mock())
 class TestPatroni(unittest.TestCase):
 
     @patch('pkgutil.get_importer', Mock(return_value=MockFrozenImporter()))
     @patch('sys.frozen', Mock(return_value=True), create=True)
     @patch.object(BaseHTTPServer.HTTPServer, '__init__', Mock())
     @patch.object(etcd.Client, 'read', etcd_read)
+    @patch.object(Thread, 'start', Mock())
     def setUp(self):
         self._handlers = logging.getLogger().handlers[:]
         RestApiServer._BaseServer__is_shut_down = Mock()
@@ -165,6 +165,7 @@ class TestPatroni(unittest.TestCase):
         self.p.tags['nosync'] = None
         self.assertFalse(self.p.nosync)
 
+    @patch.object(Thread, 'join', Mock())
     def test_shutdown(self):
         self.p.api.shutdown = Mock(side_effect=Exception)
         self.p.shutdown()


### PR DESCRIPTION
Since it is based on Thread with daemon set to True, the shutdown of logger was very likely to happen too early, what was causing some lines not to appear at the destination.

Close https://github.com/zalando/patroni/issues/1173