### PR TITLE
Bugfix: Patroni falsely reported postgres as running

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1332,6 +1332,7 @@ class Ha(object):
 
             if not self.state_handler.is_healthy():
                 if self.is_paused():
+                    self.state_handler.set_state('stopped')
                     if self.has_lock():
                         self._delete_leader()
                         return 'removed leader lock because postgres is not running'
@@ -1344,6 +1345,8 @@ class Ha(object):
                             (self._rewind.is_needed and self._rewind.can_rewind_or_reinitialize_allowed):
                         return 'postgres is not running'
 
+                if self.state_handler.state in ('running', 'starting'):
+                    self.state_handler.set_state('crashed')
                 # try to start dead postgres
                 return self.recover()
 


### PR DESCRIPTION
If postgres is not running due to the crash, panic or because it was stopped by some external force, we need to change the internal state.
So far we always relied on the state being set in the `Postgresql.start()` method. Unfortunately not in all cases this method is reachable. For example, the `Postgresql.follow()` could raise an exception when calling `write_recovery_conf()` and there is not enough disk space to write the file.

In order to solve it, we explicitly set the state when detected that the postgres is not alive. In the `pause` we set it to `stopped`, otherwise to `crashed` if it was `running` or `starting` before.