### PR TITLE
remove hba conf only if exists post bootstrap

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -355,7 +355,8 @@ END;$$""".format(f, rewind['username'])
                     self._running_custom_bootstrap = False
                     # If we don't have custom configuration for pg_hba.conf we need to restore original file
                     if not postgresql.config.get('pg_hba'):
-                        os.unlink(postgresql.config.pg_hba_conf)
+                        if os.path.exists(postgresql.config.pg_hba_conf):
+                            os.unlink(postgresql.config.pg_hba_conf)
                         postgresql.config.restore_configuration_files()
                     postgresql.config.write_postgresql_conf()
                     postgresql.config.replace_pg_ident()


### PR DESCRIPTION
Patroni fails If hba conf happens to be located in non pgdata dir after custom bootstrap.

```
2020-08-27 23:25:06,966 INFO: establishing a new patroni connection to the postgres cluster
2020-08-27 23:25:06,997 INFO: running post_bootstrap
2020-08-27 23:25:07,009 ERROR: post_bootstrap
Traceback (most recent call last):
  File "../lib/python3.8/site-packages/patroni/postgresql/bootstrap.py", line 357, in post_bootstrap
    os.unlink(postgresql.config.pg_hba_conf)
FileNotFoundError: [Errno 2] No such file or directory: '../pgrept1/sysdata/pg_hba.conf'
2020-08-27 23:25:07,016 INFO: removing initialize key after failed attempt to bootstrap the cluster
```