### PR TITLE
Feature / configuration option `service_prefix` for Consul DCS

### DIFF
--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -101,7 +101,8 @@ Most of the parameters are optional, but you have to specify one of the **host**
 -  **dc**: (optional) Datacenter to communicate with. By default the datacenter of the host is used.
 -  **consistency**: (optional) Select consul consistency mode. Possible values are ``default``, ``consistent``, or ``stale`` (more details in `consul API reference <https://www.consul.io/api/features/consistency.html/>`__)
 -  **checks**: (optional) list of Consul health checks used for the session. By default an empty list is used.
--  **register\_service**: (optional) whether or not to register a service with the name defined by the scope parameter and the tag master, replica or standby-leader depending on the node's role. Defaults to **false**.
+-  **register\_service**: (optional) whether or not to register a service with the name defined by the scope parameter (optionally prefixed by **service_prefix**) and the tag master, replica or standby-leader depending on the node's role. Defaults to **false**.
+-  **service\_prefix**: (optional) Prefix for the name of the service to register. Separator to the scope parameter must be provided explicitly. Default is no prefix.
 -  **service\_check\_interval**: (optional) how often to perform health check against registered url.
 
 Etcd


### PR DESCRIPTION
To enhance service registration in consul, I'd like to suggest to add a configuration option `service_prefix` to the consul section of the patroni configuration.

This option allows to prefix the registered service name with an arbitrary string. The need for this option arises as the `scope` name usually doesn't include a string like `patroni-` (as this would be redundant in the `scope` name itself). As a result, the service name registered in consul is very generic and somewhat meaningless / lacking the type-of-service information.

With the change introduced in this PR, a service can be named i.e. `patroni-batman` or `pgdb-myservice` instead of just `batman` or `myservice`.

The change is fully backwards-compatible.