### PR TITLE
Don't let Patroni mistake logical replication slots for physical replicas

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -439,8 +439,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
                     "FROM (SELECT (SELECT rolname FROM pg_authid WHERE oid = usesysid) AS usename,"
                     " application_name, client_addr, w.state, sync_state, sync_priority"
                     " FROM pg_catalog.pg_stat_get_wal_senders() w, pg_catalog.pg_stat_get_activity(pid)"
-                    " INNER JOIN pg_replication_slots AS rs ON rs.active_pid = pid"
-                    " WHERE application_name slot_type = 'physical') AS ri")
+                    " LEFT JOIN pg_replication_slots AS rs ON rs.active_pid = pid"
+                    " WHERE slot_type IS NULL OR slot_type = 'physical') AS ri")
 
             row = self.query(stmt.format(postgresql.wal_name, postgresql.lsn_name), retry=retry)[0]
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -438,7 +438,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
                     " pg_catalog.array_to_json(pg_catalog.array_agg(pg_catalog.row_to_json(ri))) "
                     "FROM (SELECT (SELECT rolname FROM pg_authid WHERE oid = usesysid) AS usename,"
                     " application_name, client_addr, w.state, sync_state, sync_priority"
-                    " FROM pg_catalog.pg_stat_get_wal_senders() w, pg_catalog.pg_stat_get_activity(pid)) AS ri")
+                    " FROM pg_catalog.pg_stat_get_wal_senders() w, pg_catalog.pg_stat_get_activity(pid)"
+                    " INNER JOIN pg_replication_slots AS rs ON rs.active_pid = pid"
+                    " WHERE application_name slot_type = 'physical') AS ri")
 
             row = self.query(stmt.format(postgresql.wal_name, postgresql.lsn_name), retry=retry)[0]
 


### PR DESCRIPTION
In testing a PostgreSQL plugin that uses logical slots alongside Patroni, we found that the logical slots were mistakenly showing in the Patroni REST API output as though they were physical Patroni-managed replicas. This wasn't causing an obvious problem in Patroni's functioning, however the
output was still incorrect. Although we did not observe such, we believe that this may also impact failovers if Patroni were to try to failover to the (erroneous) logical replication slot.

We tracked this behavior to the SQL statement seen here. This adds logic
to select only physical slots when considering Patroni replicas.

@devmage