### PR TITLE
Explicitly disallow patching non-existent config

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -196,6 +196,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
         request = self._read_json_content()
         if request:
             cluster = self.server.patroni.dcs.get_cluster()
+            if not (cluster.config and cluster.config.modify_index):
+                return self.send_error(503)
             data = cluster.config.data.copy()
             if patch_config(data, request):
                 value = json.dumps(data, separators=(',', ':'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -250,6 +250,8 @@ class TestRestApiHandler(unittest.TestCase):
         MockRestApiServer(RestApiHandler, request)
         mock_dcs.set_config_value.return_value = False
         MockRestApiServer(RestApiHandler, request)
+        mock_dcs.get_cluster.return_value.config = None
+        MockRestApiServer(RestApiHandler, request)
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_PUT_config(self, mock_dcs):


### PR DESCRIPTION
For DCS other than `kubernetes` it was failing with exception due to the `cluster.config` being `None`, but on Kubernetes it was happily creating the config annotation and preventing writing bootstrap configuration after the bootstrap finished.