### PR TITLE
Get rid of dependency on tzlocal module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
       - expect-dev # for unbuffer
 env:
   global:
-  - ETCDVERSION=3.0.17 ZKVERSION=3.4.11 CONSULVERSION=0.7.4
+  - ETCDVERSION=3.0.17 ZKVERSION=3.4.14 CONSULVERSION=0.7.4
   - PYVERSIONS="2.7 3.5 3.6"
   - EXCLUDE_BEHAVE="3.5"
   - BOTO_CONFIG=/doesnotexist

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -6,6 +6,7 @@ import click
 import codecs
 import datetime
 import dateutil.parser
+import dateutil.tz
 import cdiff
 import copy
 import difflib
@@ -19,7 +20,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import tzlocal
 import yaml
 
 from click import ClickException
@@ -445,7 +445,7 @@ def parse_scheduled(scheduled):
         try:
             scheduled_at = dateutil.parser.parse(scheduled)
             if scheduled_at.tzinfo is None:
-                scheduled_at = tzlocal.get_localzone().localize(scheduled_at)
+                scheduled_at = scheduled_at.replace(tzinfo=dateutil.tz.tzlocal())
         except (ValueError, TypeError):
             message = 'Unable to parse scheduled timestamp ({0}). It should be in an unambiguous format (e.g. ISO 8601)'
             raise PatroniCtlException(message.format(scheduled))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ python-etcd>=0.4.3,<0.5
 python-consul>=0.7.1
 click>=4.1
 prettytable>=0.7
-tzlocal
 python-dateutil
 psutil>=2.0.0
 cdiff


### PR DESCRIPTION
It was used only to add the local timezone to the datetime specified in the patronictl for scheduled switchover or restart.
The `dateutil.tz.tzlocal()` does the same job equally well.