### PR TITLE
Add consul service_tags configuration field

### DIFF
--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -103,6 +103,7 @@ Most of the parameters are optional, but you have to specify one of the **host**
 -  **consistency**: (optional) Select consul consistency mode. Possible values are ``default``, ``consistent``, or ``stale`` (more details in `consul API reference <https://www.consul.io/api/features/consistency.html/>`__)
 -  **checks**: (optional) list of Consul health checks used for the session. By default an empty list is used.
 -  **register\_service**: (optional) whether or not to register a service with the name defined by the scope parameter and the tag master, replica or standby-leader depending on the node's role. Defaults to **false**.
+-  **service\_tags**: (optional) additional static tags to add to the Consul service apart from the role (``master``/``replica``/``standby-leader``).  By default an empty list is used.
 -  **service\_check\_interval**: (optional) how often to perform health check against registered url.
 
 Etcd

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -219,6 +219,7 @@ class Consul(AbstractDCS):
         self.__session_checks = config.get('checks', [])
         self._register_service = config.get('register_service', False)
         if self._register_service:
+            self._service_tags = config.get('service_tags', [])
             self._service_name = service_name_from_scope_name(self._scope)
             if self._scope != self._service_name:
                 logger.warning('Using %s as consul service name instead of scope name %s', self._service_name,
@@ -414,12 +415,14 @@ class Consul(AbstractDCS):
         conn_parts = urlparse(data['conn_url'])
         check = base.Check.http(api_parts.geturl(), self._service_check_interval,
                                 deregister='{0}s'.format(self._client.http.ttl * 10))
+        tags = self._service_tags[:]
+        tags.append(role)
         params = {
             'service_id': '{0}/{1}'.format(self._scope, self._name),
             'address': conn_parts.hostname,
             'port': conn_parts.port,
             'check': check,
-            'tags': [role]
+            'tags': tags
         }
 
         if state == 'stopped':


### PR DESCRIPTION
This is useful for dynamic service discovery, for example by load balancers.