### PR TITLE
Fix permissions for openshift block devices

### DIFF
--- a/kubernetes/openshift-example/templates/template_patroni_persistent.yaml
+++ b/kubernetes/openshift-example/templates/template_patroni_persistent.yaml
@@ -106,6 +106,20 @@ objects:
           application: ${APPLICATION_NAME}
           cluster-name: ${PATRONI_CLUSTER_NAME}
       spec:
+        initContainers:
+        - command:
+          - chmod
+          - '0700'
+          - /home/postgres/pgdata/pgroot/data
+          image: docker-registry.default.svc:5000/${NAMESPACE}/patroni:latest
+          imagePullPolicy: IfNotPresent
+          name: fix-perms
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /home/postgres/pgdata
+            name: ${APPLICATION_NAME}
         containers:
         - env:
           - name: PATRONI_KUBERNETES_POD_IP

--- a/kubernetes/openshift-example/templates/template_patroni_persistent.yaml
+++ b/kubernetes/openshift-example/templates/template_patroni_persistent.yaml
@@ -108,9 +108,9 @@ objects:
       spec:
         initContainers:
         - command:
-          - chmod
-          - '0700'
-          - /home/postgres/pgdata/pgroot/data
+          - sh
+          - -c 
+          - "mkdir -p /home/postgres/pgdata/pgroot/data && chmod 0700 /home/postgres/pgdata/pgroot/data"
           image: docker-registry.default.svc:5000/${NAMESPACE}/patroni:latest
           imagePullPolicy: IfNotPresent
           name: fix-perms


### PR DESCRIPTION
OpenShift enforces securityContext.fsGroups for block devices and sets group stickybits for volumeMounts.

This leads to patroni pods failing to start after the first restart:
> 2020-01-13 14:46:13.695 UTC [143] FATAL:  data directory "/home/postgres/pgdata/pgroot/data" has invalid permissions
2020-01-13 14:46:13.695 UTC [143] DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).

A initContainer which fixes the OpenShift tampering solves the issue. I stole the solution from the stable postgres helm chart:
https://github.com/helm/charts/pull/14540/files

Tested on OpenShift v3.11

Note: This error does not occur when using shared filesystems (like NFS)