### PR TITLE
Move WAL and tablespaces after a failed init

### DIFF
--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -402,6 +402,10 @@ class TestPostgresql(BaseTestPostgresql):
 
     @patch('os.rename', Mock())
     @patch('os.path.isdir', Mock(return_value=True))
+    @patch('os.unlink', Mock())
+    @patch('os.symlink', Mock())
+    @patch('patroni.postgresql.Postgresql.pg_wal_realpath', Mock(return_value={'pg_wal': '/mnt/pg_wal'}))
+    @patch('patroni.postgresql.Postgresql.pg_tblspc_realpaths', Mock(return_value={'42': '/mnt/tablespaces/archive'}))
     def test_move_data_directory(self):
         self.p.move_data_directory()
         with patch('os.rename', Mock(side_effect=OSError)):


### PR DESCRIPTION
For init processes that use a symlinked WAL directory, or use custom
scripts that create new tablespaces, these directories should also be
renamed after a failed init attempt, as currently the following errors
occur if the first init attempt failed, but a second one might succeed:

      fixing permissions on existing directory /var/lib/postgresql/data ... ok
      initdb: error: directory "/var/lib/postgresql/wal/pg_wal" exists but is not empty
      [...]
      File "/usr/lib/python3/dist-packages/patroni/ha.py", line 1173, in post_bootstrap
        self.cancel_initialization()
      File "/usr/lib/python3/dist-packages/patroni/ha.py", line 1168, in cancel_initialization
        raise PatroniException('Failed to bootstrap cluster')
      patroni.exceptions.PatroniException: 'Failed to bootstrap cluster'

In the remove_data_directory function the same happens for removing the
data directory, it seems the same kind of thing should also happen when
moving a data directory.