### PR TITLE
Handle IPv6 addresses in split_host_port

### DIFF
--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -357,6 +357,8 @@ def polling_loop(timeout, interval=1):
 
 def split_host_port(value, default_port):
     t = value.rsplit(':', 1)
+    if ':' in t[0]:
+        t[0] = t[0].strip('[]')
     t.append(default_port)
     return t[0], int(t[1])
 


### PR DESCRIPTION
This PR makes split_host_port return IPv6 address without enclosing
brackets. This is due to the fact that e.g. socket.* functions expect
host not to contain them when being called with IPv6.

Close: #1532