### PR TITLE
WIP: Feature: Plugin for additional health check

### DIFF
--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -170,6 +170,7 @@ PostgreSQL
         -  **sslcert**: (optional) maps to the `sslcert <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERT>`__ connection parameter, which specifies the location of the client certificate.
         -  **sslrootcert**: (optional) maps to the `sslrootcert <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT>`__ connection parameter, which specifies the location of a file containing one ore more certificate authorities (CA) certificates that the client will use to verify a server's certificate.
         -  **sslcrl**: (optional) maps to the `sslcrl <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCRL>`__ connection parameter, which specifies the location of a file containing a certificate revocation list. A client will reject connecting to any server that has a certificate present in this list.
+- **liveness**: 
 -  **callbacks**: callback scripts to run on certain actions. Patroni will pass the action, role and cluster name. (See scripts/aws.py as an example of how to write them.)
         -  **on\_reload**: run this script when configuration reload is triggered.
         -  **on\_restart**: run this script when the postgres restarts (without changing role).


### PR DESCRIPTION
## Feature: Plugin for additional health check

Patroni keeps a persistent Postgres connection for health checks. If the postmaster doesn't respond or hang for some reason (Issue described in [1371](https://github.com/zalando/patroni/issues/1371)), the query will continue to run normally though the master is in an unhealthy state.

**Change**:
Plugin for additional health check on master node. 

```
....
postgresql:
liveness:
  probe: /..../db_conn.py
  max_failures: 20
  timeout: 3
  interval: 300
callbacks:
  on_role_change: /.../xyz.py
connect_address: abc1:4335
....
```

**probe**: The plugin process should be very quick and should not engage the thread for a long time. It could be a very simple one making a new connection request to the master. The plugin call could be an expensive operation & may add overhead if it runs through each run cycle.
**interval**: Patroni should run the plugin at specified interval to reduce the overhead.
**timeout**: The time Patroni allowed to wait for the plugin process to complete. It should terminate the process if it exceeds the timeout.
**max_failures**: Maximum failures Patroni can tolerate (Patroni should not take action when value set to <= 0, it can initiate failover if the value set to >0  and if the # of failures > max_failures).