### PR TITLE
Fix compatibility with different versions of kubernetes module

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -102,8 +102,12 @@ class KubernetesWatcher(Thread):
 
     def _do_watch(self):
         response = self._dcs.start_watch_stream()
-        for line in k8s_watch.watch.iter_resp_lines(response):
-            self._process_event(json.loads(line))
+        try:
+            for line in k8s_watch.watch.iter_resp_lines(response):
+                self._process_event(json.loads(line))
+        finally:
+            response.close()
+            response.release_conn()
 
     def run(self):
         while True:

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -162,5 +162,5 @@ class TestKubernetesWatcher(unittest.TestCase):
         self.assertRaises(SleepException, self.k._watcher.run)
 
     def test_run(self, mock_response):
-        mock_iter_resp_lines.side_effect = Exception
+        mock_response.side_effect = Exception
         self.assertRaises(SleepException, self.k._watcher.run)


### PR DESCRIPTION
Depending on the version the module implements (or don't) its own retry strategy and what is really bad sometimes there are bugs.
Since we already have retries in the Paroni code we avoid using Watch.stream(), but rely on iter_resp_lines function.

Improves #1189