### PR TITLE
Use pg_rewind with --restore-target-wal on 13 if possible

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -653,6 +653,15 @@ class Postgresql(object):
             return False
         return True
 
+    def get_guc_value(self, name):
+        cmd = [self.pgcommand('postgres'), self._data_dir, '-C', name]
+        try:
+            data = subprocess.check_output(cmd)
+            if data:
+                return data.decode('utf-8').strip()
+        except Exception as e:
+            logger.error('Failed to execute %s: %r', cmd, e)
+
     def controldata(self):
         """ return the contents of pg_controldata, or non-True value if pg_controldata call failed """
         result = {}

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -171,9 +171,13 @@ class Rewind(object):
         env['PGOPTIONS'] = '-c statement_timeout=0'
         dsn = self._postgresql.config.format_dsn(r, True)
         logger.info('running pg_rewind from %s', dsn)
+
+        cmd = [self._postgresql.pgcommand('pg_rewind')]
+        if self._postgresql.major_version >= 130000 and self._postgresql.get_guc_value('restore_command'):
+            cmd.append('--restore-target-wal')
+        cmd.extend(['-D', self._postgresql.data_dir, '--source-server', dsn])
         try:
-            return self._postgresql.cancellable.call([self._postgresql.pgcommand('pg_rewind'), '-D',
-                                                      self._postgresql.data_dir, '--source-server', dsn], env=env) == 0
+            return self._postgresql.cancellable.call(cmd, env=env) == 0
         except OSError:
             return False
 


### PR DESCRIPTION
On PostgreSQL 13 check if restore_command is configured and tell pg_rewind to use it.