### PR TITLE
Disable SSL verification for Consul

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -55,6 +55,8 @@ class HTTPClient(object):
             kwargs['ca_certs'] = ca_cert
         if verify or ca_cert:
             kwargs['cert_reqs'] = ssl.CERT_REQUIRED
+        else:
+            kwargs['cert_reqs'] = ssl.CERT_NONE
         self.http = urllib3.PoolManager(num_pools=10, **kwargs)
         self._ttl = None
 


### PR DESCRIPTION
Consul client uses urllib3 with a verify=True by default. When
SSL verification is disabled with verify=False, we can see
CERTIFICATE_VERIFY_FAILED exceptions. With urllib3 1.19.1-1 on
Debian Stretch, the "cert_reqs" argument  must be explicitaly set
to ssl.CERT_NONE to effectively disable SSL verification.