### PR TITLE
Windows compatibility fixes

### DIFF
--- a/features/standby_cluster.feature
+++ b/features/standby_cluster.feature
@@ -25,6 +25,7 @@ Feature: standby cluster
     Then postgres1 is a leader of batman1 after 10 seconds
     When I add the table foo to postgres0
     Then table foo is present on postgres1 after 20 seconds
+    And I sleep for 3 seconds
     When I issue a GET request to http://127.0.0.1:8009/master
     Then I receive a response code 503
     When I issue a GET request to http://127.0.0.1:8009/standby_leader

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -283,9 +283,9 @@ class Rewind(object):
             if b > -1:
                 b += len(pattern)
                 e = line.find('": ', b)
-                if e > -1:
-                    waldir, wal_filename = os.path.split(line[b:e])
-                    if waldir.endswith(os.path.sep + 'pg_' + self._postgresql.wal_name) and len(wal_filename) == 24:
+                if e > -1 and '/' in line[b:e]:
+                    waldir, wal_filename = line[b:e].rsplit('/', 1)
+                    if waldir.endswith('/pg_' + self._postgresql.wal_name) and len(wal_filename) == 24:
                         return wal_filename
 
     def pg_rewind(self, r):

--- a/tests/test_raft_controller.py
+++ b/tests/test_raft_controller.py
@@ -8,6 +8,7 @@ from patroni.config import Config
 from patroni.raft_controller import RaftController, main as _main
 
 from . import SleepException
+from .test_raft import remove_files
 
 
 class TestPatroniRaftController(unittest.TestCase):
@@ -15,10 +16,7 @@ class TestPatroniRaftController(unittest.TestCase):
     SELF_ADDR = '127.0.0.1:5360'
 
     def remove_files(self):
-        for f in ('journal', 'dump'):
-            f = self.SELF_ADDR + '.' + f
-            if os.path.exists(f):
-                os.unlink(f)
+        remove_files(self.SELF_ADDR + '.')
 
     @patch('pysyncobj.tcp_server.TcpServer.bind', Mock())
     def setUp(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,9 +36,10 @@ class TestUtils(unittest.TestCase):
     def test_enable_keepalive(self):
         with patch('socket.SIO_KEEPALIVE_VALS', 1, create=True):
             self.assertIsNotNone(enable_keepalive(Mock(), 10, 5))
-        for platform in ('linux2', 'darwin', 'other'):
-            with patch('sys.platform', platform):
-                self.assertIsNone(enable_keepalive(Mock(), 10, 5))
+        with patch('socket.SIO_KEEPALIVE_VALS', None, create=True):
+            for platform in ('linux2', 'darwin', 'other'):
+                with patch('sys.platform', platform):
+                    self.assertIsNone(enable_keepalive(Mock(), 10, 5))
 
 
 @patch('time.sleep', Mock())

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -153,6 +153,7 @@ class TestValidator(unittest.TestCase):
         self.assertEqual(['etcd.hosts.1', 'etcd.hosts.2', 'kubernetes.pod_ip', 'postgresql.bin_dir',
                           'postgresql.data_dir', 'restapi.connect_address'], parse_output(output))
 
+    @patch('socket.inet_pton', Mock(), create=True)
     def test_bin_dir_is_empty(self, mock_out, mock_err):
         directories.append(config["postgresql"]["data_dir"])
         directories.append(config["postgresql"]["bin_dir"])


### PR DESCRIPTION
* pg_rewind error messages contains '/' as directory separator
* fix Raft unit tests on win
* fix validator unit tests on win
* fix keepalive unit tests on win
* make standby cluster behave tests less shaky