### PR TITLE
Move multiprocessing.set_start_method() back to main

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -162,11 +162,6 @@ class Patroni(object):
 
 
 def patroni_main():
-    if sys.version_info >= (3, 4):
-        # The default, forking, method is not a good idea in a multithreaded process: https://bugs.python.org/issue6721
-        import multiprocessing
-        multiprocessing.set_start_method('spawn')
-
     patroni = Patroni()
     try:
         patroni.run()
@@ -203,6 +198,11 @@ def check_psycopg2():
 
 
 def main():
+    import multiprocessing
+    if sys.version_info >= (3, 4):  # pragma: no cover
+        # The default, forking, method is not a good idea in a multithreaded process: https://bugs.python.org/issue6721
+        multiprocessing.set_start_method('spawn')
+
     check_psycopg2()
     if os.getpid() != 1:
         return patroni_main()
@@ -236,7 +236,6 @@ def main():
     signal.signal(signal.SIGABRT, passtochild)
     signal.signal(signal.SIGTERM, passtochild)
 
-    import multiprocessing
     patroni = multiprocessing.Process(target=patroni_main)
     patroni.start()
     pid = patroni.pid

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -66,7 +66,6 @@ class TestPatroni(unittest.TestCase):
 
     @patch('sys.argv', ['patroni.py', 'postgres0.yml'])
     @patch('time.sleep', Mock(side_effect=SleepException))
-    @patch('multiprocessing.set_start_method', Mock(), create=True)
     @patch.object(etcd.Client, 'delete', Mock())
     @patch.object(Client, 'machines', PropertyMock(return_value=['http://remotehost:2379']))
     @patch.object(Thread, 'join', Mock())
@@ -79,12 +78,11 @@ class TestPatroni(unittest.TestCase):
                 with patch('patroni.ha.Ha.is_paused', Mock(return_value=True)):
                     os.environ['PATRONI_POSTGRESQL_DATA_DIR'] = 'data/test0'
                     patroni_main()
-        with patch('patroni.Patroni', Mock(side_effect=Exception)), patch('sys.version_info', (3, 6)):
-            self.assertRaises(Exception, patroni_main)
 
     @patch('os.getpid')
     @patch('multiprocessing.Process')
     @patch('patroni.patroni_main', Mock())
+    @patch('multiprocessing.set_start_method', Mock(), create=True)
     def test_patroni_main(self, mock_process, mock_getpid):
         mock_getpid.return_value = 2
         _main()


### PR DESCRIPTION
It is not possible to call it from forked process