### PR TITLE
Sleep when encountering Exception

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -191,6 +191,7 @@ class ObjectCache(Thread):
                 with self._condition:
                     self._is_ready = False
                 logger.error('ObjectCache.run %r', e)
+                time.sleep(1)
 
     def is_ready(self):
         """Must be called only when holding the lock on `_condition`"""


### PR DESCRIPTION
When an exception is thrown when refreshing the cache, the retry is
immediate. In one instance this caused our deployment to loop very fast
without giving a lot of useful information, an excerpt from the
incident:

    2020-03-10 09:44:21,212 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,213 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,214 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,214 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,215 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,215 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,216 ERROR: ObjectCache.run ApiException()
    2020-03-10 09:44:21,216 ERROR: ObjectCache.run ApiException()

In this case, a permission issue was the culprit, but sleeping for a
while for every exception seems reasonable, as to not be consuming a
full CPU, and not to be generating a huge amount of log output.