### PR TITLE
Kill callback child processes when it is necessary

### DIFF
--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -1,5 +1,6 @@
 import logging
-import subprocess
+import psutil
+
 from threading import Event, Lock, Thread
 
 logger = logging.getLogger(__name__)
@@ -13,19 +14,48 @@ class CallbackExecutor(Thread):
         self._lock = Lock()
         self._cmd = None
         self._process = None
+        self._process_cmd = None
+        self._process_children = []
         self._callback_event = Event()
         self.start()
 
     def call(self, cmd):
-        with self._lock:
-            if self._process and self._process.poll() is None:
-                try:
-                    self._process.kill()
-                    logger.warning('Killed the old callback process because it was still running: %s', self._cmd)
-                except OSError:
-                    logger.exception('Failed to kill the old callback')
+        self._cancel()
         self._cmd = cmd
         self._callback_event.set()
+
+    def _cancel(self):
+        with self._lock:
+            if self._process and self._process.poll() is None and not self._process_children:
+                try:
+                    self._process_children = self._process.children(recursive=True)
+                except psutil.Error:
+                    pass
+
+                try:
+                    self._process.kill()
+                    logger.warning('Killed the old callback process because it was still running: %s',
+                                   self._process_cmd)
+                except psutil.NoSuchProcess:
+                    return
+                except psutil.AccessDenied:
+                    logger.exception('Failed to kill the old callback')
+
+    def _wait(self):
+        self._process.wait()
+
+        waitlist = []
+        with self._lock:
+            for child in self._process_children:
+                if child.is_running():
+                    try:
+                        child.kill()
+                    except psutil.NoSuchProcess:
+                        continue
+                    except psutil.AccessDenied:
+                        pass
+                    waitlist.append(child)
+        psutil.wait_procs(waitlist)
 
     def run(self):
         while True:
@@ -33,8 +63,10 @@ class CallbackExecutor(Thread):
             self._callback_event.clear()
             with self._lock:
                 try:
-                    self._process = subprocess.Popen(self._cmd, close_fds=True)
+                    self._process_children = []
+                    self._process_cmd = self._cmd
+                    self._process = psutil.Popen(self._process_cmd, close_fds=True)
                 except Exception:
                     logger.exception('Failed to execute %s',  self._cmd)
                     continue
-            self._process.wait()
+            self._wait()

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -1,60 +1,32 @@
 import logging
-import psutil
 
-from patroni.postgresql.misc import terminate_processes
-from threading import Event, Lock, Thread
+from patroni.postgresql.cancellable import CancellableExecutor
+from threading import Event, Thread
 
 logger = logging.getLogger(__name__)
 
 
-class CallbackExecutor(Thread):
+class CallbackExecutor(CancellableExecutor, Thread):
 
     def __init__(self):
-        super(CallbackExecutor, self).__init__()
+        CancellableExecutor.__init__(self)
+        Thread.__init__(self)
         self.daemon = True
-        self._lock = Lock()
         self._cmd = None
-        self._process = None
-        self._process_cmd = None
-        self._process_children = []
         self._callback_event = Event()
         self.start()
 
     def call(self, cmd):
-        self._cancel()
+        self._kill_process()
         self._cmd = cmd
         self._callback_event.set()
-
-    def _cancel(self):
-        with self._lock:
-            if self._process and self._process.poll() is None and not self._process_children:
-                try:
-                    self._process_children = self._process.children(recursive=True)
-                except psutil.Error:
-                    pass
-
-                try:
-                    self._process.kill()
-                    logger.warning('Killed the old callback process because it was still running: %s',
-                                   self._process_cmd)
-                except psutil.NoSuchProcess:
-                    return
-                except psutil.AccessDenied:
-                    logger.exception('Failed to kill the old callback')
 
     def run(self):
         while True:
             self._callback_event.wait()
             self._callback_event.clear()
             with self._lock:
-                try:
-                    self._process_children = []
-                    self._process_cmd = self._cmd
-                    self._process = psutil.Popen(self._process_cmd, close_fds=True)
-                except Exception:
-                    logger.exception('Failed to execute %s',  self._cmd)
+                if not self._start_process(self._cmd, close_fds=True):
                     continue
             self._process.wait()
-            with self._lock:
-                children = self._process_children
-            terminate_processes(children)
+            self._kill_children()

--- a/patroni/postgresql/cancellable.py
+++ b/patroni/postgresql/cancellable.py
@@ -92,13 +92,14 @@ class CancellableSubprocess(CancellableExecutor):
                     raise PostgresException('cancelled')
 
                 self._is_cancelled = False
