### PR TITLE
Add no_params option for custom bootstrap method

### DIFF
--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -24,6 +24,7 @@ arguments to them, i.e. the name of the cluster and the path to the data directo
         <custom_bootstrap_method_name>:
             command: <path_to_custom_bootstrap_script> [param1 [, ...]]
             keep_existing_recovery_conf: False
+            no_params: False
             recovery_conf:
                 recovery_target_action: promote
                 recovery_target_timeline: latest
@@ -39,6 +40,8 @@ in the configuration files, Patroni supplies two cluster-specific ones:
     Name of the cluster to be bootstrapped
 --datadir
     Path to the data directory of the cluster instance to be bootstrapped
+
+Passing these two additional flags can be disabled by setting a special ``no_params`` parameter to ``True``.
 
 If the bootstrap script returns 0, Patroni tries to configure and start the PostgreSQL instance produced by it. If any
 of the intermediate steps fail, or the script returns a non-zero value, Patroni assumes that the bootstrap has failed,

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -25,10 +25,6 @@ class Bootstrap(object):
     def keep_existing_recovery_conf(self):
         return self._running_custom_bootstrap and self._keep_existing_recovery_conf
 
-    @property
-    def supply_params(self):
-        return self._running_custom_bootstrap and not self._no_params
-
     @staticmethod
     def process_user_options(tool, options, not_allowed_options, error_handler):
         user_options = []
@@ -102,8 +98,8 @@ class Bootstrap(object):
 
     def _custom_bootstrap(self, config):
         self._postgresql.set_state('running custom bootstrap script')
-        params = [] if not self.supply_params else ['--scope=' + self._postgresql.scope,
-                                                    '--datadir=' + self._postgresql.data_dir]
+        params = [] if config.get('no_params') else ['--scope=' + self._postgresql.scope, 
+                                                     '--datadir=' + self._postgresql.data_dir]
         try:
             logger.info('Running custom bootstrap script: %s', config['command'])
             if self._postgresql.cancellable.call(shlex.split(config['command']) + params) != 0:
@@ -288,7 +284,6 @@ class Bootstrap(object):
         method = config.get('method') or 'initdb'
         if method != 'initdb' and method in config and 'command' in config[method]:
             self._keep_existing_recovery_conf = config[method].get('keep_existing_recovery_conf')
-            self._no_params = config[method].get('no_params', False)
             self._running_custom_bootstrap = True
             do_initialize = self._custom_bootstrap
         else:

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -98,7 +98,7 @@ class Bootstrap(object):
 
     def _custom_bootstrap(self, config):
         self._postgresql.set_state('running custom bootstrap script')
-        params = [] if config.get('no_params') else ['--scope=' + self._postgresql.scope, 
+        params = [] if config.get('no_params') else ['--scope=' + self._postgresql.scope,
                                                      '--datadir=' + self._postgresql.data_dir]
         try:
             logger.info('Running custom bootstrap script: %s', config['command'])


### PR DESCRIPTION
This PR allows setting an additional `no_params` option for custom cluster bootstrap method to prevent passing cluster-specific flags `--scope` and `--datadir`, and not wrapping WAL-G, pgBackRest etc one-liners into separate shell scripts to restore a backup.

Closes #1475 