### PR TITLE
Properly handle the exception raised from refresh_session

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -367,7 +367,11 @@ class Consul(AbstractDCS):
     def touch_member(self, data, permanent=False):
         cluster = self.cluster
         member = cluster and cluster.get_member(self._name, fallback_to_leader=False)
-        create_member = not permanent and self.refresh_session()
+
+        try:
+            create_member = not permanent and self.refresh_session()
+        except DCSError:
+            return False
 
         if member and (create_member or member.session != self._session):
             self._client.kv.delete(self.member_path)

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1367,8 +1367,12 @@ class Ha(object):
 
     def run_cycle(self):
         with self._async_executor:
-            info = self._run_cycle()
-            return (self.is_paused() and 'PAUSE: ' or '') + info
+            try:
+                info = self._run_cycle()
+                return (self.is_paused() and 'PAUSE: ' or '') + info
+            except Exception:
+                logger.exception('Unexpected exception')
+                return 'Unexpected exception raised, please report it as a BUG'
 
     def shutdown(self):
         if self.is_paused():

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -122,6 +122,8 @@ class TestConsul(unittest.TestCase):
         self.c.refresh_session = Mock(return_value=True)
         for _ in range(0, 4):
             self.c.touch_member({'balbla': 'blabla'})
+        self.c.refresh_session = Mock(side_effect=ConsulError('foo'))
+        self.assertFalse(self.c.touch_member({'balbla': 'blabla'}))
 
     @patch.object(consul.Consul.KV, 'put', Mock(side_effect=InvalidSession))
     def test_take_leader(self):

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1069,3 +1069,8 @@ class TestHa(PostgresInit):
         self.ha.cluster = get_cluster_initialized_without_leader(leader=True, cluster_config=config)
         self.ha.has_lock = true
         self.assertEqual(self.ha.run_cycle(), 'no action.  i am the leader with the lock')
+
+    @patch.object(Cluster, 'has_member', true)
+    def test_run_cycle(self):
+        self.ha.dcs.touch_member = Mock(side_effect=DCSError('foo'))
+        self.assertEqual(self.ha.run_cycle(), 'Unexpected exception raised, please report it as a BUG')


### PR DESCRIPTION
The `touch_member()` could be called from the finally block of the `_run_cycle()`. In case if it raised an exception the whole Patroni process was crashing.
In order to avoid future crashes we wrap `_run_cycle()` into the try..except block and ask a user to report a BUG.

Close https://github.com/zalando/patroni/issues/1529