### PR TITLE
Fix race condition in postmaster_start_time()

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -728,9 +728,12 @@ class Postgresql(object):
 
     def postmaster_start_time(self):
         try:
-            cursor = self.query("SELECT pg_catalog.to_char(pg_catalog.pg_postmaster_start_time(),"
-                                " 'YYYY-MM-DD HH24:MI:SS.MS TZ')")
-            return cursor.fetchone()[0]
+            query = "SELECT pg_catalog.to_char(pg_catalog.pg_postmaster_start_time(), 'YYYY-MM-DD HH24:MI:SS.MS TZ')"
+            if current_thread().ident == self.__thread_ident:
+                return self.query(query).fetchone()[0]
+            with self.connection().cursor() as cursor:
+                cursor.execute(query)
+                return cursor.fetchone()[0]
         except psycopg2.Error:
             return None
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -458,6 +458,10 @@ class TestPostgresql(BaseTestPostgresql):
     def test_postmaster_start_time(self):
         with patch.object(MockCursor, "fetchone", Mock(return_value=('foo', True, '', '', '', '', False))):
             self.assertEqual(self.p.postmaster_start_time(), 'foo')
+            t = Thread(target=self.p.postmaster_start_time)
+            t.start()
+            t.join()
+
         with patch.object(MockCursor, "execute", side_effect=psycopg2.Error):
             self.assertIsNone(self.p.postmaster_start_time())
 


### PR DESCRIPTION
when it is executed not from the main thread we need to create a new cursor object.