### PR TITLE
Only remove PATRONI_ENV_PREFIX'd environment variables

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -23,7 +23,6 @@ import yaml
 
 from click import ClickException
 from contextlib import contextmanager
-from patroni.config import Config
 from patroni.dcs import get_dcs as _get_dcs
 from patroni.exceptions import PatroniException
 from patroni.postgresql import Postgresql
@@ -67,6 +66,8 @@ def parse_dcs(dcs):
 
 
 def load_config(path, dcs):
+    from patroni.config import Config
+
     if not (os.path.exists(path) and os.access(path, os.R_OK)):
         logging.debug('Ignoring configuration file "%s". It does not exists or is not readable.', path)
     else:

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -6,6 +6,8 @@ import re
 import signal
 import subprocess
 
+from patroni.config import Config
+
 logger = logging.getLogger(__name__)
 
 STOP_SIGNALS = {
@@ -153,7 +155,7 @@ class PostmasterProcess(psutil.Process):
         # In order to make everything portable we can't use fork&exec approach here, so  we will call
         # ourselves and pass list of arguments which must be used to start postgres.
         # On Windows, in order to run a side-by-side assembly the specified env must include a valid SYSTEMROOT.
-        env = {p: os.environ[p] for p in ('PATH', 'LD_LIBRARY_PATH', 'LC_ALL', 'LANG', 'SYSTEMROOT') if p in os.environ}
+        env = {p: os.environ[p] for p in os.environ if not p.startswith(Config.PATRONI_ENV_PREFIX)}
         try:
             proc = PostmasterProcess._from_pidfile(data_dir)
             if proc and not proc._is_postmaster_process():


### PR DESCRIPTION
I run PG clusters using Patroni that have an ODCB backed Foreign Data Wrapper to connect to about 30 different database technologies. Some drivers require environment variables to be set to work properly (It's pretty much the 1990 Wild Wild West). Since Patroni strips out all env variables except a small hard-coded list, I have to run a custom patched version of Patroni that modifies this list of variables.

I understand that Patroni has taken a vary conservative stance by stripping out all env variables except an explicit list since there may be secrets in some ENV vars, but I urge you to reconsider this and to only strip out known PATRONI_ environment variables. 

Typically when someone comes across Patroni, I think it's a fair assumption that they are already running Postgres directly or using pg_ctl. Neither of these tools strip out any environment variables.

Thanks for the consideration!