### PR TITLE
Add SSL support for ZooKeeper

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -77,7 +77,7 @@ Environment names for Etcdv3 are similar as for Etcd, you just need to use ``ETC
 ZooKeeper
 ---------
 -  **PATRONI\_ZOOKEEPER\_HOSTS**: Comma separated list of ZooKeeper cluster members: "'host1:port1','host2:port2','etc...'". It is important to quote every single entity!
--  **PATRONI\_ZOOKEEPER\_USE\_SSL**: (optional) Whether SSL is used or not. Defaults to `false`. If set to `false`, all SSL specific parameters are ignored.
+-  **PATRONI\_ZOOKEEPER\_USE\_SSL**: (optional) Whether SSL is used or not. Defaults to ``false``. If set to ``false``, all SSL specific parameters are ignored.
 -  **PATRONI\_ZOOKEEPER\_CACERT**: (optional) The ca certificate. If present it will enable validation.
 -  **PATRONI\_ZOOKEEPER\_CERT**: (optional) File with the client certificate.
 -  **PATRONI\_ZOOKEEPER\_KEY**: (optional) File with the client key.

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -85,7 +85,7 @@ ZooKeeper
 -  **PATRONI\_ZOOKEEPER\_VERIFY**: (optional) Whether to verify certificate or not. Defaults to `true`.
 
 .. note::
-    It is required to install ``kazoo>=2.6.0`` to use SSL.
+    It is required to install ``kazoo>=2.6.0`` to support SSL.
 
 
 Exhibitor

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -76,7 +76,13 @@ Environment names for Etcdv3 are similar as for Etcd, you just need to use ``ETC
 
 ZooKeeper
 ---------
--  **PATRONI\_ZOOKEEPER\_HOSTS**: comma separated list of ZooKeeper cluster members: "'host1:port1','host2:port2','etc...'". It is important to quote every single entity!
+-  **PATRONI\_ZOOKEEPER\_HOSTS**: Comma separated list of ZooKeeper cluster members: "'host1:port1','host2:port2','etc...'". It is important to quote every single entity!
+-  **PATRONI\_ZOOKEEPER\_USE\_SSL**: (optional) Whether SSL is used or not. Defaults to `false`. If set to `false`, all SSL specific parameters are ignored.
+-  **PATRONI\_ZOOKEEPER\_CACERT**: (optional) The ca certificate. If present it will enable validation.
+-  **PATRONI\_ZOOKEEPER\_CERT**: (optional) File with the client certificate.
+-  **PATRONI\_ZOOKEEPER\_KEY**: (optional) File with the client key.
+-  **PATRONI\_ZOOKEEPER\_KEY\_PASSWORD**: (optional) The client key password.
+-  **PATRONI\_ZOOKEEPER\_VERIFY**: (optional) Whether to verify certificate or not. Defaults to `true`.
 
 Exhibitor
 ---------

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -78,7 +78,7 @@ ZooKeeper
 ---------
 -  **PATRONI\_ZOOKEEPER\_HOSTS**: Comma separated list of ZooKeeper cluster members: "'host1:port1','host2:port2','etc...'". It is important to quote every single entity!
 -  **PATRONI\_ZOOKEEPER\_USE\_SSL**: (optional) Whether SSL is used or not. Defaults to ``false``. If set to ``false``, all SSL specific parameters are ignored.
--  **PATRONI\_ZOOKEEPER\_CACERT**: (optional) The ca certificate. If present it will enable validation.
+-  **PATRONI\_ZOOKEEPER\_CACERT**: (optional) The CA certificate. If present it will enable validation.
 -  **PATRONI\_ZOOKEEPER\_CERT**: (optional) File with the client certificate.
 -  **PATRONI\_ZOOKEEPER\_KEY**: (optional) File with the client key.
 -  **PATRONI\_ZOOKEEPER\_KEY\_PASSWORD**: (optional) The client key password.

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -84,6 +84,10 @@ ZooKeeper
 -  **PATRONI\_ZOOKEEPER\_KEY\_PASSWORD**: (optional) The client key password.
 -  **PATRONI\_ZOOKEEPER\_VERIFY**: (optional) Whether to verify certificate or not. Defaults to `true`.
 