-                if self._start_process(*args, **kwargs):
-                    if communicate_input:
-                        if input_data:
-                            self._process.communicate(input_data)
-                        self._process.stdin.close()
+                started = self._start_process(*args, **kwargs)
 
-                    return self._process.wait()
+            if started:
+                if communicate_input:
+                    if input_data:
+                        self._process.communicate(input_data)
+                    self._process.stdin.close()
+                return self._process.wait()
         finally:
             with self._lock:
                 self._process = None

--- a/patroni/postgresql/misc.py
+++ b/patroni/postgresql/misc.py
@@ -1,4 +1,5 @@
 import logging
+import psutil
 
 from patroni.exceptions import PostgresException
 
@@ -68,3 +69,17 @@ def parse_history(data):
                 yield values
             except (IndexError, ValueError):
                 logger.exception('Exception when parsing timeline history line "%s"', values)
+
+
+def terminate_processes(procs):
+    waitlist = []
+    for proc in procs:
+        if proc.is_running():
+            try:
+                proc.kill()
+            except psutil.NoSuchProcess:
+                continue
+            except psutil.AccessDenied:
+                pass
+            waitlist.append(proc)
+    psutil.wait_procs(waitlist)

--- a/patroni/postgresql/misc.py
+++ b/patroni/postgresql/misc.py
@@ -1,5 +1,4 @@
 import logging
-import psutil
 
 from patroni.exceptions import PostgresException
 
@@ -69,17 +68,3 @@ def parse_history(data):
                 yield values
             except (IndexError, ValueError):
                 logger.exception('Exception when parsing timeline history line "%s"', values)
-
-
-def terminate_processes(procs):
-    waitlist = []
-    for proc in procs:
-        if proc.is_running():
-            try:
-                proc.kill()
-            except psutil.NoSuchProcess:
-                continue
-            except psutil.AccessDenied:
-                pass
-            waitlist.append(proc)
-    psutil.wait_procs(waitlist)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -16,6 +16,7 @@ from . import psycopg2_connect, BaseTestPostgresql
 @patch('os.rename', Mock())
 class TestBootstrap(BaseTestPostgresql):
 
+    @patch('patroni.postgresql.CallbackExecutor', Mock())
     def setUp(self):
         super(TestBootstrap, self).setUp()
         self.b = self.p.bootstrap

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -1,3 +1,4 @@
+import psutil
 import unittest
 
 from mock import Mock, patch
@@ -6,8 +7,9 @@ from patroni.postgresql.callback_executor import CallbackExecutor
 
 class TestCallbackExecutor(unittest.TestCase):
 
-    @patch('subprocess.Popen')
+    @patch('psutil.Popen')
     def test_callback_executor(self, mock_popen):
+        mock_popen.return_value.children.return_value = []
         mock_popen.return_value.wait.side_effect = Exception
         mock_popen.return_value.poll.return_value = None
 
@@ -17,7 +19,21 @@ class TestCallbackExecutor(unittest.TestCase):
 
         self.assertIsNone(ce.call([]))
 
-        mock_popen.return_value.kill.side_effect = OSError
+        mock_popen.return_value.kill.side_effect = psutil.AccessDenied()
+        self.assertIsNone(ce.call([]))
+
+        mock_child = psutil.Popen([])
+        mock_popen.return_value.children.return_value = [mock_child]
+        self.assertIsNone(ce.call([]))
+        ce._process.wait = Mock()
+        ce._wait()
+
+        mock_child.kill.side_effect = psutil.NoSuchProcess(123)
+        ce._wait()
+
+        ce._process_children = []
+        mock_popen.return_value.children.side_effect = psutil.Error()
+        mock_popen.return_value.kill.side_effect = psutil.NoSuchProcess(123)
         self.assertIsNone(ce.call([]))
 
         mock_popen.side_effect = Exception

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -10,12 +10,12 @@ class TestCallbackExecutor(unittest.TestCase):
     @patch('psutil.Popen')
     def test_callback_executor(self, mock_popen):
         mock_popen.return_value.children.return_value = []
-        mock_popen.return_value.poll.return_value = None
+        mock_popen.return_value.is_running.return_value = True
 
-        with patch('patroni.postgresql.callback_executor.terminate_processes', Mock(side_effect=Exception)):
-            ce = CallbackExecutor()
-            self.assertIsNone(ce.call([]))
-            ce.join()
+        ce = CallbackExecutor()
+        ce._kill_children = Mock(side_effect=Exception)
+        self.assertIsNone(ce.call([]))
+        ce.join()
 
         self.assertIsNone(ce.call([]))
 

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -29,6 +29,6 @@ class TestCallbackExecutor(unittest.TestCase):
 
         mock_popen.side_effect = Exception
         ce = CallbackExecutor()
