### PR TITLE
Test I/O before feeding the (watch)dog

### DIFF
--- a/patroni/watchdog/linux.py
+++ b/patroni/watchdog/linux.py
@@ -1,8 +1,11 @@
 import collections
 import ctypes
+import logging
 import os
 import platform
 from patroni.watchdog.base import WatchdogBase, WatchdogError
+
+logger = logging.getLogger(__name__)
 
 # Pythonification of linux/ioctl.h
 IOC_NONE = 0
@@ -143,6 +146,7 @@ class LinuxWatchdogDevice(WatchdogBase):
 
     def close(self):
         if self.is_running:
+            logger.debug('stop feeding the dog')
             try:
                 os.write(self._fd, b'V')
                 os.close(self._fd)
@@ -192,6 +196,7 @@ class LinuxWatchdogDevice(WatchdogBase):
 
     def keepalive(self):
         try:
+            logger.debug('feeding the dog')
             os.write(self._fd, b'1')
         except OSError as e:
             raise WatchdogError("Could not send watchdog keepalive: {0}".format(e))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -169,6 +169,7 @@ def run_async(self, func, args=()):
 @patch.object(etcd.Client, 'write', etcd_write)
 @patch.object(etcd.Client, 'read', etcd_read)
 @patch.object(etcd.Client, 'delete', Mock(side_effect=etcd.EtcdException))
+@patch.object(Watchdog, '_write_test_file', Mock())
 @patch('patroni.postgresql.polling_loop', Mock(return_value=range(1)))
 @patch('patroni.async_executor.AsyncExecutor.busy', PropertyMock(return_value=False))
 @patch('patroni.async_executor.AsyncExecutor.run_async', run_async)


### PR DESCRIPTION
RDBMS, PostgreSQL included, are highly dependent of disk i/o to perform correctly. PostgreSQL doesn't work on read-only file systems. There is no point of letting a primary node alive when it can't write to its own data directory.

This commit implements a test file write in the data directory before feeding the watchdog. The primary host will reboot when there is a read-only file system or an i/o freeze longer than the watchdog timeout. Patroni will elect a new leader and recover the service automatically.