### PR TITLE
Patronictl - fail if a config file is specified explicitly but not found

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -69,7 +69,11 @@ def load_config(path, dcs):
     from patroni.config import Config
 
     if not (os.path.exists(path) and os.access(path, os.R_OK)):
-        logging.debug('Ignoring configuration file "%s". It does not exists or is not readable.', path)
+        if path != CONFIG_FILE_PATH:    # bail if non-default config location specified but file not found / readable
+            raise PatroniCtlException('Provided config file {0} not existing or no read rights.'
+                                      ' Check the -c/--config-file parameter'.format(path))
+        else:
+            logging.debug('Ignoring configuration file "%s". It does not exists or is not readable.', path)
     else:
         logging.debug('Loading configuration from file %s', path)
     config = Config(path, validator=None).copy()

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -24,7 +24,6 @@ CONFIG_FILE_PATH = './test-ctl.yaml'
 def test_rw_config():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        load_config(CONFIG_FILE_PATH + '/dummy', None)
         store_config({'etcd': {'host': 'localhost:2379'}}, CONFIG_FILE_PATH + '/dummy')
         load_config(CONFIG_FILE_PATH + '/dummy', '0.0.0.0')
         os.remove(CONFIG_FILE_PATH + '/dummy')
@@ -42,6 +41,12 @@ class TestCtl(unittest.TestCase):
             mock_machines.__get__ = Mock(return_value=['http://remotehost:2379'])
             self.runner = CliRunner()
             self.e = get_dcs({'etcd': {'ttl': 30, 'host': 'ok:2379', 'retry_timeout': 10}}, 'foo')
+
+    def test_abort_on_missing_or_unaccessible_config(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with self.assertRaises(PatroniCtlException):
+                load_config('./non-existing-config-file', None)
 
     @patch('psycopg2.connect', psycopg2_connect)
     def test_get_cursor(self):


### PR DESCRIPTION
For some reason patronictl currently does not complain when an explicitly provided config file does not exists. Is that on purpose? 
Countless times I've written something like that:
```
$ python3 patronictl.py -c postgresql0.yml list
2020-03-27 13:28:15,773 - WARNING - Listing members: No cluster names were provided
```
With the patched version it would bail out if non-default file location does not exist:
```
$ python3 patronictl.py -c postgresql0.yml list
Error: Provided config file postgresql0.yml not existing or no read rights. Check the -c/--config-file parameter
```