### PR TITLE
Try to fetch missing WAL if pg_rewind complains about it

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -138,6 +138,10 @@ class Postgresql(object):
         return self.config.get('callbacks') or {}
 
     @property
+    def wal_dir(self):
+        return os.path.join(self._data_dir, 'pg_' + self.wal_name)
+
+    @property
     def wal_name(self):
         return 'wal' if self._major_version >= 100000 else 'xlog'
 
@@ -743,7 +747,7 @@ class Postgresql(object):
         return self._cluster_info_state_get('timeline')
 
     def get_history(self, timeline):
-        history_path = os.path.join(self._data_dir, 'pg_' + self.wal_name, '{0:08X}.history'.format(timeline))
+        history_path = os.path.join(self.wal_dir, '{0:08X}.history'.format(timeline))
         history_mtime = mtime(history_path)
         if history_mtime:
             try:

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -250,9 +250,6 @@ class Rewind(object):
     def checkpoint_after_promote(self):
         return self._state == REWIND_STATUS.CHECKPOINT
 
-    def _wal_dir(self):
-        return os.path.join(self._postgresql.data_dir, 'pg_' + self._postgresql.wal_name)
-
     def _fetch_missing_wal(self, restore_command, wal_filename):
         cmd = ''
         length = len(restore_command)
@@ -261,7 +258,7 @@ class Rewind(object):
             if restore_command[i] == '%' and i + 1 < length:
                 i += 1
                 if restore_command[i] == 'p':
-                    cmd += os.path.join(self._wal_dir(), wal_filename)
+                    cmd += os.path.join(self._postgresql.wal_dir, wal_filename)
                 elif restore_command[i] == 'f':
                     cmd += wal_filename
                 elif restore_command[i] == 'r':
@@ -409,7 +406,7 @@ class Rewind(object):
         return self._postgresql.cancellable.call(cmd, communicate=communicate)
 
     def cleanup_archive_status(self):
-        status_dir = os.path.join(self._wal_dir(), 'archive_status')
+        status_dir = os.path.join(self._postgresql.wal_dir, 'archive_status')
         try:
             for f in os.listdir(status_dir):
                 path = os.path.join(status_dir, f)

--- a/tests/test_cancellable.py
+++ b/tests/test_cancellable.py
@@ -13,7 +13,7 @@ class TestCancellableSubprocess(unittest.TestCase):
 
     def test_call(self):
         self.c.cancel()
-        self.assertRaises(PostgresException, self.c.call, communicate_input=None)
+        self.assertRaises(PostgresException, self.c.call)
 
     def test__kill_children(self):
         self.c._process_children = [Mock()]

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -18,6 +18,28 @@ class MockThread(object):
         self._target(*self._args)
 
 
+def mock_cancellable_call(*args, **kwargs):
+    communicate = kwargs.pop('communicate', None)
+    if isinstance(communicate, dict):
+        communicate.update(stdout=b'', stderr=b'pg_rewind: error: could not open file ' +
+                                              b'"data/postgresql0/pg_xlog/000000010000000000000003": No such file')
+    return 1
+
+
+def mock_cancellable_call0(*args, **kwargs):
+    communicate = kwargs.pop('communicate', None)
+    if isinstance(communicate, dict):
+        communicate.update(stdout=b'', stderr=b'')
+    return 0
+
+
+def mock_cancellable_call1(*args, **kwargs):
+    communicate = kwargs.pop('communicate', None)
+    if isinstance(communicate, dict):
+        communicate.update(stdout=b'', stderr=b'')
+    return 1
+
+
 @patch('subprocess.call', Mock(return_value=0))
 @patch('psycopg2.connect', psycopg2_connect)
 class TestRewind(BaseTestPostgresql):
@@ -36,16 +58,23 @@ class TestRewind(BaseTestPostgresql):
         self.p.config._config['use_pg_rewind'] = False
         self.assertFalse(self.r.can_rewind)
 
-    @patch.object(Postgresql, 'major_version', PropertyMock(return_value=130000))
-    @patch.object(CancellableSubprocess, 'call')
-    def test_pg_rewind(self, mock_cancellable_subprocess_call):
+    def test_pg_rewind(self):
         r = {'user': '', 'host': '', 'port': '', 'database': '', 'password': ''}
-        mock_cancellable_subprocess_call.return_value = 0
-        with patch('subprocess.check_output', Mock(return_value=b'foo')):
-            self.assertTrue(self.r.pg_rewind(r))
-        mock_cancellable_subprocess_call.side_effect = OSError
-        with patch('subprocess.check_output', Mock(side_effect=Exception)):
-            self.assertFalse(self.r.pg_rewind(r))
+        with patch.object(Postgresql, 'major_version', PropertyMock(return_value=130000)),\
+                patch.object(CancellableSubprocess, 'call', Mock(return_value=None)):
+            with patch('subprocess.check_output', Mock(return_value=b'boo')):
+                self.assertFalse(self.r.pg_rewind(r))
+            with patch('subprocess.check_output', Mock(side_effect=Exception)):
+                self.assertFalse(self.r.pg_rewind(r))
+
+        with patch.object(Postgresql, 'major_version', PropertyMock(return_value=120000)),\
+                patch('subprocess.check_output', Mock(return_value=b'foo %f %p %r %% % %')):
+            with patch.object(CancellableSubprocess, 'call', mock_cancellable_call):
+                self.assertFalse(self.r.pg_rewind(r))
+            with patch.object(CancellableSubprocess, 'call', mock_cancellable_call0):
+                self.assertTrue(self.r.pg_rewind(r))
+            with patch.object(CancellableSubprocess, 'call', mock_cancellable_call1):
+                self.assertFalse(self.r.pg_rewind(r))
 
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))
     def test__get_local_timeline_lsn(self):
@@ -60,7 +89,7 @@ class TestRewind(BaseTestPostgresql):
             with patch.object(MockCursor, 'fetchone', Mock(side_effect=[(False, ), Exception])):
                 self.r.rewind_or_reinitialize_needed_and_possible(self.leader)
 
-    @patch.object(CancellableSubprocess, 'call', Mock(return_value=0))
+    @patch.object(CancellableSubprocess, 'call', mock_cancellable_call)
     @patch.object(Postgresql, 'checkpoint', side_effect=['', '1'],)
     @patch.object(Postgresql, 'stop', Mock(return_value=False))
     @patch.object(Postgresql, 'start', Mock())
@@ -140,7 +169,8 @@ class TestRewind(BaseTestPostgresql):
     @patch('psutil.Popen')
     def test_single_user_mode(self, subprocess_popen_mock):
         subprocess_popen_mock.return_value.wait.return_value = 0
-        self.assertEqual(self.r.single_user_mode('CHECKPOINT', {'archive_mode': 'on'}), 0)
+        subprocess_popen_mock.return_value.communicate.return_value = ('', '')
+        self.assertEqual(self.r.single_user_mode({'input': 'CHECKPOINT'}, {'archive_mode': 'on'}), 0)
 
     @patch('os.listdir', Mock(side_effect=[OSError, ['a', 'b']]))
     @patch('os.unlink', Mock(side_effect=OSError))


### PR DESCRIPTION
It could happen that the WAL segment required for pg_rewind doesn't exist in the pg_wal anymore and therefore pg_rewind can't find the checkpoint location before the diverging point.
Starting from PostgreSQL 13 pg_rewind could use restore_command for fetching missing WALs, but we can do better than that.
On older PostgreSQL versions Patroni will parse the stdout and stderr of failed rewind, try to fetch the missing WAL, and repeat the pg_rewind attempt.