### PR TITLE
bugfix for attribute error during bootstrap

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -526,8 +526,10 @@ class Ha(object):
             cluster_history = {l[0]: l for l in cluster_history or []}
             history = self.state_handler.get_history(master_timeline)
             if history:
-                if self.cluster.config and hasattr(self.cluster.config, 'max_timelines_history'):
+                try:
                     history = history[-self.cluster.config.max_timelines_history:]
+                except AttributeError:
+                    pass
                 for line in history:
                     # enrich current history with promotion timestamps stored in DCS
                     if len(line) == 3 and line[0] in cluster_history \

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -526,7 +526,8 @@ class Ha(object):
             cluster_history = {l[0]: l for l in cluster_history or []}
             history = self.state_handler.get_history(master_timeline)
             if history:
-                history = history[-self.cluster.config.max_timelines_history:]
+                if self.cluster.config and hasattr(self.cluster.config, 'max_timelines_history'):
+                    history = history[-self.cluster.config.max_timelines_history:]
                 for line in history:
                     # enrich current history with promotion timestamps stored in DCS
                     if len(line) == 3 and line[0] in cluster_history \

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -525,11 +525,8 @@ class Ha(object):
         elif not cluster_history or cluster_history[-1][0] != master_timeline - 1 or len(cluster_history[-1]) != 4:
             cluster_history = {l[0]: l for l in cluster_history or []}
             history = self.state_handler.get_history(master_timeline)
-            if history:
-                try:
-                    history = history[-self.cluster.config.max_timelines_history:]
-                except AttributeError:
-                    pass
+            if history and self.cluster.config:
+                history = history[-self.cluster.config.max_timelines_history:]
                 for line in history:
                     # enrich current history with promotion timestamps stored in DCS
                     if len(line) == 3 and line[0] in cluster_history \


### PR DESCRIPTION
initial bootstrap causing the following error. Fix includes the attribute check.

```
Traceback (most recent call last):
  File "/xx/bin/patroni", line 10, in <module>
    sys.exit(main())
  File "/xx/lib/python3.8/site-packages/patroni/__init__.py", line 235, in main
    return patroni_main()
  File "/xx/lib/python3.8/site-packages/patroni/__init__.py", line 199, in patroni_main
    patroni.run()
  File "/xx/lib/python3.8/site-packages/patroni/__init__.py", line 135, in run
    logger.info(self.ha.run_cycle())
  File "/xx/lib/python3.8/site-packages/patroni/ha.py", line 1370, in run_cycle
    info = self._run_cycle()
  File "/xx/lib/python3.8/site-packages/patroni/ha.py", line 1341, in _run_cycle
    return self.process_unhealthy_cluster()
  File "/xx/lib/python3.8/site-packages/patroni/ha.py", line 908, in process_unhealthy_cluster
    return self.enforce_master_role(
  File "/xx/lib/python3.8/site-packages/patroni/ha.py", line 556, in enforce_master_role
    self.update_cluster_history()
  File "/xx/lib/python3.8/site-packages/patroni/ha.py", line 529, in update_cluster_history
    history = history[-self.cluster.config.max_timelines_history:]
AttributeError: 'NoneType' object has no attribute 'max_timelines_history'
```