### PR TITLE
Multi Sync Standby Support

### DIFF
--- a/docs/replication_modes.rst
+++ b/docs/replication_modes.rst
@@ -27,7 +27,7 @@ To enable a simple synchronous replication test, add the following lines to the 
 .. code:: YAML
 
         synchronous_commit: "on"
-        synchronous_standby_names: "*"
+        synchronous_node_count: 1
 
 When using PostgreSQL synchronous replication, use at least three Postgres data nodes to ensure write availability if one host fails.
 
@@ -59,11 +59,14 @@ Synchronous mode can be switched on and off via Patroni REST interface. See :ref
 
 Note: Because of the way synchronous replication is implemented in PostgreSQL it is still possible to lose transactions even when using ``synchronous_mode_strict``. If the PostgreSQL backend is cancelled while waiting to acknowledge replication (as a result of packet cancellation due to client timeout or backend failure) transaction changes become visible for other backends. Such changes are not yet replicated and may be lost in case of standby promotion.
 
+Synchronous Replication Factor
+------------------------------
+The parameter ``synchronous_node_count`` is used by Patroni to manage number of synchronous standby databases. It is set to 1 by default. It has no effect when ``synchronous_mode`` is set to off. When enabled, Patroni manages precise number of synchronous standby databases based on parameter ``synchronous_node_count`` and adjusts the state in DCS & synchronous_standby_names as members join and leave.
 
 Synchronous mode implementation
 -------------------------------
 
-When in synchronous mode Patroni maintains synchronization state in the DCS, containing the latest primary and current synchronous standby. This state is updated with strict ordering constraints to ensure the following invariants:
+When in synchronous mode Patroni maintains synchronization state in the DCS, containing the latest primary and current synchronous standby databases. This state is updated with strict ordering constraints to ensure the following invariants:
 
 - A node must be marked as the latest leader whenever it can accept write transactions. Patroni crashing or PostgreSQL not shutting down can cause violations of this invariant.
 
@@ -71,9 +74,9 @@ When in synchronous mode Patroni maintains synchronization state in the DCS, con
 
 - A node that is not the leader or current synchronous standby is not allowed to promote itself automatically.
 
-Patroni will only ever assign one standby to ``synchronous_standby_names`` because with multiple candidates it is not possible to know which node was acting as synchronous during the failure.
+Patroni will only assign one or more synchronous standby nodes based on ``synchronous_node_count`` parameter to ``synchronous_standby_names``.
 
-On each HA loop iteration Patroni re-evaluates synchronous standby choice. If the current synchronous standby is connected and has not requested its synchronous status to be removed it remains picked. Otherwise the cluster member available for sync that is furthest ahead in replication is picked.
+On each HA loop iteration Patroni re-evaluates synchronous standby nodes choice. If the current list of synchronous standby nodes are connected and has not requested its synchronous status to be removed it remains picked. Otherwise the cluster member available for sync that is furthest ahead in replication is picked.
 
 
 .. [1] The data is still there, but recovering it requires a manual recovery effort by data recovery specialists. When Patroni is allowed to rewind with ``use_pg_rewind`` the forked timeline will be automatically erased to rejoin the failed primary with the cluster.

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -64,6 +64,7 @@ class Config(object):
         'master_stop_timeout': 0,
         'synchronous_mode': False,
         'synchronous_mode_strict': False,
+        'synchronous_node_count': 1,
         'standby_cluster': {
             'create_replica_methods': '',
             'host': '',
@@ -381,6 +382,7 @@ class Config(object):
             'retry_timeout',
             'synchronous_mode',
             'synchronous_mode_strict',
+            'synchronous_node_count',
         )
 
         pg_config.update({p: config[p] for p in updated_fields if p in config})

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -381,7 +381,7 @@ class SyncState(namedtuple('SyncState', 'index,leader,sync_standby')):
                 data = {}
         else:
             data = {}
-        return SyncState(index, data.get('leader'), data.get('sync_standby'))
+        return SyncState(index, data.get('leader'), data.get('sync_standby', []))
 
     def matches(self, name):
         """
@@ -399,7 +399,10 @@ class SyncState(namedtuple('SyncState', 'index,leader,sync_standby')):
         >>> SyncState(1, None, None).matches('foo')
         False
         """
-        return name is not None and name in (self.leader, self.sync_standby)
+        member_list = [self.leader]
+        if self.sync_standby:
+            member_list += self.sync_standby
+        return name is not None and name in member_list
 
 
 class TimelineHistory(namedtuple('TimelineHistory', 'index,value,lines')):

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -154,7 +154,7 @@ class ZooKeeper(AbstractDCS):
     def load_members(self, sync_standby):
         members = []
         for member in self.get_children(self.members_path, self.cluster_watcher):
-            watch = member == sync_standby and self.cluster_watcher or None
+            watch = member in sync_standby and self.cluster_watcher or None
             data = self.get_node(self.members_path + member, watch)
             if data is not None:
                 members.append(self.member(member, *data))
@@ -187,7 +187,7 @@ class ZooKeeper(AbstractDCS):
         sync = SyncState.from_node(sync and sync[1].version, sync and sync[0])
 
         # get list of members
-        sync_standby = sync.leader == self._name and sync.sync_standby or None
+        sync_standby = sync.leader == self._name and sync.sync_standby or []
         members = self.load_members(sync_standby) if self._MEMBERS[:-1] in nodes else []
 
         # get leader

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -387,7 +387,7 @@ def cluster_as_json(cluster):
         if m.name == leader_name:
             config = cluster.config.data if cluster.config and cluster.config.modify_index else {}
             role = 'standby_leader' if is_standby_cluster(config.get('standby_cluster')) else 'leader'
-        elif m.name == cluster.sync.sync_standby:
+        elif cluster.sync.matches(m.name):
             role = 'sync_standby'
         else:
             role = 'replica'


### PR DESCRIPTION
Credit to @ants.

As per comment in PR [672](https://github.com/zalando/patroni/pull/672), this is to extend current one synchronous standby functionality to support precise number of synchronous standby databases. 

The new parameter synchronous_node_count is used by Patroni to manage number of synchronous standby databases. It is set to 1 by default. It has no effect when synchronous_mode is set to off. When enabled, Patroni manages precise number of synchronous standby databases based on parameter synchronous_node_count and adjusts the state in DCS & synchronous_standby_names as members join and leave.

This functionality can be further extended to support Priority (FIRST n) based synchronous replication & Quorum (ANY n) based synchronous replication in future.

### Synchronous Replication Factor

The parameter ``synchronous_node_count`` is used by Patroni to manage number of synchronous standby databases. It is set to 1 by default. It has no effect when ``synchronous_mode`` is set to off. When enabled, Patroni manages precise number of synchronous standby databases based on parameter ``synchronous_node_count`` and adjusts the state in DCS & synchronous_standby_names as members join and leave.