### PR TITLE
Fix to skip physical replication slot creation for leader node with special chars

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -500,7 +500,8 @@ class Cluster(namedtuple('Cluster', 'initialize,config,leader,last_leader_operat
                     value['type'] = 'logical' if value.get('database') and value.get('plugin') else 'physical'
 
                 if value['type'] == 'physical':
-                    if name != slot_name_from_member_name(my_name):  # Don't try to create permanent physical replication slot for yourself
+                    # Don't try to create permanent physical replication slot for yourself
+                    if name != slot_name_from_member_name(my_name):
                         slots[name] = value
                     continue
                 elif value['type'] == 'logical' and value.get('database') and value.get('plugin'):

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -500,7 +500,7 @@ class Cluster(namedtuple('Cluster', 'initialize,config,leader,last_leader_operat
                     value['type'] = 'logical' if value.get('database') and value.get('plugin') else 'physical'
 
                 if value['type'] == 'physical':
-                    if name != my_name:  # Don't try to create permanent physical replication slot for yourself
+                    if name != slot_name_from_member_name(my_name):  # Don't try to create permanent physical replication slot for yourself
                         slots[name] = value
                     continue
                 elif value['type'] == 'logical' and value.get('database') and value.get('plugin'):


### PR DESCRIPTION
Patroni appears to be creating dormant slot (when `slots` defined) for leader node when the name contains special chars such as '-'  (for e.g. "abc-us-1"). Fix includes skipping the creation of physical replication slot for leader.

```
cluster nodes: abc-us-001 & abc-us-002.

patroni config
.....
slots:
  abc_us_001:
    type: physical
  abc_us_002:
    type: physical
....

appsdb=# select * from pg_replication_slots;
   slot_name   | plugin | slot_type | datoid | database | temporary | active | active_pid |   xmin   | catalog_xmin | restart_lsn | confirmed
_flush_lsn 
---------------+--------+-----------+--------+----------+-----------+--------+------------+----------+--------------+-------------+----------
-----------
 abc_us_001 |        | physical  |        |          | f         | t      |     122217 | 29981370 |              | B7/F0000408 | 
 abc_us_002 |        | physical  |        |          | f         | f      |            |          |              | B7/F00001A8 | 
(2 rows)
```