### PR TITLE
Show tags for member via patronictl

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -726,7 +726,7 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
     cluster = cluster_as_json(cluster)
 
     columns = ['Cluster', 'Member', 'Host', 'Role', 'State', 'TL', 'Lag in MB']
-    for c in ('Pending restart', 'Scheduled restart'):
+    for c in ('Pending restart', 'Scheduled restart', 'Tags'):
         if extended or any(m.get(c.lower().replace(' ', '_')) for m in cluster['members']):
             columns.append(c)
 
@@ -741,7 +741,8 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
         m.update(cluster=name, member=m['name'], tl=m.get('timeline', ''),
                  role='' if m['role'] == 'replica' else m['role'].replace('_', ' ').title(),
                  lag_in_mb=round(lag/1024/1024) if isinstance(lag, six.integer_types) else lag,
-                 pending_restart='*' if m.get('pending_restart') else '')
+                 pending_restart='*' if m.get('pending_restart') else '',
+                 tags=m.get('tags', ''))
 
         if append_port:
             m['host'] = ':'.join([m['host'], str(m['port'])])

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -742,7 +742,7 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
                  role='' if m['role'] == 'replica' else m['role'].replace('_', ' ').title(),
                  lag_in_mb=round(lag/1024/1024) if isinstance(lag, six.integer_types) else lag,
                  pending_restart='*' if m.get('pending_restart') else '',
-                 tags=m.get('tags', ''))
+                 tags=json.dumps(m['tags']) if m.get('tags') else '')
 
         if append_port:
             m['host'] = ':'.join([m['host'], str(m['port'])])
@@ -755,7 +755,7 @@ def output_members(cluster, name, extended=False, fmt='pretty'):
 
         rows.append([m.get(n.lower().replace(' ', '_'), '') for n in columns])
 
-    print_output(columns, rows, {'Lag in MB': 'r', 'TL': 'r'}, fmt)
+    print_output(columns, rows, {'Lag in MB': 'r', 'TL': 'r', 'Tags': 'l'}, fmt)
 
     if fmt != 'pretty':  # Omit service info when using machine-readable formats
         return


### PR DESCRIPTION
Add one more field to patronictl output to check tags defined for a member.
Closes #1375 

<details><summary>Examples for various output formats</summary>
<p>

#### Pretty
```
+---------+-------------+----------------+--------+---------+----+-----------+-----------------+---------------------------+---------------------------------------------+
| Cluster |    Member   |      Host      |  Role  |  State  | TL | Lag in MB | Pending restart |     Scheduled restart     |                     Tags                    |
+---------+-------------+----------------+--------+---------+----+-----------+-----------------+---------------------------+---------------------------------------------+
|  batman | postgresql0 | 127.0.0.1:5432 | Leader | running |  1 |           |        *        | 2020-02-01T19:00:00+02:00 |                                             |
|  batman | postgresql1 | 127.0.0.1:5433 |        | running |  1 |         0 |        *        | 2020-02-01T19:00:00+02:00 | {'nofailover': True, 'noloadbalance': True} |
|  batman | postgresql2 | 127.0.0.1:5434 |        | running |  1 |         0 |        *        |                           |        {'replicatefrom': 'postgres1'}       |
+---------+-------------+----------------+--------+---------+----+-----------+-----------------+---------------------------+---------------------------------------------+
```
#### YAML
```
- Cluster: batman
  Host: 127.0.0.1:5432
  Lag in MB: ''
  Member: postgresql0
  Pending restart: '*'
  Role: Leader
  Scheduled restart: '2020-02-01T19:00:00+02:00'
  State: running
  TL: 1
  Tags: ''
- Cluster: batman
  Host: 127.0.0.1:5433
  Lag in MB: 0
  Member: postgresql1
  Pending restart: '*'
  Role: ''
  Scheduled restart: '2020-02-01T19:00:00+02:00'
  State: running
  TL: 1
  Tags:
    nofailover: true
    noloadbalance: true
- Cluster: batman
  Host: 127.0.0.1:5434
  Lag in MB: 0
  Member: postgresql2
  Pending restart: '*'
  Role: ''
  Scheduled restart: ''
  State: running
  TL: 1
  Tags:
    replicatefrom: postgres1
```
#### JSON
```
[
  {
    "Cluster": "batman",
    "Member": "postgresql0",
    "Host": "127.0.0.1:5432",
    "Role": "Leader",
    "State": "running",
    "TL": 1,
    "Lag in MB": "",
    "Pending restart": "*",
    "Scheduled restart": "2020-02-01T19:00:00+02:00",
    "Tags": ""
  },
  {
    "Cluster": "batman",
    "Member": "postgresql1",
    "Host": "127.0.0.1:5433",
    "Role": "",
    "State": "running",
    "TL": 1,
    "Lag in MB": 0,
    "Pending restart": "*",
    "Scheduled restart": "2020-02-01T19:00:00+02:00",
    "Tags": {
      "nofailover": true,
      "noloadbalance": true
    }
  },
  {
    "Cluster": "batman",
    "Member": "postgresql2",
    "Host": "127.0.0.1:5434",
    "Role": "",
    "State": "running",
    "TL": 1,
    "Lag in MB": 0,
    "Pending restart": "*",
    "Scheduled restart": "",
    "Tags": {
      "replicatefrom": "postgres1"
    }
  }
]
```
</p>
</details>