+.. note::
+    It is required to install ``kazoo>=2.6.0`` to use SSL.
+
+
 Exhibitor
 ---------
 -  **PATRONI\_EXHIBITOR\_HOSTS**: initial list of Exhibitor (ZooKeeper) nodes in format: 'host1,host2,etc...'. This list updates automatically whenever the Exhibitor (ZooKeeper) cluster topology changes.

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -82,7 +82,7 @@ ZooKeeper
 -  **PATRONI\_ZOOKEEPER\_CERT**: (optional) File with the client certificate.
 -  **PATRONI\_ZOOKEEPER\_KEY**: (optional) File with the client key.
 -  **PATRONI\_ZOOKEEPER\_KEY\_PASSWORD**: (optional) The client key password.
--  **PATRONI\_ZOOKEEPER\_VERIFY**: (optional) Whether to verify certificate or not. Defaults to `true`.
+-  **PATRONI\_ZOOKEEPER\_VERIFY**: (optional) Whether to verify certificate or not. Defaults to ``true``.
 
 .. note::
     It is required to install ``kazoo>=2.6.0`` to support SSL.

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -147,7 +147,13 @@ If you want that Patroni works with Etcd cluster via protocol version 3, you nee
 
 ZooKeeper
 ----------
--  **hosts**: list of ZooKeeper cluster members in format: ['host1:port1', 'host2:port2', 'etc...'].
+-  **hosts**: List of ZooKeeper cluster members in format: ['host1:port1', 'host2:port2', 'etc...'].
+-  **use_ssl**: (optional) Whether SSL is used or not. Defaults to `false`. If set to `false`, all SSL specific parameters are ignored.
+-  **cacert**: (optional) The ca certificate. If present it will enable validation.
+-  **cert**: (optional) File with the client certificate.
+-  **key**: (optional) File with the client key.
+-  **key_password**: (optional) The client key password.
+-  **verify**: (optional) Whether to verify certificate or not. Defaults to `true`.
 
 Exhibitor
 ---------

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -156,7 +156,7 @@ ZooKeeper
 -  **verify**: (optional) Whether to verify certificate or not. Defaults to `true`.
 
 .. note::
-    It is required to install ``kazoo>=2.6.0`` to use SSL.
+    It is required to install ``kazoo>=2.6.0`` to support SSL.
 
 
 Exhibitor

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -148,12 +148,12 @@ If you want that Patroni works with Etcd cluster via protocol version 3, you nee
 ZooKeeper
 ----------
 -  **hosts**: List of ZooKeeper cluster members in format: ['host1:port1', 'host2:port2', 'etc...'].
--  **use_ssl**: (optional) Whether SSL is used or not. Defaults to `false`. If set to `false`, all SSL specific parameters are ignored.
--  **cacert**: (optional) The ca certificate. If present it will enable validation.
+-  **use_ssl**: (optional) Whether SSL is used or not. Defaults to ``false``. If set to ``false``, all SSL specific parameters are ignored.
+-  **cacert**: (optional) The CA certificate. If present it will enable validation.
 -  **cert**: (optional) File with the client certificate.
 -  **key**: (optional) File with the client key.
 -  **key_password**: (optional) The client key password.
--  **verify**: (optional) Whether to verify certificate or not. Defaults to `true`.
+-  **verify**: (optional) Whether to verify certificate or not. Defaults to ``true``.
 
 .. note::
     It is required to install ``kazoo>=2.6.0`` to support SSL.

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -155,6 +155,10 @@ ZooKeeper
 -  **key_password**: (optional) The client key password.
 -  **verify**: (optional) Whether to verify certificate or not. Defaults to `true`.
 
