### PR TITLE
Avoid spawning semaphore tracker process

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -198,11 +198,6 @@ def check_psycopg2():
 
 
 def main():
-    import multiprocessing
-    if sys.version_info >= (3, 4):  # pragma: no cover
-        # The default, forking, method is not a good idea in a multithreaded process: https://bugs.python.org/issue6721
-        multiprocessing.set_start_method('spawn')
-
     check_psycopg2()
     if os.getpid() != 1:
         return patroni_main()
@@ -236,6 +231,7 @@ def main():
     signal.signal(signal.SIGABRT, passtochild)
     signal.signal(signal.SIGTERM, passtochild)
 
+    import multiprocessing
     patroni = multiprocessing.Process(target=patroni_main)
     patroni.start()
     pid = patroni.pid

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -9,9 +9,13 @@ import sys
 
 from patroni import PATRONI_ENV_PREFIX
 
-if sys.version_info >= (3, 4):  # pragma: no cover
+# avoid spawning the resource tracker process
+if sys.version_info >= (3, 8):  # pragma: no cover
+    import multiprocessing.resource_tracker
+    multiprocessing.resource_tracker.getfd = lambda: 0
+elif sys.version_info >= (3, 4):  # pragma: no cover
     import multiprocessing.semaphore_tracker
-    multiprocessing.semaphore_tracker.getfd = lambda: 0  # avoid spawning the semaphore_tracker process
+    multiprocessing.semaphore_tracker.getfd = lambda: 0
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -112,7 +112,8 @@ class TestBootstrap(BaseTestPostgresql):
         config = {'users': {'replicator': {'password': 'rep-pass', 'options': ['replication']}}}
 
         with patch.object(Postgresql, 'is_running', Mock(return_value=False)),\
-                patch('multiprocessing.Process', Mock(side_effect=Exception)):
+                patch('multiprocessing.Process', Mock(side_effect=Exception)),\
+                patch('multiprocessing.get_context', Mock(side_effect=Exception), create=True):
             self.assertRaises(Exception, self.b.bootstrap, config)
         with open(os.path.join(self.p.data_dir, 'pg_hba.conf')) as f:
             lines = f.readlines()
@@ -140,6 +141,7 @@ class TestBootstrap(BaseTestPostgresql):
 
         mock_cancellable_subprocess_call.return_value = 0
         with patch('multiprocessing.Process', Mock(side_effect=Exception("42"))),\
+                patch('multiprocessing.get_context', Mock(side_effect=Exception("42")), create=True),\
                 patch('os.path.isfile', Mock(return_value=True)),\
                 patch('os.unlink', Mock()),\
                 patch.object(ConfigHandler, 'save_configuration_files', Mock()),\

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -82,7 +82,6 @@ class TestPatroni(unittest.TestCase):
     @patch('os.getpid')
     @patch('multiprocessing.Process')
     @patch('patroni.patroni_main', Mock())
-    @patch('multiprocessing.set_start_method', Mock(), create=True)
     def test_patroni_main(self, mock_process, mock_getpid):
         mock_getpid.return_value = 2
         _main()

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import psutil
 import unittest
 
@@ -96,6 +97,7 @@ class TestPostmasterProcess(unittest.TestCase):
     @patch('subprocess.Popen')
     @patch('os.setsid', Mock(), create=True)
     @patch('multiprocessing.Process', MockProcess)
+    @patch('multiprocessing.get_context', Mock(return_value=multiprocessing), create=True)
     @patch.object(PostmasterProcess, 'from_pid')
     @patch.object(PostmasterProcess, '_from_pidfile')
     def test_start(self, mock_frompidfile, mock_frompid, mock_popen):


### PR DESCRIPTION
We are not using semaphores, therefore we don't need to track them.