### PR TITLE
Simplify Dockerfile to avoid the unnecessary problems caused by compression

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,12 +1,5 @@
 #!/bin/sh
 
-if [ -f /a.tar.xz ]; then
-    echo "decompressing image..."
-    sudo tar xpJf /a.tar.xz -C / > /dev/null 2>&1
-    sudo rm /a.tar.xz
-    sudo ln -snf dash /bin/sh
-fi
-
 readonly PATRONI_SCOPE=${PATRONI_SCOPE:-batman}
 PATRONI_NAMESPACE=${PATRONI_NAMESPACE:-/service}
 readonly PATRONI_NAMESPACE=${PATRONI_NAMESPACE%/}

--- a/extras/confd/templates/haproxy.tmpl
+++ b/extras/confd/templates/haproxy.tmpl
@@ -1,10 +1,10 @@
 global
-	maxconn 100
+	maxconn 2000
 
 defaults
 	log	global
 	mode	tcp
-	retries 2
+	retries	2
 	timeout client 30m
 	timeout connect 4s
 	timeout server 30m
@@ -21,12 +21,12 @@ listen master
 	option httpchk OPTIONS /master
 	http-check expect status 200
 	default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
-{{range gets "/members/*"}}	server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} maxconn 100 check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
+{{range gets "/members/*"}}	server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} maxconn 1000 check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}
 listen replicas
 	bind *:5001
 	option httpchk OPTIONS /replica
 	http-check expect status 200
 	default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
-{{range gets "/members/*"}}	server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} maxconn 100 check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
+{{range gets "/members/*"}}	server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} maxconn 500 check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}


### PR DESCRIPTION
If COMPRESS is specified during construction, an error will be reported during startup.

```shell
# prod@tao-infra-01 /opt/patroni/bin $ docker logs -f postgres_pg01.xxx
# decompressing image...
# sudo: unable to resolve host pg01
# sudo: unable to resolve host pg01
# hostname: unrecognized option '--ip-address'
# BusyBox v1.22.1 (Debian 1:1.22.0-19+b3) multi-call binary.

# Usage: hostname [OPTIONS] [HOSTNAME | -F FILE]

# Get or set hostname or DNS domain name

# 	-s	Short
# 	-i	Addresses for the hostname
# 	-d	DNS domain name
# 	-f	Fully qualified domain name
# 	-F FILE	Use FILE's content as hostname

# python3: error while loading shared libraries: libexpat.so.1: cannot open shared object file: No such file or directory
```