-        ce._callback_event.wait = Mock(side_effect=[None, Exception])
+        ce._condition.wait = Mock(side_effect=[None, Exception])
         self.assertIsNone(ce.call([]))
         ce.join()

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -10,26 +10,17 @@ class TestCallbackExecutor(unittest.TestCase):
     @patch('psutil.Popen')
     def test_callback_executor(self, mock_popen):
         mock_popen.return_value.children.return_value = []
-        mock_popen.return_value.wait.side_effect = Exception
         mock_popen.return_value.poll.return_value = None
 
-        ce = CallbackExecutor()
-        self.assertIsNone(ce.call([]))
-        ce.join()
+        with patch('patroni.postgresql.callback_executor.terminate_processes', Mock(side_effect=Exception)):
+            ce = CallbackExecutor()
+            self.assertIsNone(ce.call([]))
+            ce.join()
 
         self.assertIsNone(ce.call([]))
 
         mock_popen.return_value.kill.side_effect = psutil.AccessDenied()
         self.assertIsNone(ce.call([]))
-
-        mock_child = psutil.Popen([])
-        mock_popen.return_value.children.return_value = [mock_child]
-        self.assertIsNone(ce.call([]))
-        ce._process.wait = Mock()
-        ce._wait()
-
-        mock_child.kill.side_effect = psutil.NoSuchProcess(123)
-        ce._wait()
 
         ce._process_children = []
         mock_popen.return_value.children.side_effect = psutil.Error()

--- a/tests/test_cancellable.py
+++ b/tests/test_cancellable.py
@@ -15,17 +15,18 @@ class TestCancellableSubprocess(unittest.TestCase):
         self.c.cancel()
         self.assertRaises(PostgresException, self.c.call, communicate_input=None)
 
+    def test__kill_children(self):
+        self.c._process_children = [Mock()]
+        self.c._kill_children()
+        self.c._process_children[0].kill.side_effect = psutil.AccessDenied()
+        self.c._kill_children()
+        self.c._process_children[0].kill.side_effect = psutil.NoSuchProcess(123)
+        self.c._kill_children()
+
     @patch('patroni.postgresql.cancellable.polling_loop', Mock(return_value=[0, 0]))
     def test_cancel(self):
         self.c._process = Mock()
         self.c._process.is_running.return_value = True
-
-        self.c._process.children.return_value = [Mock()]
-        self.c.cancel()
-        self.c._process.children.return_value[0].kill.side_effect = psutil.AccessDenied()
-        self.c.cancel()
-        self.c._process.children.return_value[0].kill.side_effect = psutil.NoSuchProcess(123)
-        self.c.cancel()
         self.c._process.children.side_effect = psutil.Error()
         self.c.cancel()
         self.c._process.is_running.side_effect = [True, False]

--- a/tests/test_cancellable.py
+++ b/tests/test_cancellable.py
@@ -28,6 +28,7 @@ class TestCancellableSubprocess(unittest.TestCase):
         self.c._process = Mock()
         self.c._process.is_running.return_value = True
         self.c._process.children.side_effect = psutil.Error()
+        self.c._process.suspend.side_effect = psutil.Error()
         self.c.cancel()
         self.c._process.is_running.side_effect = [True, False]
         self.c.cancel()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -90,6 +90,7 @@ class TestPostgresql(BaseTestPostgresql):
 
     @patch('subprocess.call', Mock(return_value=0))
     @patch('os.rename', Mock())
+    @patch('patroni.postgresql.CallbackExecutor', Mock())
     @patch.object(Postgresql, 'get_major_version', Mock(return_value=120000))
     @patch.object(Postgresql, 'is_running', Mock(return_value=True))
     def setUp(self):
@@ -637,7 +638,7 @@ class TestPostgresql(BaseTestPostgresql):
             data = self.p.read_postmaster_opts()
             self.assertEqual(data, dict())
 
-    @patch('subprocess.Popen')
+    @patch('psutil.Popen')
     def test_single_user_mode(self, subprocess_popen_mock):
         subprocess_popen_mock.return_value.wait.return_value = 0
         self.assertEqual(self.p.single_user_mode('CHECKPOINT', {'archive_mode': 'on'}), 0)


### PR DESCRIPTION
Not doing so makes it hard to implement callbacks in bash and eventually can lead to the situation when two callbacks are running at the same time. In case if we failed to kill the child process we will still wait for it to finish.

The same problem could happen with custom bootstrap, therefore we happen to kill the custom bootstrap process we also kill all child subprocesses.

Closes https://github.com/zalando/patroni/issues/1238