### PR TITLE
Scrub KUBERNETES_ environment from the postmaster

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -9,6 +9,7 @@ from patroni.version import __version__
 logger = logging.getLogger(__name__)
 
 PATRONI_ENV_PREFIX = 'PATRONI_'
+KUBERNETES_ENV_PREFIX = 'KUBERNETES_'
 
 
 class Patroni(object):

--- a/patroni/postgresql/postmaster.py
+++ b/patroni/postgresql/postmaster.py
@@ -7,7 +7,7 @@ import signal
 import subprocess
 import sys
 
-from patroni import PATRONI_ENV_PREFIX
+from patroni import PATRONI_ENV_PREFIX, KUBERNETES_ENV_PREFIX
 
 # avoid spawning the resource tracker process
 if sys.version_info >= (3, 8):  # pragma: no cover
@@ -176,7 +176,8 @@ class PostmasterProcess(psutil.Process):
         # In order to make everything portable we can't use fork&exec approach here, so  we will call
         # ourselves and pass list of arguments which must be used to start postgres.
         # On Windows, in order to run a side-by-side assembly the specified env must include a valid SYSTEMROOT.
-        env = {p: os.environ[p] for p in os.environ if not p.startswith(PATRONI_ENV_PREFIX)}
+        env = {p: os.environ[p] for p in os.environ if not p.startswith(
+            PATRONI_ENV_PREFIX) and not p.startswith(KUBERNETES_ENV_PREFIX)}
         try:
             proc = PostmasterProcess._from_pidfile(data_dir)
             if proc and not proc._is_postmaster_process():


### PR DESCRIPTION
The `KUBERNETES_` environment variables are not required for PostgreSQL,
yet having them exposed to the postmaster will also expose them to
backends and to regular database users (using pl/perl for example).

Currently, when starting up PostgreSQL in our Kubernetes cluster, these are the environment variables that I can look at as a regular user:

```
 KUBERNETES_PORT_443_TCP       | tcp://10.152.183.1:443
 KUBERNETES_PORT_443_TCP_ADDR  | 10.152.183.1
 KUBERNETES_PORT_443_TCP_PORT  | 443
 KUBERNETES_PORT_443_TCP_PROTO | tcp
 KUBERNETES_SERVICE_HOST       | 10.152.183.1
 KUBERNETES_SERVICE_PORT       | 443
 KUBERNETES_SERVICE_PORT_HTTPS | 443
 LANG                          | C.UTF-8
 LC_COLLATE                    | C.UTF-8
 LC_CTYPE                      | C.UTF-8
 LC_MESSAGES                   | C.UTF-8
 LC_MONETARY                   | C
 LC_NUMERIC                    | C
 LC_TIME                       | C
 PATH                          | /usr/lib/postgresql/11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 PGDATA                        | /var/lib/postgresql/data
 PGHOST                        | /var/run/postgresql
 PGLOCALEDIR                   | /usr/share/locale
 PGSYSCONFDIR                  | /etc/postgresql-common
```
Although the information contained by the variables doesn't seem to be too worrysome, I'd rather not expose them altogether, and have the environment look like this:

```
     name     |                                          value                                          
--------------+-----------------------------------------------------------------------------------------
 LANG         | C.UTF-8
 LC_COLLATE   | C.UTF-8
 LC_CTYPE     | C.UTF-8
 LC_MESSAGES  | C.UTF-8
 LC_MONETARY  | C
 LC_NUMERIC   | C
 LC_TIME      | C
 PATH         | /usr/lib/postgresql/11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 PGDATA       | /var/lib/postgresql/data
 PGHOST       | /var/run/postgresql
 PGLOCALEDIR  | /usr/share/locale
 PGSYSCONFDIR | /etc/postgresql-common
(12 rows)
```