### PR TITLE
To issue checkpoint after the promotion

### DIFF
--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -174,6 +174,7 @@ def run_async(self, func, args=()):
 @patch('patroni.async_executor.AsyncExecutor.run_async', run_async)
 @patch('subprocess.call', Mock(return_value=0))
 @patch('time.sleep', Mock())
+@patch.object(Ha, '_do_checkpoint_after_promote', Mock(return_value=None))
 class TestHa(PostgresInit):
 
     @patch('socket.getaddrinfo', socket_getaddrinfo)


### PR DESCRIPTION
After the failover, the old primary waits on checkpoint to happen on the new primary before starting the rewind process.
This change request is to do a checkpoint on the primary right after the promotion to prevent the message like
2020-04-12 12:33:08,427 INFO 140054969964288 rewind.py execute 171: Waiting for checkpoint on <new_primary> before rewind

Reference to  PR https://github.com/zalando/patroni/pull/1490 