### PR TITLE
Switch API socket to TLS after connection

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -395,7 +395,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
     def setup(self):
         self.request = self.server.wrap_socket(self.request)
-        super().setup()
+        super(RestApiHandler, self).setup()
 
     def parse_request(self):
         """Override parse_request method to enrich basic functionality of `BaseHTTPRequestHandler` class

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -395,7 +395,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
     def setup(self):
         self.request = self.server.wrap_socket(self.request)
-        super(RestApiHandler, self).setup()
+        BaseHTTPRequestHandler.setup(self)
 
     def parse_request(self):
         """Override parse_request method to enrich basic functionality of `BaseHTTPRequestHandler` class


### PR DESCRIPTION
The API endpoint is a threaded HTTP server, so it creates a new thread to handle each request.  However, because it wraps its listening socket in SSL, the `ssl` module insists on completing the TLS handshake before it returns from `accept()`, so the entire TLS handshake happens in the main thread.  This means that if the TLS handshake stalls for any reason, the API endpoint becomes unresponsive (issue #1545).

This commit moves the `wrap_socket()` call so that it happens only after each connection has been accepted, meaning that it happens in the per-connection thread and can't affect the main one.

My understanding of Python's threading is limited, so I'm not sure about the thread-safety of my changes. I suspect there may be a problem when reconfiguring to turn on TLS: `RestApiServer.__initialize` updates `__protocol` before configuring TLS, so if a connection thread calls `setup` in that gap, it might try to use `__ctx` before it exists. If this is a problem, it should be fairly easy to fix.