### PR TITLE
Don't try calling a non existing leader in patronictl pause

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1008,7 +1008,7 @@ def show_diff(before_editing, after_editing):
     If the output is to a tty the diff will be colored. Inputs are expected to be unicode strings.
     """
     def listify(string):
-        return [l+'\n' for l in string.rstrip('\n').split('\n')]
+        return [line + '\n' for line in string.rstrip('\n').split('\n')]
 
     unified_diff = difflib.unified_diff(listify(before_editing), listify(after_editing))
 

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -942,7 +942,7 @@ def toggle_pause(config, cluster_name, paused, wait):
         raise PatroniCtlException('Cluster is {0} paused'.format(paused and 'already' or 'not'))
 
     members = []
-    if cluster.leader:
+    if cluster.leader and cluster.leader.member.api_url:
         members.append(cluster.leader.member)
     members.extend([m for m in cluster.members if m.api_url and (not members or members[0].name != m.name)])
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -523,7 +523,7 @@ class Ha(object):
             if cluster_history:
                 self.dcs.set_history_value('[]')
         elif not cluster_history or cluster_history[-1][0] != master_timeline - 1 or len(cluster_history[-1]) != 4:
-            cluster_history = {l[0]: l for l in cluster_history or []}
+            cluster_history = {line[0]: line for line in cluster_history or []}
             history = self.state_handler.get_history(master_timeline)
             if history:
                 history = history[-self.cluster.config.max_timelines_history:]


### PR DESCRIPTION
While pausing a cluster without a leader on K8s patronictl was showing warnings that member "None" could not be accessed.