### PR TITLE
Compatibility with PostgreSQL 13

### DIFF
--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -35,6 +35,7 @@ For the parameters below, PostgreSQL does not require equal values among the mas
 - max_wal_senders: 5
 - max_replication_slots: 5
 - wal_keep_segments: 8
+- wal_keep_size: 128MB
 
 These parameters are validated to ensure they are sane, or meet a minimum value.
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -193,7 +193,6 @@ Config endpoint
 	    "parameters": {
 	      "hot_standby": "on",
 	      "wal_log_hints": "on",
-	      "wal_keep_segments": 8,
 	      "wal_level": "hot_standby",
 	      "max_wal_senders": 5,
 	      "max_replication_slots": 5,
@@ -221,7 +220,6 @@ Config endpoint
 	    "parameters": {
 	      "hot_standby": "on",
 	      "wal_log_hints": "on",
-	      "wal_keep_segments": 8,
 	      "wal_level": "hot_standby",
 	      "max_wal_senders": 5,
 	      "max_replication_slots": 5,
@@ -273,7 +271,6 @@ If you want to remove (reset) some setting just patch it with ``null``:
 	    "parameters": {
 	      "hot_standby": "on",
 	      "unix_socket_directories": ".",
-	      "wal_keep_segments": 8,
 	      "wal_level": "hot_standby",
 	      "wal_log_hints": "on",
 	      "max_wal_senders": 5,
@@ -289,7 +286,7 @@ The above call removes ``postgresql.parameters.max_connections`` from the dynami
 .. code-block:: bash
 
 	$ curl -s -XPUT -d \
-		'{"maximum_lag_on_failover":1048576,"retry_timeout":10,"postgresql":{"use_slots":true,"use_pg_rewind":true,"parameters":{"hot_standby":"on","wal_log_hints":"on","wal_keep_segments":8,"wal_level":"hot_standby","unix_socket_directories":".","max_wal_senders":5}},"loop_wait":3,"ttl":20}' \
+		'{"maximum_lag_on_failover":1048576,"retry_timeout":10,"postgresql":{"use_slots":true,"use_pg_rewind":true,"parameters":{"hot_standby":"on","wal_log_hints":"on","wal_level":"hot_standby","unix_socket_directories":".","max_wal_senders":5}},"loop_wait":3,"ttl":20}' \
 		http://localhost:8008/config | jq .
 	{
 	  "ttl": 20,
@@ -300,7 +297,6 @@ The above call removes ``postgresql.parameters.max_connections`` from the dynami
 	    "parameters": {
 	      "hot_standby": "on",
 	      "unix_socket_directories": ".",
-	      "wal_keep_segments": 8,
 	      "wal_level": "hot_standby",
 	      "wal_log_hints": "on",
 	      "max_wal_senders": 5

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -77,7 +77,8 @@ class Config(object):
         'postgresql': {
             'bin_dir': '',
             'use_slots': True,
-            'parameters': CaseInsensitiveDict({p: v[0] for p, v in ConfigHandler.CMDLINE_OPTIONS.items()})
+            'parameters': CaseInsensitiveDict({p: v[0] for p, v in ConfigHandler.CMDLINE_OPTIONS.items()
+                                               if p not in ('wal_keep_segments', 'wal_keep_size')})
         },
         'watchdog': {
             'mode': 'automatic',

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -470,7 +470,7 @@ class Postgresql(object):
         self.config.replace_pg_ident()
 
         options = ['--{0}={1}'.format(p, configuration[p]) for p in self.config.CMDLINE_OPTIONS
-                   if p in configuration and p != 'wal_keep_segments']
+                   if p in configuration and p not in ('wal_keep_segments', 'wal_keep_size')]
 
         if self.cancellable.is_cancelled:
             return False


### PR DESCRIPTION
So far Patroni was enforcing the same value of `wal_keep_segments` on all nodes in the cluster. If the parameter was missing from the global configuration it was using the default value `8`.
In pg13 beta3 the `wal_keep_segments` was renamed to the `wal_keep_size` and it broke Patroni.

If `wal_keep_segments` happened to be present in the configuration for pg13, Paroni will recalculate the value to `wal_keep_size` assuming that the `wal_segment_size` is 16MB. Sure, it is possible to get the real value of `wal_segment_size` from pg_control, but since we are dealing with the case of misconfiguration it is not worse time spend on it.