+.. note::
+    It is required to install ``kazoo>=2.6.0`` to use SSL.
+
+
 Exhibitor
 ---------
 -  **hosts**: initial list of Exhibitor (ZooKeeper) nodes in format: 'host1,host2,etc...'. This list updates automatically whenever the Exhibitor (ZooKeeper) cluster topology changes.

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -307,7 +307,7 @@ class Config(object):
                               'CACERT', 'CERT', 'KEY', 'VERIFY', 'TOKEN', 'CHECKS', 'DC', 'CONSISTENCY',
                               'REGISTER_SERVICE', 'SERVICE_CHECK_INTERVAL', 'NAMESPACE', 'CONTEXT',
                               'USE_ENDPOINTS', 'SCOPE_LABEL', 'ROLE_LABEL', 'POD_IP', 'PORTS', 'LABELS',
-                              'BYPASS_API_SERVICE') and name:
+                              'BYPASS_API_SERVICE', 'KEY_PASSWORD', 'USE_SSL') and name:
                     value = os.environ.pop(param)
                     if suffix == 'PORT':
                         value = value and parse_int(value)

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -63,7 +63,7 @@ class ZooKeeper(AbstractDCS):
         if isinstance(hosts, list):
             hosts = ','.join(hosts)
 
-        mapping = {'use_ssl': 'use_ssl', 'verify': 'verify_certs', 'cacert': 'ca', 
+        mapping = {'use_ssl': 'use_ssl', 'verify': 'verify_certs', 'cacert': 'ca',
                    'cert': 'certfile', 'key': 'keyfile', 'key_password': 'keyfile_password'}
         kwargs = {v: config[k] for k, v in mapping.items() if k in config}
 

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -10,7 +10,6 @@ from patroni.dcs import AbstractDCS, ClusterConfig, Cluster, Failover, Leader, M
 from patroni.exceptions import DCSError
 from patroni.utils import deep_compare
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -10,7 +10,6 @@ from patroni.dcs import AbstractDCS, ClusterConfig, Cluster, Failover, Leader, M
 from patroni.exceptions import DCSError
 from patroni.utils import deep_compare
 
-from ..utils import parse_bool
 
 logger = logging.getLogger(__name__)
 

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -65,20 +65,9 @@ class ZooKeeper(AbstractDCS):
         if isinstance(hosts, list):
             hosts = ','.join(hosts)
 
-        kwargs = dict(zip(['ca', 'certfile', 'keyfile', 'keyfile_password'],
-                          [config.get(p) for p in ('cacert', 'cert', 'key', 'key_password')]))
-
-        use_ssl = config.get('use_ssl', False)
-        if not isinstance(use_ssl, bool):
-            use_ssl = parse_bool(use_ssl)
-        if isinstance(use_ssl, bool):
-            kwargs['use_ssl'] = use_ssl
-
-        verify_certs = config.get('verify', True)
-        if not isinstance(verify_certs, bool):
-            verify_certs = parse_bool(verify_certs)
-        if isinstance(verify_certs, bool):
-            kwargs['verify_certs'] = verify_certs
+        mapping = {'use_ssl': 'use_ssl', 'verify': 'verify_certs', 'cacert': 'ca', 
+                   'cert': 'certfile', 'key': 'keyfile', 'key_password': 'keyfile_password'}
+        kwargs = {v: config[k] for k, v in mapping.items() if k in config}
 
         self._client = KazooClient(hosts, handler=PatroniSequentialThreadingHandler(config['retry_timeout']),
                                    timeout=config['ttl'], connection_retry=KazooRetry(max_delay=1, max_tries=-1,


### PR DESCRIPTION
This is an attempt to add support of secure client connections using SSL for ZooKeeper DCS.
Here is the example of `zookeeper` config section:
```
zookeeper:
  hosts:
    - 127.0.0.1:2281
  use_ssl: true
  cacert: /path/to/certs/ca.crt
  cert: /path/to/certs/client.crt
  key: /path/to/certs/client.key
  key_password: secret123
  verify: false
```
Closes #1658 