### PR TITLE
Compatibility fixes

### DIFF
--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -488,9 +488,9 @@ def keepalive_socket_options(timeout, idle, cnt=3):
 
     if sys.platform.startswith('linux'):
         yield (socket.SOL_TCP, 18, int(timeout * 1000))  # TCP_USER_TIMEOUT
-        TCP_KEEPIDLE = socket.TCP_KEEPIDLE
-        TCP_KEEPINTVL = socket.TCP_KEEPINTVL
-        TCP_KEEPCNT = socket.TCP_KEEPCNT
+        TCP_KEEPIDLE = getattr(socket, 'TCP_KEEPIDLE', None)
+        TCP_KEEPINTVL = getattr(socket, 'TCP_KEEPINTVL', None)
+        TCP_KEEPCNT = getattr(socket, 'TCP_KEEPCNT', None)
     elif sys.platform.startswith('darwin'):
         TCP_KEEPIDLE = 0x10  # (named "TCP_KEEPALIVE" in C)
         TCP_KEEPINTVL = 0x101

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3>=1.19.1,!=1.21
+urllib3[secure]>=1.19.1,!=1.21
 boto
 PyYAML
 six >= 1.7


### PR DESCRIPTION
* socket.TCP_KEEP* are not defined on windows, macosx, and *bsd
* add [secure] extra to urllib3 for better handling of ip/host checks