### PR TITLE
Wake up the main thread after checkpoint is done

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -945,7 +945,7 @@ class Ha(object):
                     return msg
 
                 # check if the node is ready to be used by pg_rewind
-                self._rewind.ensure_checkpoint_after_promote()
+                self._rewind.ensure_checkpoint_after_promote(self.wakeup)
 
                 if self.is_standby_cluster():
                     # in case of standby cluster we don't really need to

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -117,16 +117,16 @@ class TestRewind(BaseTestPostgresql):
     @patch.object(Postgresql, 'checkpoint')
     def test_ensure_checkpoint_after_promote(self, mock_checkpoint, mock_controldata):
         mock_checkpoint.return_value = None
-        self.r.ensure_checkpoint_after_promote()
-        self.r.ensure_checkpoint_after_promote()
+        self.r.ensure_checkpoint_after_promote(Mock())
+        self.r.ensure_checkpoint_after_promote(Mock())
 
         self.r.reset_state()
         mock_controldata.return_value = {"Latest checkpoint's TimeLineID": 1}
         mock_checkpoint.side_effect = Exception
-        self.r.ensure_checkpoint_after_promote()
-        self.r.ensure_checkpoint_after_promote()
+        self.r.ensure_checkpoint_after_promote(Mock())
+        self.r.ensure_checkpoint_after_promote(Mock())
 
         self.r.reset_state()
         mock_controldata.side_effect = TypeError
-        self.r.ensure_checkpoint_after_promote()
-        self.r.ensure_checkpoint_after_promote()
+        self.r.ensure_checkpoint_after_promote(Mock())
+        self.r.ensure_checkpoint_after_promote(Mock())


### PR DESCRIPTION
Replicas are waiting for checkpoint indication via member key of the leader in DCS. The key is normally updated only one time per HA loop.
Without waking the main thread up replicas will have to wait up to `loop_wait` seconds longer than necessary.