### PR TITLE
Improve workflow when PGDATA is not empty during bootstrap

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1272,26 +1272,31 @@ class Ha(object):
                     return 'released leader key voluntarily as data dir empty and currently leader'
 
                 return self.bootstrap()  # new node
-            # "bootstrap", but data directory is not empty
-            elif not self.sysid_valid(self.cluster.initialize) and self.cluster.is_unlocked() and not self.is_paused():
-                if not self.state_handler.cb_called and self.state_handler.is_running() \
-                        and not self.state_handler.is_leader():
-                    self._join_aborted = True
-                    logger.error('No initialize key in DCS and PostgreSQL is running as replica, aborting start')
-                    logger.error('Please first start Patroni on the node running as master')
-                    sys.exit(1)
-                self.dcs.initialize(create_new=(self.cluster.initialize is None), sysid=self.state_handler.sysid)
             else:
                 # check if we are allowed to join
                 data_sysid = self.state_handler.sysid
                 if not self.sysid_valid(data_sysid):
-                    # data directory is not empty, but no valid sysid, cluster must be broken, suggest reinit
+                    # data directory is not empty, but no valid sysid
+                    if not self.sysid_valid(self.cluster.initialize):
+                        logger.fatal('PostgreSQL data dir for the new cluster is not empty and not valid')
+                        sys.exit(1)
+                    # suggest reinit
                     return "data dir for the cluster is not empty, but system ID is invalid; consider doing reinitalize"
 
-                if self.sysid_valid(self.cluster.initialize) and self.cluster.initialize != self.state_handler.sysid:
-                    logger.fatal("system ID mismatch, node %s belongs to a different cluster: %s != %s",
-                                 self.state_handler.name, self.cluster.initialize, self.state_handler.sysid)
-                    sys.exit(1)
+                if self.sysid_valid(self.cluster.initialize):
+                    if self.cluster.initialize != data_sysid:
+                        logger.fatal("system ID mismatch, node %s belongs to a different cluster: %s != %s",
+                                     self.state_handler.name, self.cluster.initialize, data_sysid)
+                        sys.exit(1)
+                elif self.cluster.is_unlocked() and not self.is_paused():
+                    # "bootstrap", but data directory is not empty
+                    if not self.state_handler.cb_called and self.state_handler.is_running() \
+                            and not self.state_handler.is_leader():
+                        self._join_aborted = True
+                        logger.error('No initialize key in DCS and PostgreSQL is running as replica, aborting start')
+                        logger.error('Please first start Patroni on the node running as master')
+                        sys.exit(1)
+                    self.dcs.initialize(create_new=(self.cluster.initialize is None), sysid=data_sysid)
 
             if not self.state_handler.is_healthy():
                 if self.is_paused():

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1276,11 +1276,7 @@ class Ha(object):
                 # check if we are allowed to join
                 data_sysid = self.state_handler.sysid
                 if not self.sysid_valid(data_sysid):
-                    # data directory is not empty, but no valid sysid
-                    if not self.sysid_valid(self.cluster.initialize):
-                        logger.fatal('PostgreSQL data dir for the new cluster is not empty and not valid')
-                        sys.exit(1)
-                    # suggest reinit
+                    # data directory is not empty, but no valid sysid, cluster must be broken, suggest reinit
                     return "data dir for the cluster is not empty, but system ID is invalid; consider doing reinitalize"
 
                 if self.sysid_valid(self.cluster.initialize):

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -200,7 +200,7 @@ class Postgresql(object):
 
     @property
     def sysid(self):
-        if not self._sysid and not self.bootstrapping:
+        if not self._sysid and not self.bootstrapping or not self.is_running():
             data = self.controldata()
             self._sysid = data.get('Database system identifier', "")
         return self._sysid
@@ -627,6 +627,8 @@ class Postgresql(object):
                               if l and ':' in l}
             except subprocess.CalledProcessError:
                 logger.exception("Error when calling pg_controldata")
+        if not result:
+            self._sysid = None
         return result
 
     @contextmanager

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -178,6 +178,7 @@ class PostgresInit(unittest.TestCase):
     @patch.object(ConfigHandler, 'write_postgresql_conf', Mock())
     @patch.object(ConfigHandler, 'replace_pg_hba', Mock())
     @patch.object(ConfigHandler, 'replace_pg_ident', Mock())
+    @patch.object(Postgresql, 'get_postgres_role_from_data_directory', Mock(return_value='master'))
     def setUp(self):
         data_dir = 'data/test0'
         self.p = Postgresql({'name': 'postgresql0', 'scope': 'batman', 'data_dir': data_dir,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -101,6 +101,9 @@ class TestBootstrap(BaseTestPostgresql):
     @patch.object(CancellableSubprocess, 'call', Mock())
     @patch.object(Postgresql, 'is_running', Mock(return_value=True))
     @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=False))
