### PR TITLE
Feature: Tags/noslotdrop: retain inactive replication slots

### DIFF
--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -240,3 +240,4 @@ Tags
 - **noloadbalance**: ``true`` or ``false``. If set to ``true`` the node will return HTTP Status Code 503 for the ``GET /replica`` REST API health-check and therefore will be excluded from the load-balancing. Defaults to ``false``.
 - **replicatefrom**: The IP address/hostname of another replica. Used to support cascading replication.
 - **nosync**: ``true`` or ``false``. If set to ``true`` the node will never be selected as a synchronous replica.
+- **noslotdrop**: ``true`` or ``false``. If set to ``true`` the node will retain the inactive replication slots. Defaults to ``false``. Patroni drops related physical replication slots by default, when the standby is taken offline for maintenance. When set to ``true``, it retains the slot.

--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -61,7 +61,7 @@ class Patroni(object):
 
     def get_tags(self):
         return {tag: value for tag, value in self.config.get('tags', {}).items()
-                if tag not in ('clonefrom', 'nofailover', 'noloadbalance', 'nosync') or value}
+                if tag not in ('clonefrom', 'nofailover', 'noloadbalance', 'nosync', 'noslotdrop') or value}
 
     @property
     def nofailover(self):

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -196,6 +196,10 @@ class Member(namedtuple('Member', 'index,name,session,data')):
         return self.tags.get('clonefrom', False) and bool(self.conn_url)
 
     @property
+    def noslotdrop(self):
+        return self.tags.get('noslotdrop', False)
+
+    @property
     def state(self):
         return self.data.get('state', 'unknown')
 

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -374,6 +374,7 @@ schema = Schema({
     Optional("clonefrom"): bool,
     Optional("noloadbalance"): bool,
     Optional("replicatefrom"): str,
-    Optional("nosync"): bool
+    Optional("nosync"): bool,
+    Optional("noslotdrop"): bool
   }
 })


### PR DESCRIPTION
Patroni drops unused & undefined (in slots section) replication slots by default including replica related replication slot when the replica is taken offline for planned maintenance. This affects the replica when it rejoins the cluster and if the required wal logs are already removed from the disk. 

A new tag **_noslotdrop_** (True|False, defaults to False) is being added as part of this change. When this tag is set to True (on master), Patroni will not drop the unused and undefined replication slots when the replicas are taken offline. This helps to retain wal logs on master when replicas are taken offline for maintenance. Please note that this may lead to a large number of wal logs accumulating in the file system and cause the file system to become full if the replicas are taken offline for an extended period.

## Tags     [![Tags](https://readthedocs.org/projects/patroni/badge/?version=latest)](https://patroni.readthedocs.io/en/latest/SETTINGS.html#tags)

- **noslotdrop**: ``true`` or ``false``. If set to ``true`` the node will retain the inactive replication slots. Defaults to ``false``. Patroni drops physical replication slots by default, when the replica is taken offline for maintenance. When set to ``true``, it retains the slot.