### PR TITLE
guarantee callback order and serialization of commands

### DIFF
--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -1,40 +1,44 @@
-import logging
-import subprocess
 from threading import Event, Lock, Thread
+import subprocess
+import logging
+import time
+import queue
 
 logger = logging.getLogger(__name__)
 
-
 class CallbackExecutor(Thread):
+    '''
+    Execution thread that queues commands and executes them in order.
+    Guarantees that commands are executed in the order they are received via
+    FIFO queue.
+    '''
 
-    def __init__(self):
+    def __init__(self, executor=subprocess.Popen):
         super(CallbackExecutor, self).__init__()
         self.daemon = True
-        self._lock = Lock()
-        self._cmd = None
-        self._process = None
-        self._callback_event = Event()
+        self._cmds_queue = queue.Queue()
+        self._executor = executor
         self.start()
 
     def call(self, cmd):
-        with self._lock:
-            if self._process and self._process.poll() is None:
-                try:
-                    self._process.kill()
-                    logger.warning('Killed the old callback process because it was still running: %s', self._cmd)
-                except OSError:
-                    logger.exception('Failed to kill the old callback')
-        self._cmd = cmd
-        self._callback_event.set()
+      # Queue up the command
+      self._cmds_queue.put(cmd)
 
     def run(self):
         while True:
-            self._callback_event.wait()
-            self._callback_event.clear()
-            with self._lock:
-                try:
-                    self._process = subprocess.Popen(self._cmd, close_fds=True)
-                except Exception:
-                    logger.exception('Failed to execute %s',  self._cmd)
-                    continue
-            self._process.wait()
+            logger.info("Callback sleeping until new command is queued")
+            cmd = self._cmds_queue.get()
+            cmd_str = ' '.join(cmd)
+            logger.info("Callback executor waking to call {}".format(cmd_str))
+            try:
+                logger.info("Spawning process for {}".format(cmd_str))
+                p = self._executor(cmd, close_fds=True)
+                logger.info("Waiting for {} to complete".format(cmd_str))
+                p.wait()
+            except Exception:
+                logger.exception('Failed to execute %s', cmd_str)
+            # Mark the command as done in the queue. This is probably unnecessary
+            # however if .join() is used later it will be necessary so best
+            # to just do it anyways
+            logger.info("{} has completed".format(cmd_str))
+            self._cmds_queue.task_done()

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -12,11 +12,10 @@ class CallbackExecutor(threading.Thread):
     FIFO queue.
     '''
 
-    def __init__(self, executor=subprocess.Popen):
+    def __init__(self):
         super(CallbackExecutor, self).__init__()
         self.daemon = True
         self._cmds_queue = queue.Queue()
-        self._executor = executor
         self.start()
 
     def call(self, cmd):
@@ -31,7 +30,7 @@ class CallbackExecutor(threading.Thread):
             logger.debug("Callback executor waking to call %s", cmd_str)
             try:
                 logger.debug("Spawning process for %s", cmd_str)
-                p = self._executor(cmd, close_fds=True)
+                p = subprocess.Popen(cmd, close_fds=True)
                 logger.debug("Waiting for %s to complete", cmd_str)
                 p.wait()
                 logger.debug("%s has completed", cmd_str)

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -1,12 +1,11 @@
-from threading import Event, Lock, Thread
+import threading
 import subprocess
 import logging
-import time
 from six.moves import queue
 
 logger = logging.getLogger(__name__)
 
-class CallbackExecutor(Thread):
+class CallbackExecutor(threading.Thread):
     '''
     Execution thread that queues commands and executes them in order.
     Guarantees that commands are executed in the order they are received via

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -2,7 +2,7 @@ from threading import Event, Lock, Thread
 import subprocess
 import logging
 import time
-import queue
+from six.moves import queue
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +26,19 @@ class CallbackExecutor(Thread):
 
     def run(self):
         while True:
-            logger.info("Callback sleeping until new command is queued")
+            logger.debug("Callback sleeping until new command is queued")
             cmd = self._cmds_queue.get()
             cmd_str = ' '.join(cmd)
-            logger.info("Callback executor waking to call {}".format(cmd_str))
+            logger.debug("Callback executor waking to call %s", cmd_str)
             try:
-                logger.info("Spawning process for {}".format(cmd_str))
+                logger.debug("Spawning process for %s", cmd_str)
                 p = self._executor(cmd, close_fds=True)
-                logger.info("Waiting for {} to complete".format(cmd_str))
+                logger.debug("Waiting for %s to complete", cmd_str)
                 p.wait()
+                logger.debug("%s has completed", cmd_str)
             except Exception:
                 logger.exception('Failed to execute %s', cmd_str)
             # Mark the command as done in the queue. This is probably unnecessary
             # however if .join() is used later it will be necessary so best
             # to just do it anyways
-            logger.info("{} has completed".format(cmd_str))
             self._cmds_queue.task_done()

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from mock import mock
 
 from patroni.postgresql.callback_executor import CallbackExecutor
 import time

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -7,12 +7,13 @@ import time
 
 class TestCallbackExecutor(unittest.TestCase):
 
-    def test_callback_executor_calls_commands_in_order(self):
-        mock_popen = mock.MagicMock('subprocess.Popen')
+    @mock.patch('subprocess.Popen')
+    def test_callback_executor_calls_commands_in_order(self, mock_popen):
+        #mock_popen = mock.MagicMock('subprocess.Popen')
         # First command sleep, second return immidately, third throws exception
         mock_popen.return_value.wait.side_effect = [lambda: time.sleep(1), mock.Mock(), Exception]
 
-        ce = CallbackExecutor(mock_popen)
+        ce = CallbackExecutor()
         for x in range(1,4):
           ce.call([str(x)])
 


### PR DESCRIPTION
Closes #1238

Utilizes a FIFO queue for the callback commands received to preserve the order of the callback scripts.

The previous lock mechanism has a bug where the `self._cmd` could be set prior to the command being executed by a different call to the `call` method if the calls were close enough together in time.