### PR TITLE
Don't fire on_reload when promoting to standby_leader on 13+

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -602,7 +602,7 @@ class Postgresql(object):
 
     def reload(self, block_callbacks=False):
         ret = self.pg_ctl('reload')
-        if ret:
+        if ret and not block_callbacks:
             self.call_nowait(ACTION_ON_RELOAD)
         return ret
 

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -600,7 +600,7 @@ class Postgresql(object):
         except psycopg2.Error:
             pass
 
-    def reload(self):
+    def reload(self, block_callbacks=False):
         ret = self.pg_ctl('reload')
         if ret:
             self.call_nowait(ACTION_ON_RELOAD)
@@ -767,7 +767,8 @@ class Postgresql(object):
         if self.is_running():
             if do_reload:
                 self.config.write_postgresql_conf()
-                self.reload()
+                if self.reload(block_callbacks=change_role) and change_role:
+                    self.set_role(role)
             else:
                 self.restart(block_callbacks=change_role, role=role)
         else:

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -152,7 +152,6 @@ def run_async(self, func, args=()):
 @patch.object(Postgresql, 'is_leader', Mock(return_value=True))
 @patch.object(Postgresql, 'timeline_wal_position', Mock(return_value=(1, 10, 1)))
 @patch.object(Postgresql, '_cluster_info_state_get', Mock(return_value=3))
-@patch.object(Postgresql, 'call_nowait', Mock(return_value=True))
 @patch.object(Postgresql, 'data_directory_empty', Mock(return_value=False))
 @patch.object(Postgresql, 'controldata', Mock(return_value={
     'Database system identifier': SYSID,
@@ -701,6 +700,9 @@ class TestHa(PostgresInit):
         self.p.config.check_recovery_conf = Mock(return_value=(False, False))
         self.assertEqual(self.ha.run_cycle(), 'promoted self to a standby leader because i had the session lock')
         self.assertEqual(self.ha.run_cycle(), 'no action.  i am the standby leader with the lock')
+        self.p.set_role('replica')
+        self.p.config.check_recovery_conf = Mock(return_value=(True, False))
+        self.assertEqual(self.ha.run_cycle(), 'promoted self to a standby leader because i had the session lock')
 
     def test_process_healthy_standby_cluster_as_cascade_replica(self):
         self.p.is_leader = false


### PR DESCRIPTION
PostgreSQL 13 finally introduced the possibility to change primary_conninfo without a restart. Just doing reload is enough, but in case if the role is changing from the replica to the standby_leader we want to call only on_role_change callback and skip on_reload, because they duplicate each other.