### PR TITLE
Explicitly start logger Thread

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -114,6 +114,7 @@ class Patroni(object):
 
     def run(self):
         self.api.start()
+        self.logger.start()
         self.next_run = time.time()
 
         while not self.received_sigterm:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -38,12 +38,13 @@ class TestPatroniLogger(unittest.TestCase):
         logger = PatroniLogger()
         patroni_config = Config()
         logger.reload_config(patroni_config['log'])
+        logger.start()
 
         with patch.object(logging.Handler, 'format', Mock(side_effect=Exception)):
             logging.error('test')
 
-        self.assertEqual(logger._log_handler.maxBytes, config['log']['file_size'])
-        self.assertEqual(logger._log_handler.backupCount, config['log']['file_num'])
+        self.assertEqual(logger.log_handler.maxBytes, config['log']['file_size'])
+        self.assertEqual(logger.log_handler.backupCount, config['log']['file_num'])
 
         config['log'].pop('dir')
         logger.reload_config(config['log'])

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -122,6 +122,7 @@ class TestPatroni(unittest.TestCase):
         self.p.sighup_handler()
         self.p.ha.dcs.watch = Mock(side_effect=SleepException)
         self.p.api.start = Mock()
+        self.p.logger.start = Mock()
         self.p.config._dynamic_configuration = {}
         self.assertRaises(SleepException, self.p.run)
         with patch('patroni.config.Config.set_dynamic_configuration', Mock(return_value=True)):


### PR DESCRIPTION
The PatroniLogger object is instantiated in the Patroni constructor and down the road there might be a fatal error causing Patroni process to exit, but live thread prevents the normal shutdown.
In order to mitigate the issue and don't loose ability to use the logging infrastructure we will switch to QueueLogger only when the thread was explicitly started from the Patroni.run() method.

Continuation of https://github.com/zalando/patroni/pull/1178