+    @patch.object(Postgresql, 'controldata', Mock(return_value={'max_connections setting': 100,
+                                                                'max_prepared_xacts setting': 0,
+                                                                'max_locks_per_xact setting': 64}))
     def test_bootstrap(self):
         with patch('subprocess.call', Mock(return_value=1)):
             self.assertFalse(self.b.bootstrap({}))
@@ -126,6 +129,7 @@ class TestBootstrap(BaseTestPostgresql):
 
     @patch.object(CancellableSubprocess, 'call')
     @patch.object(Postgresql, 'get_major_version', Mock(return_value=90600))
+    @patch.object(Postgresql, 'controldata',  Mock(return_value={'Database cluster state': 'in production'}))
     def test_custom_bootstrap(self, mock_cancellable_subprocess_call):
         self.p.config._config.pop('pg_hba')
         config = {'method': 'foo', 'foo': {'command': 'bar'}}

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1027,9 +1027,16 @@ class TestHa(PostgresInit):
             self.assertEqual(self.ha.run_cycle(), 'no action.  i am the leader with the lock')
 
     @patch('sys.exit', return_value=1)
-    @patch('requests.get', requests_get)
     def test_abort_join(self, exit_mock):
         self.ha.cluster = get_cluster_not_initialized_without_leader()
+        self.p.is_leader = false
+        self.ha.run_cycle()
+        exit_mock.assert_called_once_with(1)
+
+    @patch('sys.exit', return_value=1)
+    def test_abort_bootstrap(self, exit_mock):
+        self.ha.cluster = get_cluster_not_initialized_without_leader()
+        self.ha.sysid_valid = false
         self.p.is_leader = false
         self.ha.run_cycle()
         exit_mock.assert_called_once_with(1)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1033,14 +1033,6 @@ class TestHa(PostgresInit):
         self.ha.run_cycle()
         exit_mock.assert_called_once_with(1)
 
-    @patch('sys.exit', return_value=1)
-    def test_abort_bootstrap(self, exit_mock):
-        self.ha.cluster = get_cluster_not_initialized_without_leader()
-        self.ha.sysid_valid = false
-        self.p.is_leader = false
-        self.ha.run_cycle()
-        exit_mock.assert_called_once_with(1)
-
     def test_after_pause(self):
         self.ha.has_lock = true
         self.ha.cluster.is_unlocked = false

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -115,9 +115,7 @@ class TestPatroni(unittest.TestCase):
     @patch('patroni.config.Config.save_cache', Mock())
     @patch('patroni.config.Config.reload_local_configuration', Mock(return_value=True))
     @patch('patroni.ha.Ha.is_leader', Mock(return_value=True))
-    @patch('patroni.ha.Ha.sysid_valid', Mock(return_value=True))
     @patch.object(Postgresql, 'state', PropertyMock(return_value='running'))
-    @patch.object(Postgresql, 'sysid', PropertyMock(return_value='postgresql0'))
     @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=False))
     def test_run(self):
         self.p.postgresql.set_role('replica')

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -115,7 +115,9 @@ class TestPatroni(unittest.TestCase):
     @patch('patroni.config.Config.save_cache', Mock())
     @patch('patroni.config.Config.reload_local_configuration', Mock(return_value=True))
     @patch('patroni.ha.Ha.is_leader', Mock(return_value=True))
+    @patch('patroni.ha.Ha.sysid_valid', Mock(return_value=True))
     @patch.object(Postgresql, 'state', PropertyMock(return_value='running'))
+    @patch.object(Postgresql, 'sysid', PropertyMock(return_value='postgresql0'))
     @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=False))
     def test_run(self):
         self.p.postgresql.set_role('replica')

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -101,6 +101,7 @@ class TestPostgresql(BaseTestPostgresql):
     @patch.object(Postgresql, 'wait_for_startup')
     @patch.object(Postgresql, 'wait_for_port_open')
     @patch.object(Postgresql, 'is_running')
+    @patch.object(Postgresql, 'controldata', Mock())
     def test_start(self, mock_is_running, mock_wait_for_port_open, mock_wait_for_startup, mock_popen):
         mock_is_running.return_value = MockPostmaster()
         mock_wait_for_port_open.return_value = True
@@ -362,6 +363,7 @@ class TestPostgresql(BaseTestPostgresql):
 
     @patch('os.listdir', Mock(return_value=['recovery.conf']))
     @patch('os.path.exists', Mock(return_value=True))
+    @patch.object(Postgresql, 'controldata', Mock())
     def test_get_postgres_role_from_data_directory(self):
         self.assertEqual(self.p.get_postgres_role_from_data_directory(), 'replica')
 


### PR DESCRIPTION
Recently it has happened two times when people tried to deploy the new cluster but postgres data directory wasn't empty and also wasn't valid. In this case Patroni was still creating initialize key in DCS and trying to start the postgres up.
Now it will complain about non-empty invalid postgres data directory and exit.

Close https://github.com/zalando/patroni/issues/1216