### PR TITLE
striping extra spaces if etcd.hosts is written with spaces i.e. "host1:port1, host2:port2"

### DIFF
--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -416,7 +416,7 @@ class Etcd(AbstractDCS):
             config['hosts'] = []
             for value in hosts:
                 if isinstance(value, six.string_types):
-                    config['hosts'].append(uri(protocol, split_host_port(value, default_port)))
+                    config['hosts'].append(uri(protocol, split_host_port(value.strip(), default_port)))
         elif 'host' in config:
             host, port = split_host_port(config['host'], 2379)
             config['host'] = host


### PR DESCRIPTION
patroni fails to connect to the etcd server if config looks like this:
```
etcd:
    hosts: host1:port1, host2:port2
```
it can be easily fixed with striping strings after split.