### PR TITLE
Advanced validation of PostgreSQL parameters

### DIFF
--- a/patroni/postgresql/validator.py
+++ b/patroni/postgresql/validator.py
@@ -27,7 +27,8 @@ class CaseInsensitiveDict(HTTPHeaderDict):
 
 class Bool(namedtuple('Bool', 'version_from,version_till')):
 
-    def transform(self, name, value):
+    @staticmethod
+    def transform(name, value):
         if parse_bool(value) is not None:
             return value
         logger.warning('Removing bool parameter=%s from the config due to the invalid value=%s', name, value)
@@ -81,7 +82,8 @@ class Enum(namedtuple('Enum', 'version_from,version_till,possible_values')):
 
 class String(namedtuple('String', 'version_from,version_till')):
 
-    def transform(self, name, value):
+    @staticmethod
+    def transform(name, value):
         return value
 
 

--- a/patroni/postgresql/validator.py
+++ b/patroni/postgresql/validator.py
@@ -1,0 +1,490 @@
+import logging
+
+from urllib3.response import HTTPHeaderDict
+
+from ..utils import parse_bool, parse_int, parse_real
+
+logger = logging.getLogger(__name__)
+
+
+class CaseInsensitiveDict(HTTPHeaderDict):
+
+    def add(self, key, val):
+        self[key] = val
+
+    def __getitem__(self, key):
+        return self._container[key.lower()][1]
+
+    def __repr__(self):
+        return str(dict(self.items()))
+
+    def copy(self):
+        return CaseInsensitiveDict(self._container.values())
+
+
+# Format:
+#  key - parameter name
+#  value - tuple or multiple tuples if something was changing in GUC across postgres versions
+#  tuple - (version_from, version_till, vartype, ...)
+#    version_from - the minimal version of postgres this parameter exists (supported in patroni)
+#    version_till - the version of postgres where the parameter was removed or changed
+#    vartype - possible values: bool, integer, real, enum, string
+#
+#    for integer and real there are additional values:
+#      min_val - the minimal possible value accepted by postgres
+#      max_val - the maximum possible value
+#      unit - ms, s, B, kB, 8kB, MB, 16MB
+#    for enum there is additional value - the tuple with possible enum values
+parameters = CaseInsensitiveDict({
+    'allow_system_table_mods': (90300, None, 'bool'),
+    'application_name': (90300, None, 'string'),
+    'archive_command': (90300, None, 'string'),
+    'archive_mode': (
+        (90300, 90500, 'bool'),
+        (90500, None, 'enum', ('always', 'on', 'off'))
+    ),
+    'archive_timeout': (90300, None, 'integer', 0, 1073741823, 's'),
+    'array_nulls': (90300, None, 'bool'),
+    'authentication_timeout': (90300, None, 'integer', 1, 600, 's'),
+    'autovacuum': (90300, None, 'bool'),
+    'autovacuum_analyze_scale_factor': (90300, None, 'real', 0, 100, None),
+    'autovacuum_analyze_threshold': (90300, None, 'integer', 0, 2147483647, None),
+    'autovacuum_freeze_max_age': (90300, None, 'integer', 100000, 2000000000, None),
+    'autovacuum_max_workers': (
+        (90300, 90600, 'integer', 1, 8388607, None),
+        (90600, None, 'integer', 1, 262143, None)
+    ),
+    'autovacuum_multixact_freeze_max_age': (90300, None, 'integer', 10000, 2000000000, None),
+    'autovacuum_naptime': (90300, None, 'integer', 1, 2147483, 's'),
+    'autovacuum_vacuum_cost_delay': (
+        (90300, 120000, 'integer', -1, 100, 'ms'),
+        (120000, None, 'real', -1, 100, 'ms')
+    ),
+    'autovacuum_vacuum_cost_limit': (90300, None, 'integer', -1, 10000, None),
+    'autovacuum_vacuum_insert_scale_factor': (130000, None, 'real', 0, 100, None),
+    'autovacuum_vacuum_insert_threshold': (130000, None, 'integer', -1, 2147483647, None),
+    'autovacuum_vacuum_scale_factor': (90300, None, 'real', 0, 100, None),
+    'autovacuum_vacuum_threshold': (90300, None, 'integer', 0, 2147483647, None),
+    'autovacuum_work_mem': (90400, None, 'integer', -1, 2147483647, 'kB'),
+    'backend_flush_after': (90600, None, 'integer', 0, 256, '8kB'),
+    'backslash_quote': (90300, None, 'enum', ('safe_encoding', 'on', 'off')),
+    'backtrace_functions': (130000, None, 'string'),
+    'bgwriter_delay': (90300, None, 'integer', 10, 10000, 'ms'),
+    'bgwriter_flush_after': (90600, None, 'integer', 0, 256, '8kB'),
+    'bgwriter_lru_maxpages': (
+        (90300, 100000, 'integer', 0, 1000, None),
+        (100000, None, 'integer', 0, 1073741823, None)
+    ),
+    'bgwriter_lru_multiplier': (90300, None, 'real', 0, 10, None),
+    'bonjour': (90300, None, 'bool'),
+    'bonjour_name': (90300, None, 'string'),
+    'bytea_output': (90300, None, 'enum', ('escape', 'hex')),
+    'check_function_bodies': (90300, None, 'bool'),
+    'checkpoint_completion_target': (90300, None, 'real', 0, 1, None),
+    'checkpoint_flush_after': (90600, None, 'integer', 0, 256, '8kB'),
+    'checkpoint_segments': (90300, 90500, 'integer', 1, 2147483647, None),
+    'checkpoint_timeout': (
+        (90300, 90600, 'integer', 30, 3600, 's'),
+        (90600, None, 'integer', 30, 86400, 's')
+    ),
+    'checkpoint_warning': (90300, None, 'integer', 0, 2147483647, 's'),
+    'client_encoding': (90300, None, 'string'),
+    'client_min_messages': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2',
+                                                  'debug1', 'log', 'notice', 'warning', 'error')),
+    'cluster_name': (90500, None, 'string'),
+    'commit_delay': (90300, None, 'integer', 0, 100000, None),
+    'commit_siblings': (90300, None, 'integer', 0, 1000, None),
+    'config_file': (90300, None, 'string'),
+    'constraint_exclusion': (90300, None, 'enum', ('partition', 'on', 'off')),
+    'cpu_index_tuple_cost': (90300, None, 'real', 0, 1.79769e+308, None),
+    'cpu_operator_cost': (90300, None, 'real', 0, 1.79769e+308, None),
+    'cpu_tuple_cost': (90300, None, 'real', 0, 1.79769e+308, None),
+    'cursor_tuple_fraction': (90300, None, 'real', 0, 1, None),
+    'data_directory': (90300, None, 'string'),
+    'data_sync_retry': (90400, None, 'bool'),
+    'DateStyle': (90300, None, 'string'),
+    'db_user_namespace': (90300, None, 'bool'),
+    'deadlock_timeout': (90300, None, 'integer', 1, 2147483647, 'ms'),
+    'debug_pretty_print': (90300, None, 'bool'),
+    'debug_print_parse': (90300, None, 'bool'),
+    'debug_print_plan': (90300, None, 'bool'),
+    'debug_print_rewritten': (90300, None, 'bool'),
+    'default_statistics_target': (90300, None, 'integer', 1, 10000, None),
+    'default_table_access_method': (120000, None, 'string'),
+    'default_tablespace': (90300, None, 'string'),
+    'default_text_search_config': (90300, None, 'string'),
+    'default_transaction_deferrable': (90300, None, 'bool'),
+    'default_transaction_isolation': (90300, None, 'enum', ('serializable', 'repeatable read',
+                                                            'read committed', 'read uncommitted')),
+    'default_transaction_read_only': (90300, None, 'bool'),
+    'default_with_oids': (90300, 120000, 'bool'),
+    'dynamic_library_path': (90300, None, 'string'),
+    'dynamic_shared_memory_type': (
+        (90400, 120000, 'enum', ('posix', 'sysv', 'mmap', 'none')),
+        (120000, None, 'enum', ('posix', 'sysv', 'mmap'))
+    ),
+    'effective_cache_size': (90300, None, 'integer', 1, 2147483647, '8kB'),
+    'effective_io_concurrency': (90300, None, 'integer', 0, 1000, None),
+    'enable_bitmapscan': (90300, None, 'bool'),
+    'enable_gathermerge': (100000, None, 'bool'),
+    'enable_hashagg': (90300, None, 'bool'),
+    'enable_hashjoin': (90300, None, 'bool'),
+    'enable_incremental_sort': (130000, None, 'bool'),
+    'enable_indexonlyscan': (90300, None, 'bool'),
+    'enable_indexscan': (90300, None, 'bool'),
+    'enable_material': (90300, None, 'bool'),
+    'enable_mergejoin': (90300, None, 'bool'),
+    'enable_nestloop': (90300, None, 'bool'),
+    'enable_parallel_append': (110000, None, 'bool'),
+    'enable_parallel_hash': (110000, None, 'bool'),
+    'enable_partition_pruning': (110000, None, 'bool'),
+    'enable_partitionwise_aggregate': (110000, None, 'bool'),
+    'enable_partitionwise_join': (110000, None, 'bool'),
+    'enable_seqscan': (90300, None, 'bool'),
+    'enable_sort': (90300, None, 'bool'),
+    'enable_tidscan': (90300, None, 'bool'),
+    'escape_string_warning': (90300, None, 'bool'),
+    'event_source': (90300, None, 'string'),
+    'exit_on_error': (90300, None, 'bool'),
+    'external_pid_file': (90300, None, 'string'),
+    'extra_float_digits': (90300, None, 'integer', -15, 3, None),
+    'force_parallel_mode': (90600, None, 'enum', ('off', 'on', 'regress')),
+    'from_collapse_limit': (90300, None, 'integer', 1, 2147483647, None),
+    'fsync': (90300, None, 'bool'),
+    'full_page_writes': (90300, None, 'bool'),
+    'geqo': (90300, None, 'bool'),
+    'geqo_effort': (90300, None, 'integer', 1, 10, None),
+    'geqo_generations': (90300, None, 'integer', 0, 2147483647, None),
+    'geqo_pool_size': (90300, None, 'integer', 0, 2147483647, None),
+    'geqo_seed': (90300, None, 'real', 0, 1, None),
+    'geqo_selection_bias': (90300, None, 'real', 1.5, 2, None),
+    'geqo_threshold': (90300, None, 'integer', 2, 2147483647, None),
+    'gin_fuzzy_search_limit': (90300, None, 'integer', 0, 2147483647, None),
+    'gin_pending_list_limit': (90500, None, 'integer', 64, 2147483647, 'kB'),
+    'hash_mem_multiplier': (130000, None, 'real', 1, 1000, None),
+    'hba_file': (90300, None, 'string'),
+    'hot_standby': (90300, None, 'bool'),
+    'hot_standby_feedback': (90300, None, 'bool'),
+    'huge_pages': (90400, None, 'enum', ('off', 'on', 'try')),
+    'ident_file': (90300, None, 'string'),
+    'idle_in_transaction_session_timeout': (90600, None, 'integer', 0, 2147483647, 'ms'),
+    'ignore_checksum_failure': (90300, None, 'bool'),
+    'ignore_invalid_pages': (130000, None, 'bool'),
+    'ignore_system_indexes': (90300, None, 'bool'),
+    'IntervalStyle': (90300, None, 'enum', ('postgres', 'postgres_verbose', 'sql_standard', 'iso_8601')),
+    'jit': (110000, None, 'bool'),
+    'jit_above_cost': (110000, None, 'real', -1, 1.79769e+308, None),
+    'jit_debugging_support': (110000, None, 'bool'),
+    'jit_dump_bitcode': (110000, None, 'bool'),
+    'jit_expressions': (110000, None, 'bool'),
+    'jit_inline_above_cost': (110000, None, 'real', -1, 1.79769e+308, None),
+    'jit_optimize_above_cost': (110000, None, 'real', -1, 1.79769e+308, None),
+    'jit_profiling_support': (110000, None, 'bool'),
+    'jit_provider': (110000, None, 'string'),
+    'jit_tuple_deforming': (110000, None, 'bool'),
+    'join_collapse_limit': (90300, None, 'integer', 1, 2147483647, None),
+    'krb_caseins_users': (90300, None, 'bool'),
+    'krb_server_keyfile': (90300, None, 'string'),
+    'krb_srvname': (90300, 90400, 'string'),
+    'lc_messages': (90300, None, 'string'),
+    'lc_monetary': (90300, None, 'string'),
+    'lc_numeric': (90300, None, 'string'),
+    'lc_time': (90300, None, 'string'),
+    'listen_addresses': (90300, None, 'string'),
+    'local_preload_libraries': (90300, None, 'string'),
+    'lock_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
+    'lo_compat_privileges': (90300, None, 'bool'),
+    'log_autovacuum_min_duration': (90300, None, 'integer', -1, 2147483647, 'ms'),
+    'log_checkpoints': (90300, None, 'bool'),
+    'log_connections': (90300, None, 'bool'),
+    'log_destination': (90300, None, 'string'),
+    'log_directory': (90300, None, 'string'),
+    'log_disconnections': (90300, None, 'bool'),
+    'log_duration': (90300, None, 'bool'),
+    'log_error_verbosity': (90300, None, 'enum', ('terse', 'default', 'verbose')),
+    'log_executor_stats': (90300, None, 'bool'),
+    'log_file_mode': (90300, None, 'integer', 0, 511, None),
+    'log_filename': (90300, None, 'string'),
+    'logging_collector': (90300, None, 'bool'),
+    'log_hostname': (90300, None, 'bool'),
+    'logical_decoding_work_mem': (130000, None, 'integer', 64, 2147483647, 'kB'),
+    'log_line_prefix': (90300, None, 'string'),
+    'log_lock_waits': (90300, None, 'bool'),
+    'log_min_duration_sample': (130000, None, 'integer', -1, 2147483647, 'ms'),
+    'log_min_duration_statement': (90300, None, 'integer', -1, 2147483647, 'ms'),
+    'log_min_error_statement': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'info',
+                                                      'notice', 'warning', 'error', 'log', 'fatal', 'panic')),
+    'log_min_messages': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'info',
+                                               'notice', 'warning', 'error', 'log', 'fatal', 'panic')),
+    'log_parameter_max_length': (130000, None, 'integer', -1, 1073741823, 'B'),
+    'log_parameter_max_length_on_error': (130000, None, 'integer', -1, 1073741823, 'B'),
+    'log_parser_stats': (90300, None, 'bool'),
+    'log_planner_stats': (90300, None, 'bool'),
+    'log_replication_commands': (90500, None, 'bool'),
+    'log_rotation_age': (90300, None, 'integer', 0, 35791394, 'min'),
+    'log_rotation_size': (90300, None, 'integer', 0, 2097151, 'kB'),
+    'log_statement': (90300, None, 'enum', ('none', 'ddl', 'mod', 'all')),
+    'log_statement_sample_rate': (130000, None, 'real', 0, 1, None),
+    'log_statement_stats': (90300, None, 'bool'),
+    'log_temp_files': (90300, None, 'integer', -1, 2147483647, 'kB'),
+    'log_timezone': (90300, None, 'string'),
+    'log_transaction_sample_rate': (120000, None, 'real', 0, 1, None),
+    'log_truncate_on_rotation': (90300, None, 'bool'),
+    'maintenance_io_concurrency': (130000, None, 'integer', 0, 1000, None),
+    'maintenance_work_mem': (90300, None, 'integer', 1024, 2147483647, 'kB'),
+    'max_connections': (
+        (90300, 90600, 'integer', 1, 8388607, None),
+        (90600, None, 'integer', 1, 262143, None)
+    ),
+    'max_files_per_process': (
+        (90300, 130000, 'integer', 25, 2147483647, None),
+        (130000, None, 'integer', 64, 2147483647, None)
+    ),
+    'max_locks_per_transaction': (90300, None, 'integer', 10, 2147483647, None),
+    'max_logical_replication_workers': (100000, None, 'integer', 0, 262143, None),
+    'max_parallel_maintenance_workers': (110000, None, 'integer', 0, 1024, None),
+    'max_parallel_workers': (100000, None, 'integer', 0, 1024, None),
+    'max_parallel_workers_per_gather': (90600, None, 'integer', 0, 1024, None),
+    'max_pred_locks_per_page': (100000, None, 'integer', 0, 2147483647, None),
+    'max_pred_locks_per_relation': (100000, None, 'integer', -2147483648, 2147483647, None),
+    'max_pred_locks_per_transaction': (90300, None, 'integer', 10, 2147483647, None),
+    'max_prepared_transactions': (
+        (90300, 90600, 'integer', 0, 8388607, None),
+        (90600, None, 'integer', 0, 262143, None)
+    ),
+    'max_replication_slots': (
+        (90400, 90600, 'integer', 0, 8388607, None),
+        (90600, None, 'integer', 0, 262143, None)
+    ),
+    'max_slot_wal_keep_size': (130000, None, 'integer', -1, 2147483647, 'MB'),
+    'max_stack_depth': (90300, None, 'integer', 100, 2147483647, 'kB'),
+    'max_standby_archive_delay': (90300, None, 'integer', -1, 2147483647, 'ms'),
+    'max_standby_streaming_delay': (90300, None, 'integer', -1, 2147483647, 'ms'),
+    'max_sync_workers_per_subscription': (100000, None, 'integer', 0, 262143, None),
+    'max_wal_senders': (
+        (90300, 90600, 'integer', 0, 8388607, None),
+        (90600, None, 'integer', 0, 262143, None)
+    ),
+    'max_wal_size': (
+        (90500, 100000, 'integer', 2, 2147483647, '16MB'),
+        (100000, None, 'integer', 2, 2147483647, 'MB')
+    ),
+    'max_worker_processes': (
+        (90400, 90600, 'integer', 1, 8388607, None),
+        (90600, None, 'integer', 0, 262143, None)
+    ),
+    'min_parallel_index_scan_size': (100000, None, 'integer', 0, 715827882, '8kB'),
+    'min_parallel_relation_size': (90600, 100000, 'integer', 0, 715827882, '8kB'),
+    'min_parallel_table_scan_size': (100000, None, 'integer', 0, 715827882, '8kB'),
+    'min_wal_size': (
+        (90500, 100000, 'integer', 2, 2147483647, '16MB'),
+        (100000, None, 'integer', 2, 2147483647, 'MB')
+    ),
+    'old_snapshot_threshold': (90600, None, 'integer', -1, 86400, 'min'),
+    'operator_precedence_warning': (90500, None, 'bool'),
+    'parallel_leader_participation': (110000, None, 'bool'),
+    'parallel_setup_cost': (90600, None, 'real', 0, 1.79769e+308, None),
+    'parallel_tuple_cost': (90600, None, 'real', 0, 1.79769e+308, None),
+    'password_encryption': (
+        (90300, 100000, 'bool'),
+        (100000, None, 'enum', ('md5', 'scram-sha-256'))
+    ),
+    'plan_cache_mode': (120000, None, 'enum', ('auto', 'force_generic_plan', 'force_custom_plan')),
+    'port': (90300, None, 'integer', 1, 65535, None),
+    'post_auth_delay': (90300, None, 'integer', 0, 2147, 's'),
+    'pre_auth_delay': (90300, None, 'integer', 0, 60, 's'),
+    'quote_all_identifiers': (90300, None, 'bool'),
+    'random_page_cost': (90300, None, 'real', 0, 1.79769e+308, None),
+    'replacement_sort_tuples': (90600, 110000, 'integer', 0, 2147483647, None),
+    'restart_after_crash': (90300, None, 'bool'),
+    'row_security': (90500, None, 'bool'),
+    'search_path': (90300, None, 'string'),
+    'seq_page_cost': (90300, None, 'real', 0, 1.79769e+308, None),
+    'session_preload_libraries': (90400, None, 'string'),
+    'session_replication_role': (90300, None, 'enum', ('origin', 'replica', 'local')),
+    'shared_buffers': (90300, None, 'integer', 16, 1073741823, '8kB'),
+    'shared_memory_type': (120000, None, 'enum', ('sysv', 'mmap')),
+    'shared_preload_libraries': (90300, None, 'string'),
+    'sql_inheritance': (90300, 100000, 'bool'),
+    'ssl': (90300, None, 'bool'),
+    'ssl_ca_file': (90300, None, 'string'),
+    'ssl_cert_file': (90300, None, 'string'),
+    'ssl_ciphers': (90300, None, 'string'),
+    'ssl_crl_file': (90300, None, 'string'),
+    'ssl_dh_params_file': (100000, None, 'string'),
+    'ssl_ecdh_curve': (90400, None, 'string'),
+    'ssl_key_file': (90300, None, 'string'),
+    'ssl_max_protocol_version': (120000, None, 'enum', ('', 'tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3')),
+    'ssl_min_protocol_version': (120000, None, 'enum', ('tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3')),
+    'ssl_passphrase_command': (110000, None, 'string'),
+    'ssl_passphrase_command_supports_reload': (110000, None, 'bool'),
+    'ssl_prefer_server_ciphers': (90400, None, 'bool'),
+    'ssl_renegotiation_limit': (90300, 90500, 'integer', 0, 2147483647, 'kB'),
+    'standard_conforming_strings': (90300, None, 'bool'),
+    'statement_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
+    'stats_temp_directory': (90300, None, 'string'),
+    'superuser_reserved_connections': (
+        (90300, 90600, 'integer', 0, 8388607, None),
+        (90600, None, 'integer', 0, 262143, None),
+    ),
+    'synchronize_seqscans': (90300, None, 'bool'),
+    'synchronous_commit': (
+        (90300, 90600, 'enum', ('local', 'remote_write', 'on', 'off')),
+        (90600, None, 'enum', ('local', 'remote_write', 'remote_apply', 'on', 'off'))
+    ),
+    'synchronous_standby_names': (90300, None, 'string'),
+    'syslog_facility': (90300, None, 'enum', ('local0', 'local1', 'local2', 'local3',
+                                              'local4', 'local5', 'local6', 'local7')),
+    'syslog_ident': (90300, None, 'string'),
+    'syslog_sequence_numbers': (90600, None, 'bool'),
+    'syslog_split_messages': (90600, None, 'bool'),
+    'tcp_keepalives_count': (90300, None, 'integer', 0, 2147483647, None),
+    'tcp_keepalives_idle': (90300, None, 'integer', 0, 2147483647, 's'),
+    'tcp_keepalives_interval': (90300, None, 'integer', 0, 2147483647, 's'),
+    'tcp_user_timeout': (120000, None, 'integer', 0, 2147483647, 'ms'),
+    'temp_buffers': (90300, None, 'integer', 100, 1073741823, '8kB'),
+    'temp_file_limit': (90300, None, 'integer', -1, 2147483647, 'kB'),
+    'temp_tablespaces': (90300, None, 'string'),
+    'TimeZone': (90300, None, 'string'),
+    'timezone_abbreviations': (90300, None, 'string'),
+    'trace_notify': (90300, None, 'bool'),
+    'trace_recovery_messages': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2',
+                                                      'debug1', 'log', 'notice', 'warning', 'error')),
+    'trace_sort': (90300, None, 'bool'),
+    'track_activities': (90300, None, 'bool'),
+    'track_activity_query_size': (
+        (90300, 110000, 'integer', 100, 102400, None),
+        (110000, 130000, 'integer', 100, 102400, 'B'),
+        (130000, None, 'integer', 100, 1048576, 'B')
+    ),
+    'track_commit_timestamp': (90500, None, 'bool'),
+    'track_counts': (90300, None, 'bool'),
+    'track_functions': (90300, None, 'enum', ('none', 'pl', 'all')),
+    'track_io_timing': (90300, None, 'bool'),
+    'transaction_deferrable': (90300, None, 'bool'),
+    'transaction_isolation': (90300, None, 'enum', ('serializable', 'repeatable read',
+                                                    'read committed', 'read uncommitted')),
+    'transaction_read_only': (90300, None, 'bool'),
+    'transform_null_equals': (90300, None, 'bool'),
+    'unix_socket_directories': (90300, None, 'string'),
+    'unix_socket_group': (90300, None, 'string'),
+    'unix_socket_permissions': (90300, None, 'integer', 0, 511, None),
+    'update_process_title': (90300, None, 'bool'),
+    'vacuum_cleanup_index_scale_factor': (110000, None, 'real', 0, 1e+10, None),
+    'vacuum_cost_delay': (
+        (90300, 120000, 'integer', 0, 100, 'ms'),
+        (120000, None, 'real', 0, 100, 'ms')
+    ),
+    'vacuum_cost_limit': (90300, None, 'integer', 1, 10000, None),
+    'vacuum_cost_page_dirty': (90300, None, 'integer', 0, 10000, None),
+    'vacuum_cost_page_hit': (90300, None, 'integer', 0, 10000, None),
+    'vacuum_cost_page_miss': (90300, None, 'integer', 0, 10000, None),
+    'vacuum_defer_cleanup_age': (90300, None, 'integer', 0, 1000000, None),
+    'vacuum_freeze_min_age': (90300, None, 'integer', 0, 1000000000, None),
+    'vacuum_freeze_table_age': (90300, None, 'integer', 0, 2000000000, None),
+    'vacuum_multixact_freeze_min_age': (90300, None, 'integer', 0, 1000000000, None),
+    'vacuum_multixact_freeze_table_age': (90300, None, 'integer', 0, 2000000000, None),
+    'wal_buffers': (90300, None, 'integer', -1, 262143, '8kB'),
+    'wal_compression': (90500, None, 'bool'),
+    'wal_consistency_checking': (100000, None, 'string'),
+    'wal_init_zero': (120000, None, 'bool'),
+    'wal_keep_segments': (90300, 130000, 'integer', 0, 2147483647, None),
+    'wal_keep_size': (130000, None, 'integer', 0, 2147483647, 'MB'),
+    'wal_level': (
+        (90300, 90400, 'enum', ('minimal', 'archive', 'hot_standby')),
+        (90400, 90600, 'enum', ('minimal', 'archive', 'hot_standby', 'logical')),
+        (90600, None, 'enum', ('minimal', 'replica', 'logical'))
+    ),
+    'wal_log_hints': (90400, None, 'bool'),
+    'wal_receiver_create_temp_slot': (130000, None, 'bool'),
+    'wal_receiver_status_interval': (90300, None, 'integer', 0, 2147483, 's'),
+    'wal_receiver_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
+    'wal_recycle': (120000, None, 'bool'),
+    'wal_retrieve_retry_interval': (90500, None, 'integer', 1, 2147483647, 'ms'),
+    'wal_sender_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
+    'wal_skip_threshold': (130000, None, 'integer', 0, 2147483647, 'kB'),
+    'wal_sync_method': (90300, None, 'enum', ('fsync', 'fdatasync', 'open_sync', 'open_datasync')),
+    'wal_writer_delay': (90300, None, 'integer', 1, 10000, 'ms'),
+    'wal_writer_flush_after': (90600, None, 'integer', 0, 2147483647, '8kB'),
+    'work_mem': (90300, None, 'integer', 64, 2147483647, 'kB'),
+    'xmlbinary': (90300, None, 'enum', ('base64', 'hex')),
+    'xmloption': (90300, None, 'enum', ('content', 'document')),
+    'zero_damaged_pages': (90300, None, 'bool')
+})
+
+
+recovery_parameters = CaseInsensitiveDict({
+    'archive_cleanup_command': (90300, None, 'string'),
+    'pause_at_recovery_target': (90300, 90500, 'bool'),
+    'primary_conninfo': (90300, None, 'string'),
+    'primary_slot_name': (90400, None, 'string'),
+    'promote_trigger_file': (120000, None, 'string'),
+    'recovery_end_command': (90300, None, 'string'),
+    'recovery_min_apply_delay': (90400, None, 'integer', 0, 2147483647, 'ms'),
+    'recovery_target': (90400, None, 'enum', ('immediate',)),
+    'recovery_target_action': (90500, None, 'enum', ('pause', 'promote', 'shutdown')),
+    'recovery_target_inclusive': (90300, None, 'bool'),
+    'recovery_target_lsn': (100000, None, 'string'),
+    'recovery_target_name': (90400, None, 'string'),
+    'recovery_target_time': (90300, None, 'string'),
+    'recovery_target_timeline': (90300, None, 'string'),
+    'recovery_target_xid': (90300, None, 'string'),
+    'restore_command': (90300, None, 'string'),
+    'standby_mode': (90300, 120000, 'bool'),
+    'trigger_file': (90300, 120000, 'string')
+})
+
+
+def transform_bool(name, value):
+    bool_value = parse_bool(value)
+    if bool_value is not None:
+        return value
+    logger.warning('Removing bool parameter=%s from the config due to the invalid value=%s', name, value)
+
+
+def _transform_number(name, value, validator):
+    func = parse_int if validator[2] == 'int' else parse_real
+    num_value = func(value, validator[5])
+    if num_value is not None:
+        if num_value < validator[3]:
+            logger.warning('Value=%s of parameter=%s is too low, increasing to %s%s',
+                           value, name, validator[3], validator[5] or '')
+            return validator[3]
+        if num_value > validator[4]:
+            logger.warning('Value=%s of parameter=%s is too big, decreasing to %s%s',
+                           value, name, validator[4], validator[5] or '')
+            return validator[4]
+        return value
+    logger.warning('Removing %s parameter=%s from the config due to the invalid value=%s', validator[2], name, value)
+
+
+def transform_enum(name, value, validator):
+    if str(value).lower() in validator[3]:
+        return value
+    logger.warning('Removing enum parameter=%s from the config due to the invalid value=%s', name, value)
+
+
+def _transform_parameter_value(validators, version, name, value):
+    validators = validators.get(name)
+    if validators:
+        for validator in (validators if isinstance(validators[0], tuple) else [validators]):
+            if version >= validator[0] and (validator[1] is None or version < validator[1]):
+                converters = {
+                    'bool': lambda v1, v2, v3: transform_bool(v1, v2),
+                    'integer': _transform_number,
+                    'real': _transform_number,
+                    'enum': transform_enum,
+                    'string': lambda v1, v2, v3: v2
+                }
+                return (converters.get(validator[2]) or converters['string'])(name, value, validator)
+    logger.warning('Removing unexpected parameter=%s value=%s from the config', name, value)
+
+
+def transform_postgresql_parameter_value(version, name, value):
+    if '.' in name:
+        return value
+    return _transform_parameter_value(parameters, version, name, value)
+
+
+def transform_recovery_parameter_value(version, name, value):
+    return _transform_parameter_value(recovery_parameters, version, name, value)

--- a/patroni/postgresql/validator.py
+++ b/patroni/postgresql/validator.py
@@ -80,6 +80,14 @@ class Enum(namedtuple('Enum', 'version_from,version_till,possible_values')):
         logger.warning('Removing enum parameter=%s from the config due to the invalid value=%s', name, value)
 
 
+class EnumBool(Enum):
+
+    def transform(self, name, value):
+        if parse_bool(value) is not None:
+            return value
+        return super(EnumBool, self).transform(name, value)
+
+
 class String(namedtuple('String', 'version_from,version_till')):
 
     @staticmethod
@@ -90,23 +98,13 @@ class String(namedtuple('String', 'version_from,version_till')):
 # Format:
 #  key - parameter name
 #  value - tuple or multiple tuples if something was changing in GUC across postgres versions
-#  tuple - (version_from, version_till, vartype, ...)
-#    version_from - the minimal version of postgres this parameter exists (supported in patroni)
-#    version_till - the version of postgres where the parameter was removed or changed
-#    vartype - possible values: bool, integer, real, enum, string
-#
-#    for integer and real there are additional values:
-#      min_val - the minimal possible value accepted by postgres
-#      max_val - the maximum possible value
-#      unit - ms, s, B, kB, 8kB, MB, 16MB
-#    for enum there is additional value - the tuple with possible enum values
 parameters = CaseInsensitiveDict({
     'allow_system_table_mods': Bool(90300, None),
     'application_name': String(90300, None),
     'archive_command': String(90300, None),
     'archive_mode': (
         Bool(90300, 90500),
-        Enum(90500, None, ('always', 'on', 'off'))
+        EnumBool(90500, None, ('always',))
     ),
     'archive_timeout': Integer(90300, None, 0, 1073741823, 's'),
     'array_nulls': Bool(90300, None),
@@ -132,7 +130,7 @@ parameters = CaseInsensitiveDict({
     'autovacuum_vacuum_threshold': Integer(90300, None, 0, 2147483647, None),
     'autovacuum_work_mem': Integer(90400, None, -1, 2147483647, 'kB'),
     'backend_flush_after': Integer(90600, None, 0, 256, '8kB'),
-    'backslash_quote': Enum(90300, None, ('safe_encoding', 'on', 'off')),
+    'backslash_quote': EnumBool(90300, None, ('safe_encoding',)),
     'backtrace_functions': String(130000, None),
     'bgwriter_delay': Integer(90300, None, 10, 10000, 'ms'),
     'bgwriter_flush_after': Integer(90600, None, 0, 256, '8kB'),
@@ -160,7 +158,7 @@ parameters = CaseInsensitiveDict({
     'commit_delay': Integer(90300, None, 0, 100000, None),
     'commit_siblings': Integer(90300, None, 0, 1000, None),
     'config_file': String(90300, None),
-    'constraint_exclusion': Enum(90300, None, ('partition', 'on', 'off')),
+    'constraint_exclusion': EnumBool(90300, None, ('partition',)),
     'cpu_index_tuple_cost': Real(90300, None, 0, 1.79769e+308, None),
     'cpu_operator_cost': Real(90300, None, 0, 1.79769e+308, None),
     'cpu_tuple_cost': Real(90300, None, 0, 1.79769e+308, None),
@@ -213,7 +211,7 @@ parameters = CaseInsensitiveDict({
     'exit_on_error': Bool(90300, None),
     'external_pid_file': String(90300, None),
     'extra_float_digits': Integer(90300, None, -15, 3, None),
-    'force_parallel_mode': Enum(90600, None, ('off', 'on', 'regress')),
+    'force_parallel_mode': EnumBool(90600, None, ('regress',)),
     'from_collapse_limit': Integer(90300, None, 1, 2147483647, None),
     'fsync': Bool(90300, None),
     'full_page_writes': Bool(90300, None),
@@ -230,7 +228,7 @@ parameters = CaseInsensitiveDict({
     'hba_file': String(90300, None),
     'hot_standby': Bool(90300, None),
     'hot_standby_feedback': Bool(90300, None),
-    'huge_pages': Enum(90400, None, ('off', 'on', 'try')),
+    'huge_pages': EnumBool(90400, None, ('try',)),
     'ident_file': String(90300, None),
     'idle_in_transaction_session_timeout': Integer(90600, None, 0, 2147483647, 'ms'),
     'ignore_checksum_failure': Bool(90300, None),
@@ -394,8 +392,8 @@ parameters = CaseInsensitiveDict({
     ),
     'synchronize_seqscans': Bool(90300, None),
     'synchronous_commit': (
-        Enum(90300, 90600, ('local', 'remote_write', 'on', 'off')),
-        Enum(90600, None, ('local', 'remote_write', 'remote_apply', 'on', 'off'))
+        EnumBool(90300, 90600, ('local', 'remote_write')),
+        EnumBool(90600, None, ('local', 'remote_write', 'remote_apply'))
     ),
     'synchronous_standby_names': String(90300, None),
     'syslog_facility': Enum(90300, None, ('local0', 'local1', 'local2', 'local3',

--- a/patroni/postgresql/validator.py
+++ b/patroni/postgresql/validator.py
@@ -1,5 +1,8 @@
+import abc
 import logging
+import six
 
+from collections import namedtuple
 from urllib3.response import HTTPHeaderDict
 
 from ..utils import parse_bool, parse_int, parse_real
@@ -22,6 +25,66 @@ class CaseInsensitiveDict(HTTPHeaderDict):
         return CaseInsensitiveDict(self._container.values())
 
 
+class Bool(namedtuple('Bool', 'version_from,version_till')):
+
+    def transform(self, name, value):
+        if parse_bool(value) is not None:
+            return value
+        logger.warning('Removing bool parameter=%s from the config due to the invalid value=%s', name, value)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Number(namedtuple('Number', 'version_from,version_till,min_val,max_val,unit')):
+
+    @staticmethod
+    @abc.abstractmethod
+    def parse(value, unit):
+        """parse value"""
+
+    def transform(self, name, value):
+        num_value = self.parse(value, self.unit)
+        if num_value is not None:
+            if num_value < self.min_val:
+                logger.warning('Value=%s of parameter=%s is too low, increasing to %s%s',
+                               value, name, self.min_val, self.unit or '')
+                return self.min_val
+            if num_value > self.max_val:
+                logger.warning('Value=%s of parameter=%s is too big, decreasing to %s%s',
+                               value, name, self.max_val, self.unit or '')
+                return self.max_val
+            return value
+        logger.warning('Removing %s parameter=%s from the config due to the invalid value=%s',
+                       self.__class__.__name__.lower(), name, value)
+
+
+class Integer(Number):
+
+    @staticmethod
+    def parse(value, unit):
+        return parse_int(value, unit)
+
+
+class Real(Number):
+
+    @staticmethod
+    def parse(value, unit):
+        return parse_real(value, unit)
+
+
+class Enum(namedtuple('Enum', 'version_from,version_till,possible_values')):
+
+    def transform(self, name, value):
+        if str(value).lower() in self.possible_values:
+            return value
+        logger.warning('Removing enum parameter=%s from the config due to the invalid value=%s', name, value)
+
+
+class String(namedtuple('String', 'version_from,version_till')):
+
+    def transform(self, name, value):
+        return value
+
+
 # Format:
 #  key - parameter name
 #  value - tuple or multiple tuples if something was changing in GUC across postgres versions
@@ -36,447 +99,412 @@ class CaseInsensitiveDict(HTTPHeaderDict):
 #      unit - ms, s, B, kB, 8kB, MB, 16MB
 #    for enum there is additional value - the tuple with possible enum values
 parameters = CaseInsensitiveDict({
-    'allow_system_table_mods': (90300, None, 'bool'),
-    'application_name': (90300, None, 'string'),
-    'archive_command': (90300, None, 'string'),
+    'allow_system_table_mods': Bool(90300, None),
+    'application_name': String(90300, None),
+    'archive_command': String(90300, None),
     'archive_mode': (
-        (90300, 90500, 'bool'),
-        (90500, None, 'enum', ('always', 'on', 'off'))
+        Bool(90300, 90500),
+        Enum(90500, None, ('always', 'on', 'off'))
     ),
-    'archive_timeout': (90300, None, 'integer', 0, 1073741823, 's'),
-    'array_nulls': (90300, None, 'bool'),
-    'authentication_timeout': (90300, None, 'integer', 1, 600, 's'),
-    'autovacuum': (90300, None, 'bool'),
-    'autovacuum_analyze_scale_factor': (90300, None, 'real', 0, 100, None),
-    'autovacuum_analyze_threshold': (90300, None, 'integer', 0, 2147483647, None),
-    'autovacuum_freeze_max_age': (90300, None, 'integer', 100000, 2000000000, None),
+    'archive_timeout': Integer(90300, None, 0, 1073741823, 's'),
+    'array_nulls': Bool(90300, None),
+    'authentication_timeout': Integer(90300, None,  1, 600, 's'),
+    'autovacuum': Bool(90300, None),
+    'autovacuum_analyze_scale_factor': Real(90300, None, 0, 100, None),
+    'autovacuum_analyze_threshold': Integer(90300, None, 0, 2147483647, None),
+    'autovacuum_freeze_max_age': Integer(90300, None, 100000, 2000000000, None),
     'autovacuum_max_workers': (
-        (90300, 90600, 'integer', 1, 8388607, None),
-        (90600, None, 'integer', 1, 262143, None)
+        Integer(90300, 90600, 1, 8388607, None),
+        Integer(90600, None, 1, 262143, None)
     ),
-    'autovacuum_multixact_freeze_max_age': (90300, None, 'integer', 10000, 2000000000, None),
-    'autovacuum_naptime': (90300, None, 'integer', 1, 2147483, 's'),
+    'autovacuum_multixact_freeze_max_age': Integer(90300, None, 10000, 2000000000, None),
+    'autovacuum_naptime': Integer(90300, None, 1, 2147483, 's'),
     'autovacuum_vacuum_cost_delay': (
-        (90300, 120000, 'integer', -1, 100, 'ms'),
-        (120000, None, 'real', -1, 100, 'ms')
+        Integer(90300, 120000, -1, 100, 'ms'),
+        Real(120000, None, -1, 100, 'ms')
     ),
-    'autovacuum_vacuum_cost_limit': (90300, None, 'integer', -1, 10000, None),
-    'autovacuum_vacuum_insert_scale_factor': (130000, None, 'real', 0, 100, None),
-    'autovacuum_vacuum_insert_threshold': (130000, None, 'integer', -1, 2147483647, None),
-    'autovacuum_vacuum_scale_factor': (90300, None, 'real', 0, 100, None),
-    'autovacuum_vacuum_threshold': (90300, None, 'integer', 0, 2147483647, None),
-    'autovacuum_work_mem': (90400, None, 'integer', -1, 2147483647, 'kB'),
-    'backend_flush_after': (90600, None, 'integer', 0, 256, '8kB'),
-    'backslash_quote': (90300, None, 'enum', ('safe_encoding', 'on', 'off')),
-    'backtrace_functions': (130000, None, 'string'),
-    'bgwriter_delay': (90300, None, 'integer', 10, 10000, 'ms'),
-    'bgwriter_flush_after': (90600, None, 'integer', 0, 256, '8kB'),
+    'autovacuum_vacuum_cost_limit': Integer(90300, None, -1, 10000, None),
+    'autovacuum_vacuum_insert_scale_factor': Real(130000, None, 0, 100, None),
+    'autovacuum_vacuum_insert_threshold': Integer(130000, None, -1, 2147483647, None),
+    'autovacuum_vacuum_scale_factor': Real(90300, None, 0, 100, None),
+    'autovacuum_vacuum_threshold': Integer(90300, None, 0, 2147483647, None),
+    'autovacuum_work_mem': Integer(90400, None, -1, 2147483647, 'kB'),
+    'backend_flush_after': Integer(90600, None, 0, 256, '8kB'),
+    'backslash_quote': Enum(90300, None, ('safe_encoding', 'on', 'off')),
+    'backtrace_functions': String(130000, None),
+    'bgwriter_delay': Integer(90300, None, 10, 10000, 'ms'),
+    'bgwriter_flush_after': Integer(90600, None, 0, 256, '8kB'),
     'bgwriter_lru_maxpages': (
-        (90300, 100000, 'integer', 0, 1000, None),
-        (100000, None, 'integer', 0, 1073741823, None)
+        Integer(90300, 100000, 0, 1000, None),
+        Integer(100000, None, 0, 1073741823, None)
     ),
-    'bgwriter_lru_multiplier': (90300, None, 'real', 0, 10, None),
-    'bonjour': (90300, None, 'bool'),
-    'bonjour_name': (90300, None, 'string'),
-    'bytea_output': (90300, None, 'enum', ('escape', 'hex')),
-    'check_function_bodies': (90300, None, 'bool'),
-    'checkpoint_completion_target': (90300, None, 'real', 0, 1, None),
-    'checkpoint_flush_after': (90600, None, 'integer', 0, 256, '8kB'),
-    'checkpoint_segments': (90300, 90500, 'integer', 1, 2147483647, None),
+    'bgwriter_lru_multiplier': Real(90300, None, 0, 10, None),
+    'bonjour': Bool(90300, None),
+    'bonjour_name': String(90300, None),
+    'bytea_output': Enum(90300, None, ('escape', 'hex')),
+    'check_function_bodies': Bool(90300, None),
+    'checkpoint_completion_target': Real(90300, None, 0, 1, None),
+    'checkpoint_flush_after': Integer(90600, None, 0, 256, '8kB'),
+    'checkpoint_segments': Integer(90300, 90500, 1, 2147483647, None),
     'checkpoint_timeout': (
-        (90300, 90600, 'integer', 30, 3600, 's'),
-        (90600, None, 'integer', 30, 86400, 's')
+        Integer(90300, 90600, 30, 3600, 's'),
+        Integer(90600, None, 30, 86400, 's')
     ),
-    'checkpoint_warning': (90300, None, 'integer', 0, 2147483647, 's'),
-    'client_encoding': (90300, None, 'string'),
-    'client_min_messages': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2',
-                                                  'debug1', 'log', 'notice', 'warning', 'error')),
-    'cluster_name': (90500, None, 'string'),
-    'commit_delay': (90300, None, 'integer', 0, 100000, None),
-    'commit_siblings': (90300, None, 'integer', 0, 1000, None),
-    'config_file': (90300, None, 'string'),
-    'constraint_exclusion': (90300, None, 'enum', ('partition', 'on', 'off')),
-    'cpu_index_tuple_cost': (90300, None, 'real', 0, 1.79769e+308, None),
-    'cpu_operator_cost': (90300, None, 'real', 0, 1.79769e+308, None),
-    'cpu_tuple_cost': (90300, None, 'real', 0, 1.79769e+308, None),
-    'cursor_tuple_fraction': (90300, None, 'real', 0, 1, None),
-    'data_directory': (90300, None, 'string'),
-    'data_sync_retry': (90400, None, 'bool'),
-    'DateStyle': (90300, None, 'string'),
-    'db_user_namespace': (90300, None, 'bool'),
-    'deadlock_timeout': (90300, None, 'integer', 1, 2147483647, 'ms'),
-    'debug_pretty_print': (90300, None, 'bool'),
-    'debug_print_parse': (90300, None, 'bool'),
-    'debug_print_plan': (90300, None, 'bool'),
-    'debug_print_rewritten': (90300, None, 'bool'),
-    'default_statistics_target': (90300, None, 'integer', 1, 10000, None),
-    'default_table_access_method': (120000, None, 'string'),
-    'default_tablespace': (90300, None, 'string'),
-    'default_text_search_config': (90300, None, 'string'),
-    'default_transaction_deferrable': (90300, None, 'bool'),
-    'default_transaction_isolation': (90300, None, 'enum', ('serializable', 'repeatable read',
-                                                            'read committed', 'read uncommitted')),
-    'default_transaction_read_only': (90300, None, 'bool'),
-    'default_with_oids': (90300, 120000, 'bool'),
-    'dynamic_library_path': (90300, None, 'string'),
+    'checkpoint_warning': Integer(90300, None, 0, 2147483647, 's'),
+    'client_encoding': String(90300, None),
+    'client_min_messages': Enum(90300, None, ('debug5', 'debug4', 'debug3', 'debug2',
+                                              'debug1', 'log', 'notice', 'warning', 'error')),
+    'cluster_name': String(90500, None),
+    'commit_delay': Integer(90300, None, 0, 100000, None),
+    'commit_siblings': Integer(90300, None, 0, 1000, None),
+    'config_file': String(90300, None),
+    'constraint_exclusion': Enum(90300, None, ('partition', 'on', 'off')),
+    'cpu_index_tuple_cost': Real(90300, None, 0, 1.79769e+308, None),
+    'cpu_operator_cost': Real(90300, None, 0, 1.79769e+308, None),
+    'cpu_tuple_cost': Real(90300, None, 0, 1.79769e+308, None),
+    'cursor_tuple_fraction': Real(90300, None, 0, 1, None),
+    'data_directory': String(90300, None),
+    'data_sync_retry': Bool(90400, None),
+    'DateStyle': String(90300, None),
+    'db_user_namespace': Bool(90300, None),
+    'deadlock_timeout': Integer(90300, None, 1, 2147483647, 'ms'),
+    'debug_pretty_print': Bool(90300, None),
+    'debug_print_parse': Bool(90300, None),
+    'debug_print_plan': Bool(90300, None),
+    'debug_print_rewritten': Bool(90300, None),
+    'default_statistics_target': Integer(90300, None, 1, 10000, None),
+    'default_table_access_method': String(120000, None),
+    'default_tablespace': String(90300, None),
+    'default_text_search_config': String(90300, None),
+    'default_transaction_deferrable': Bool(90300, None),
+    'default_transaction_isolation': Enum(90300, None, ('serializable', 'repeatable read',
+                                                        'read committed', 'read uncommitted')),
+    'default_transaction_read_only': Bool(90300, None),
+    'default_with_oids': Bool(90300, 120000),
+    'dynamic_library_path': String(90300, None),
     'dynamic_shared_memory_type': (
-        (90400, 120000, 'enum', ('posix', 'sysv', 'mmap', 'none')),
-        (120000, None, 'enum', ('posix', 'sysv', 'mmap'))
+        Enum(90400, 120000, ('posix', 'sysv', 'mmap', 'none')),
+        Enum(120000, None, ('posix', 'sysv', 'mmap'))
     ),
-    'effective_cache_size': (90300, None, 'integer', 1, 2147483647, '8kB'),
-    'effective_io_concurrency': (90300, None, 'integer', 0, 1000, None),
-    'enable_bitmapscan': (90300, None, 'bool'),
-    'enable_gathermerge': (100000, None, 'bool'),
-    'enable_hashagg': (90300, None, 'bool'),
-    'enable_hashjoin': (90300, None, 'bool'),
-    'enable_incremental_sort': (130000, None, 'bool'),
-    'enable_indexonlyscan': (90300, None, 'bool'),
-    'enable_indexscan': (90300, None, 'bool'),
-    'enable_material': (90300, None, 'bool'),
-    'enable_mergejoin': (90300, None, 'bool'),
-    'enable_nestloop': (90300, None, 'bool'),
-    'enable_parallel_append': (110000, None, 'bool'),
-    'enable_parallel_hash': (110000, None, 'bool'),
-    'enable_partition_pruning': (110000, None, 'bool'),
-    'enable_partitionwise_aggregate': (110000, None, 'bool'),
-    'enable_partitionwise_join': (110000, None, 'bool'),
-    'enable_seqscan': (90300, None, 'bool'),
-    'enable_sort': (90300, None, 'bool'),
-    'enable_tidscan': (90300, None, 'bool'),
-    'escape_string_warning': (90300, None, 'bool'),
-    'event_source': (90300, None, 'string'),
-    'exit_on_error': (90300, None, 'bool'),
-    'external_pid_file': (90300, None, 'string'),
-    'extra_float_digits': (90300, None, 'integer', -15, 3, None),
-    'force_parallel_mode': (90600, None, 'enum', ('off', 'on', 'regress')),
-    'from_collapse_limit': (90300, None, 'integer', 1, 2147483647, None),
-    'fsync': (90300, None, 'bool'),
-    'full_page_writes': (90300, None, 'bool'),
-    'geqo': (90300, None, 'bool'),
-    'geqo_effort': (90300, None, 'integer', 1, 10, None),
-    'geqo_generations': (90300, None, 'integer', 0, 2147483647, None),
-    'geqo_pool_size': (90300, None, 'integer', 0, 2147483647, None),
-    'geqo_seed': (90300, None, 'real', 0, 1, None),
-    'geqo_selection_bias': (90300, None, 'real', 1.5, 2, None),
-    'geqo_threshold': (90300, None, 'integer', 2, 2147483647, None),
-    'gin_fuzzy_search_limit': (90300, None, 'integer', 0, 2147483647, None),
-    'gin_pending_list_limit': (90500, None, 'integer', 64, 2147483647, 'kB'),
-    'hash_mem_multiplier': (130000, None, 'real', 1, 1000, None),
-    'hba_file': (90300, None, 'string'),
-    'hot_standby': (90300, None, 'bool'),
-    'hot_standby_feedback': (90300, None, 'bool'),
-    'huge_pages': (90400, None, 'enum', ('off', 'on', 'try')),
-    'ident_file': (90300, None, 'string'),
-    'idle_in_transaction_session_timeout': (90600, None, 'integer', 0, 2147483647, 'ms'),
-    'ignore_checksum_failure': (90300, None, 'bool'),
-    'ignore_invalid_pages': (130000, None, 'bool'),
-    'ignore_system_indexes': (90300, None, 'bool'),
-    'IntervalStyle': (90300, None, 'enum', ('postgres', 'postgres_verbose', 'sql_standard', 'iso_8601')),
-    'jit': (110000, None, 'bool'),
-    'jit_above_cost': (110000, None, 'real', -1, 1.79769e+308, None),
-    'jit_debugging_support': (110000, None, 'bool'),
-    'jit_dump_bitcode': (110000, None, 'bool'),
-    'jit_expressions': (110000, None, 'bool'),
-    'jit_inline_above_cost': (110000, None, 'real', -1, 1.79769e+308, None),
-    'jit_optimize_above_cost': (110000, None, 'real', -1, 1.79769e+308, None),
-    'jit_profiling_support': (110000, None, 'bool'),
-    'jit_provider': (110000, None, 'string'),
-    'jit_tuple_deforming': (110000, None, 'bool'),
-    'join_collapse_limit': (90300, None, 'integer', 1, 2147483647, None),
-    'krb_caseins_users': (90300, None, 'bool'),
-    'krb_server_keyfile': (90300, None, 'string'),
-    'krb_srvname': (90300, 90400, 'string'),
-    'lc_messages': (90300, None, 'string'),
-    'lc_monetary': (90300, None, 'string'),
-    'lc_numeric': (90300, None, 'string'),
-    'lc_time': (90300, None, 'string'),
-    'listen_addresses': (90300, None, 'string'),
-    'local_preload_libraries': (90300, None, 'string'),
-    'lock_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
-    'lo_compat_privileges': (90300, None, 'bool'),
-    'log_autovacuum_min_duration': (90300, None, 'integer', -1, 2147483647, 'ms'),
-    'log_checkpoints': (90300, None, 'bool'),
-    'log_connections': (90300, None, 'bool'),
-    'log_destination': (90300, None, 'string'),
-    'log_directory': (90300, None, 'string'),
-    'log_disconnections': (90300, None, 'bool'),
-    'log_duration': (90300, None, 'bool'),
-    'log_error_verbosity': (90300, None, 'enum', ('terse', 'default', 'verbose')),
-    'log_executor_stats': (90300, None, 'bool'),
-    'log_file_mode': (90300, None, 'integer', 0, 511, None),
-    'log_filename': (90300, None, 'string'),
-    'logging_collector': (90300, None, 'bool'),
-    'log_hostname': (90300, None, 'bool'),
-    'logical_decoding_work_mem': (130000, None, 'integer', 64, 2147483647, 'kB'),
-    'log_line_prefix': (90300, None, 'string'),
-    'log_lock_waits': (90300, None, 'bool'),
-    'log_min_duration_sample': (130000, None, 'integer', -1, 2147483647, 'ms'),
-    'log_min_duration_statement': (90300, None, 'integer', -1, 2147483647, 'ms'),
-    'log_min_error_statement': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'info',
-                                                      'notice', 'warning', 'error', 'log', 'fatal', 'panic')),
-    'log_min_messages': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'info',
-                                               'notice', 'warning', 'error', 'log', 'fatal', 'panic')),
-    'log_parameter_max_length': (130000, None, 'integer', -1, 1073741823, 'B'),
-    'log_parameter_max_length_on_error': (130000, None, 'integer', -1, 1073741823, 'B'),
-    'log_parser_stats': (90300, None, 'bool'),
-    'log_planner_stats': (90300, None, 'bool'),
-    'log_replication_commands': (90500, None, 'bool'),
-    'log_rotation_age': (90300, None, 'integer', 0, 35791394, 'min'),
-    'log_rotation_size': (90300, None, 'integer', 0, 2097151, 'kB'),
-    'log_statement': (90300, None, 'enum', ('none', 'ddl', 'mod', 'all')),
-    'log_statement_sample_rate': (130000, None, 'real', 0, 1, None),
-    'log_statement_stats': (90300, None, 'bool'),
-    'log_temp_files': (90300, None, 'integer', -1, 2147483647, 'kB'),
-    'log_timezone': (90300, None, 'string'),
-    'log_transaction_sample_rate': (120000, None, 'real', 0, 1, None),
-    'log_truncate_on_rotation': (90300, None, 'bool'),
-    'maintenance_io_concurrency': (130000, None, 'integer', 0, 1000, None),
-    'maintenance_work_mem': (90300, None, 'integer', 1024, 2147483647, 'kB'),
+    'effective_cache_size': Integer(90300, None, 1, 2147483647, '8kB'),
+    'effective_io_concurrency': Integer(90300, None, 0, 1000, None),
+    'enable_bitmapscan': Bool(90300, None),
+    'enable_gathermerge': Bool(100000, None),
+    'enable_hashagg': Bool(90300, None),
+    'enable_hashjoin': Bool(90300, None),
+    'enable_incremental_sort': Bool(130000, None),
+    'enable_indexonlyscan': Bool(90300, None),
+    'enable_indexscan': Bool(90300, None),
+    'enable_material': Bool(90300, None),
+    'enable_mergejoin': Bool(90300, None),
+    'enable_nestloop': Bool(90300, None),
+    'enable_parallel_append': Bool(110000, None),
+    'enable_parallel_hash': Bool(110000, None),
+    'enable_partition_pruning': Bool(110000, None),
+    'enable_partitionwise_aggregate': Bool(110000, None),
+    'enable_partitionwise_join': Bool(110000, None),
+    'enable_seqscan': Bool(90300, None),
+    'enable_sort': Bool(90300, None),
+    'enable_tidscan': Bool(90300, None),
+    'escape_string_warning': Bool(90300, None),
+    'event_source': String(90300, None),
+    'exit_on_error': Bool(90300, None),
+    'external_pid_file': String(90300, None),
+    'extra_float_digits': Integer(90300, None, -15, 3, None),
+    'force_parallel_mode': Enum(90600, None, ('off', 'on', 'regress')),
+    'from_collapse_limit': Integer(90300, None, 1, 2147483647, None),
+    'fsync': Bool(90300, None),
+    'full_page_writes': Bool(90300, None),
+    'geqo': Bool(90300, None),
+    'geqo_effort': Integer(90300, None, 1, 10, None),
+    'geqo_generations': Integer(90300, None, 0, 2147483647, None),
+    'geqo_pool_size': Integer(90300, None, 0, 2147483647, None),
+    'geqo_seed': Real(90300, None, 0, 1, None),
+    'geqo_selection_bias': Real(90300, None, 1.5, 2, None),
+    'geqo_threshold': Integer(90300, None, 2, 2147483647, None),
+    'gin_fuzzy_search_limit': Integer(90300, None, 0, 2147483647, None),
+    'gin_pending_list_limit': Integer(90500, None, 64, 2147483647, 'kB'),
+    'hash_mem_multiplier': Real(130000, None, 1, 1000, None),
+    'hba_file': String(90300, None),
+    'hot_standby': Bool(90300, None),
+    'hot_standby_feedback': Bool(90300, None),
+    'huge_pages': Enum(90400, None, ('off', 'on', 'try')),
+    'ident_file': String(90300, None),
+    'idle_in_transaction_session_timeout': Integer(90600, None, 0, 2147483647, 'ms'),
+    'ignore_checksum_failure': Bool(90300, None),
+    'ignore_invalid_pages': Bool(130000, None),
+    'ignore_system_indexes': Bool(90300, None),
+    'IntervalStyle': Enum(90300, None, ('postgres', 'postgres_verbose', 'sql_standard', 'iso_8601')),
+    'jit': Bool(110000, None),
+    'jit_above_cost': Real(110000, None, -1, 1.79769e+308, None),
+    'jit_debugging_support': Bool(110000, None),
+    'jit_dump_bitcode': Bool(110000, None),
+    'jit_expressions': Bool(110000, None),
+    'jit_inline_above_cost': Real(110000, None, -1, 1.79769e+308, None),
+    'jit_optimize_above_cost': Real(110000, None, -1, 1.79769e+308, None),
+    'jit_profiling_support': Bool(110000, None),
+    'jit_provider': String(110000, None),
+    'jit_tuple_deforming': Bool(110000, None),
+    'join_collapse_limit': Integer(90300, None, 1, 2147483647, None),
+    'krb_caseins_users': Bool(90300, None),
+    'krb_server_keyfile': String(90300, None),
+    'krb_srvname': String(90300, 90400),
+    'lc_messages': String(90300, None),
+    'lc_monetary': String(90300, None),
+    'lc_numeric': String(90300, None),
+    'lc_time': String(90300, None),
+    'listen_addresses': String(90300, None),
+    'local_preload_libraries': String(90300, None),
+    'lock_timeout': Integer(90300, None, 0, 2147483647, 'ms'),
+    'lo_compat_privileges': Bool(90300, None),
+    'log_autovacuum_min_duration': Integer(90300, None, -1, 2147483647, 'ms'),
+    'log_checkpoints': Bool(90300, None),
+    'log_connections': Bool(90300, None),
+    'log_destination': String(90300, None),
+    'log_directory': String(90300, None),
+    'log_disconnections': Bool(90300, None),
+    'log_duration': Bool(90300, None),
+    'log_error_verbosity': Enum(90300, None, ('terse', 'default', 'verbose')),
+    'log_executor_stats': Bool(90300, None),
+    'log_file_mode': Integer(90300, None, 0, 511, None),
+    'log_filename': String(90300, None),
+    'logging_collector': Bool(90300, None),
+    'log_hostname': Bool(90300, None),
+    'logical_decoding_work_mem': Integer(130000, None, 64, 2147483647, 'kB'),
+    'log_line_prefix': String(90300, None),
+    'log_lock_waits': Bool(90300, None),
+    'log_min_duration_sample': Integer(130000, None, -1, 2147483647, 'ms'),
+    'log_min_duration_statement': Integer(90300, None, -1, 2147483647, 'ms'),
+    'log_min_error_statement': Enum(90300, None, ('debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'info',
+                                                  'notice', 'warning', 'error', 'log', 'fatal', 'panic')),
+    'log_min_messages': Enum(90300, None, ('debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'info',
+                                           'notice', 'warning', 'error', 'log', 'fatal', 'panic')),
+    'log_parameter_max_length': Integer(130000, None, -1, 1073741823, 'B'),
+    'log_parameter_max_length_on_error': Integer(130000, None, -1, 1073741823, 'B'),
+    'log_parser_stats': Bool(90300, None),
+    'log_planner_stats': Bool(90300, None),
+    'log_replication_commands': Bool(90500, None),
+    'log_rotation_age': Integer(90300, None, 0, 35791394, 'min'),
+    'log_rotation_size': Integer(90300, None, 0, 2097151, 'kB'),
+    'log_statement': Enum(90300, None, ('none', 'ddl', 'mod', 'all')),
+    'log_statement_sample_rate': Real(130000, None, 0, 1, None),
+    'log_statement_stats': Bool(90300, None),
+    'log_temp_files': Integer(90300, None, -1, 2147483647, 'kB'),
+    'log_timezone': String(90300, None),
+    'log_transaction_sample_rate': Real(120000, None, 0, 1, None),
+    'log_truncate_on_rotation': Bool(90300, None),
+    'maintenance_io_concurrency': Integer(130000, None, 0, 1000, None),
+    'maintenance_work_mem': Integer(90300, None, 1024, 2147483647, 'kB'),
     'max_connections': (
-        (90300, 90600, 'integer', 1, 8388607, None),
-        (90600, None, 'integer', 1, 262143, None)
+        Integer(90300, 90600, 1, 8388607, None),
+        Integer(90600, None, 1, 262143, None)
     ),
     'max_files_per_process': (
-        (90300, 130000, 'integer', 25, 2147483647, None),
-        (130000, None, 'integer', 64, 2147483647, None)
+        Integer(90300, 130000, 25, 2147483647, None),
+        Integer(130000, None, 64, 2147483647, None)
     ),
-    'max_locks_per_transaction': (90300, None, 'integer', 10, 2147483647, None),
-    'max_logical_replication_workers': (100000, None, 'integer', 0, 262143, None),
-    'max_parallel_maintenance_workers': (110000, None, 'integer', 0, 1024, None),
-    'max_parallel_workers': (100000, None, 'integer', 0, 1024, None),
-    'max_parallel_workers_per_gather': (90600, None, 'integer', 0, 1024, None),
-    'max_pred_locks_per_page': (100000, None, 'integer', 0, 2147483647, None),
-    'max_pred_locks_per_relation': (100000, None, 'integer', -2147483648, 2147483647, None),
-    'max_pred_locks_per_transaction': (90300, None, 'integer', 10, 2147483647, None),
+    'max_locks_per_transaction': Integer(90300, None, 10, 2147483647, None),
+    'max_logical_replication_workers': Integer(100000, None, 0, 262143, None),
+    'max_parallel_maintenance_workers': Integer(110000, None, 0, 1024, None),
+    'max_parallel_workers': Integer(100000, None, 0, 1024, None),
+    'max_parallel_workers_per_gather': Integer(90600, None, 0, 1024, None),
+    'max_pred_locks_per_page': Integer(100000, None, 0, 2147483647, None),
+    'max_pred_locks_per_relation': Integer(100000, None, -2147483648, 2147483647, None),
+    'max_pred_locks_per_transaction': Integer(90300, None, 10, 2147483647, None),
     'max_prepared_transactions': (
-        (90300, 90600, 'integer', 0, 8388607, None),
-        (90600, None, 'integer', 0, 262143, None)
+        Integer(90300, 90600, 0, 8388607, None),
+        Integer(90600, None, 0, 262143, None)
     ),
     'max_replication_slots': (
-        (90400, 90600, 'integer', 0, 8388607, None),
-        (90600, None, 'integer', 0, 262143, None)
+        Integer(90400, 90600, 0, 8388607, None),
+        Integer(90600, None, 0, 262143, None)
     ),
-    'max_slot_wal_keep_size': (130000, None, 'integer', -1, 2147483647, 'MB'),
-    'max_stack_depth': (90300, None, 'integer', 100, 2147483647, 'kB'),
-    'max_standby_archive_delay': (90300, None, 'integer', -1, 2147483647, 'ms'),
-    'max_standby_streaming_delay': (90300, None, 'integer', -1, 2147483647, 'ms'),
-    'max_sync_workers_per_subscription': (100000, None, 'integer', 0, 262143, None),
+    'max_slot_wal_keep_size': Integer(130000, None, -1, 2147483647, 'MB'),
+    'max_stack_depth': Integer(90300, None, 100, 2147483647, 'kB'),
+    'max_standby_archive_delay': Integer(90300, None, -1, 2147483647, 'ms'),
+    'max_standby_streaming_delay': Integer(90300, None, -1, 2147483647, 'ms'),
+    'max_sync_workers_per_subscription': Integer(100000, None, 0, 262143, None),
     'max_wal_senders': (
-        (90300, 90600, 'integer', 0, 8388607, None),
-        (90600, None, 'integer', 0, 262143, None)
+        Integer(90300, 90600, 0, 8388607, None),
+        Integer(90600, None, 0, 262143, None)
     ),
     'max_wal_size': (
-        (90500, 100000, 'integer', 2, 2147483647, '16MB'),
-        (100000, None, 'integer', 2, 2147483647, 'MB')
+        Integer(90500, 100000, 2, 2147483647, '16MB'),
+        Integer(100000, None, 2, 2147483647, 'MB')
     ),
     'max_worker_processes': (
-        (90400, 90600, 'integer', 1, 8388607, None),
-        (90600, None, 'integer', 0, 262143, None)
+        Integer(90400, 90600, 1, 8388607, None),
+        Integer(90600, None, 0, 262143, None)
     ),
-    'min_parallel_index_scan_size': (100000, None, 'integer', 0, 715827882, '8kB'),
-    'min_parallel_relation_size': (90600, 100000, 'integer', 0, 715827882, '8kB'),
-    'min_parallel_table_scan_size': (100000, None, 'integer', 0, 715827882, '8kB'),
+    'min_parallel_index_scan_size': Integer(100000, None, 0, 715827882, '8kB'),
+    'min_parallel_relation_size': Integer(90600, 100000, 0, 715827882, '8kB'),
+    'min_parallel_table_scan_size': Integer(100000, None, 0, 715827882, '8kB'),
     'min_wal_size': (
-        (90500, 100000, 'integer', 2, 2147483647, '16MB'),
-        (100000, None, 'integer', 2, 2147483647, 'MB')
+        Integer(90500, 100000, 2, 2147483647, '16MB'),
+        Integer(100000, None, 2, 2147483647, 'MB')
     ),
-    'old_snapshot_threshold': (90600, None, 'integer', -1, 86400, 'min'),
-    'operator_precedence_warning': (90500, None, 'bool'),
-    'parallel_leader_participation': (110000, None, 'bool'),
-    'parallel_setup_cost': (90600, None, 'real', 0, 1.79769e+308, None),
-    'parallel_tuple_cost': (90600, None, 'real', 0, 1.79769e+308, None),
+    'old_snapshot_threshold': Integer(90600, None, -1, 86400, 'min'),
+    'operator_precedence_warning': Bool(90500, None),
+    'parallel_leader_participation': Bool(110000, None),
+    'parallel_setup_cost': Real(90600, None, 0, 1.79769e+308, None),
+    'parallel_tuple_cost': Real(90600, None, 0, 1.79769e+308, None),
     'password_encryption': (
-        (90300, 100000, 'bool'),
-        (100000, None, 'enum', ('md5', 'scram-sha-256'))
+        Bool(90300, 100000),
+        Enum(100000, None, ('md5', 'scram-sha-256'))
     ),
-    'plan_cache_mode': (120000, None, 'enum', ('auto', 'force_generic_plan', 'force_custom_plan')),
-    'port': (90300, None, 'integer', 1, 65535, None),
-    'post_auth_delay': (90300, None, 'integer', 0, 2147, 's'),
-    'pre_auth_delay': (90300, None, 'integer', 0, 60, 's'),
-    'quote_all_identifiers': (90300, None, 'bool'),
-    'random_page_cost': (90300, None, 'real', 0, 1.79769e+308, None),
-    'replacement_sort_tuples': (90600, 110000, 'integer', 0, 2147483647, None),
-    'restart_after_crash': (90300, None, 'bool'),
-    'row_security': (90500, None, 'bool'),
-    'search_path': (90300, None, 'string'),
-    'seq_page_cost': (90300, None, 'real', 0, 1.79769e+308, None),
-    'session_preload_libraries': (90400, None, 'string'),
-    'session_replication_role': (90300, None, 'enum', ('origin', 'replica', 'local')),
-    'shared_buffers': (90300, None, 'integer', 16, 1073741823, '8kB'),
-    'shared_memory_type': (120000, None, 'enum', ('sysv', 'mmap')),
-    'shared_preload_libraries': (90300, None, 'string'),
-    'sql_inheritance': (90300, 100000, 'bool'),
-    'ssl': (90300, None, 'bool'),
-    'ssl_ca_file': (90300, None, 'string'),
-    'ssl_cert_file': (90300, None, 'string'),
-    'ssl_ciphers': (90300, None, 'string'),
-    'ssl_crl_file': (90300, None, 'string'),
-    'ssl_dh_params_file': (100000, None, 'string'),
-    'ssl_ecdh_curve': (90400, None, 'string'),
-    'ssl_key_file': (90300, None, 'string'),
-    'ssl_max_protocol_version': (120000, None, 'enum', ('', 'tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3')),
-    'ssl_min_protocol_version': (120000, None, 'enum', ('tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3')),
-    'ssl_passphrase_command': (110000, None, 'string'),
-    'ssl_passphrase_command_supports_reload': (110000, None, 'bool'),
-    'ssl_prefer_server_ciphers': (90400, None, 'bool'),
-    'ssl_renegotiation_limit': (90300, 90500, 'integer', 0, 2147483647, 'kB'),
-    'standard_conforming_strings': (90300, None, 'bool'),
-    'statement_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
-    'stats_temp_directory': (90300, None, 'string'),
+    'plan_cache_mode': Enum(120000, None, ('auto', 'force_generic_plan', 'force_custom_plan')),
+    'port': Integer(90300, None, 1, 65535, None),
+    'post_auth_delay': Integer(90300, None, 0, 2147, 's'),
+    'pre_auth_delay': Integer(90300, None, 0, 60, 's'),
+    'quote_all_identifiers': Bool(90300, None),
+    'random_page_cost': Real(90300, None, 0, 1.79769e+308, None),
+    'replacement_sort_tuples': Integer(90600, 110000, 0, 2147483647, None),
+    'restart_after_crash': Bool(90300, None),
+    'row_security': Bool(90500, None),
+    'search_path': String(90300, None),
+    'seq_page_cost': Real(90300, None, 0, 1.79769e+308, None),
+    'session_preload_libraries': String(90400, None),
+    'session_replication_role': Enum(90300, None, ('origin', 'replica', 'local')),
+    'shared_buffers': Integer(90300, None, 16, 1073741823, '8kB'),
+    'shared_memory_type': Enum(120000, None, ('sysv', 'mmap')),
+    'shared_preload_libraries': String(90300, None),
+    'sql_inheritance': Bool(90300, 100000),
+    'ssl': Bool(90300, None),
+    'ssl_ca_file': String(90300, None),
+    'ssl_cert_file': String(90300, None),
+    'ssl_ciphers': String(90300, None),
+    'ssl_crl_file': String(90300, None),
+    'ssl_dh_params_file': String(100000, None),
+    'ssl_ecdh_curve': String(90400, None),
+    'ssl_key_file': String(90300, None),
+    'ssl_max_protocol_version': Enum(120000, None, ('', 'tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3')),
+    'ssl_min_protocol_version': Enum(120000, None, ('tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3')),
+    'ssl_passphrase_command': String(110000, None),
+    'ssl_passphrase_command_supports_reload': Bool(110000, None),
+    'ssl_prefer_server_ciphers': Bool(90400, None),
+    'ssl_renegotiation_limit': Integer(90300, 90500, 0, 2147483647, 'kB'),
+    'standard_conforming_strings': Bool(90300, None),
+    'statement_timeout': Integer(90300, None, 0, 2147483647, 'ms'),
+    'stats_temp_directory': String(90300, None),
     'superuser_reserved_connections': (
-        (90300, 90600, 'integer', 0, 8388607, None),
-        (90600, None, 'integer', 0, 262143, None),
+        Integer(90300, 90600, 0, 8388607, None),
+        Integer(90600, None, 0, 262143, None),
     ),
-    'synchronize_seqscans': (90300, None, 'bool'),
+    'synchronize_seqscans': Bool(90300, None),
     'synchronous_commit': (
-        (90300, 90600, 'enum', ('local', 'remote_write', 'on', 'off')),
-        (90600, None, 'enum', ('local', 'remote_write', 'remote_apply', 'on', 'off'))
+        Enum(90300, 90600, ('local', 'remote_write', 'on', 'off')),
+        Enum(90600, None, ('local', 'remote_write', 'remote_apply', 'on', 'off'))
     ),
-    'synchronous_standby_names': (90300, None, 'string'),
-    'syslog_facility': (90300, None, 'enum', ('local0', 'local1', 'local2', 'local3',
-                                              'local4', 'local5', 'local6', 'local7')),
-    'syslog_ident': (90300, None, 'string'),
-    'syslog_sequence_numbers': (90600, None, 'bool'),
-    'syslog_split_messages': (90600, None, 'bool'),
-    'tcp_keepalives_count': (90300, None, 'integer', 0, 2147483647, None),
-    'tcp_keepalives_idle': (90300, None, 'integer', 0, 2147483647, 's'),
-    'tcp_keepalives_interval': (90300, None, 'integer', 0, 2147483647, 's'),
-    'tcp_user_timeout': (120000, None, 'integer', 0, 2147483647, 'ms'),
-    'temp_buffers': (90300, None, 'integer', 100, 1073741823, '8kB'),
-    'temp_file_limit': (90300, None, 'integer', -1, 2147483647, 'kB'),
-    'temp_tablespaces': (90300, None, 'string'),
-    'TimeZone': (90300, None, 'string'),
-    'timezone_abbreviations': (90300, None, 'string'),
-    'trace_notify': (90300, None, 'bool'),
-    'trace_recovery_messages': (90300, None, 'enum', ('debug5', 'debug4', 'debug3', 'debug2',
-                                                      'debug1', 'log', 'notice', 'warning', 'error')),
-    'trace_sort': (90300, None, 'bool'),
-    'track_activities': (90300, None, 'bool'),
+    'synchronous_standby_names': String(90300, None),
+    'syslog_facility': Enum(90300, None, ('local0', 'local1', 'local2', 'local3',
+                                          'local4', 'local5', 'local6', 'local7')),
+    'syslog_ident': String(90300, None),
+    'syslog_sequence_numbers': Bool(90600, None),
+    'syslog_split_messages': Bool(90600, None),
+    'tcp_keepalives_count': Integer(90300, None, 0, 2147483647, None),
+    'tcp_keepalives_idle': Integer(90300, None, 0, 2147483647, 's'),
+    'tcp_keepalives_interval': Integer(90300, None, 0, 2147483647, 's'),
+    'tcp_user_timeout': Integer(120000, None, 0, 2147483647, 'ms'),
+    'temp_buffers': Integer(90300, None, 100, 1073741823, '8kB'),
+    'temp_file_limit': Integer(90300, None, -1, 2147483647, 'kB'),
+    'temp_tablespaces': String(90300, None),
+    'TimeZone': String(90300, None),
+    'timezone_abbreviations': String(90300, None),
+    'trace_notify': Bool(90300, None),
+    'trace_recovery_messages': Enum(90300, None, ('debug5', 'debug4', 'debug3', 'debug2',
+                                                  'debug1', 'log', 'notice', 'warning', 'error')),
+    'trace_sort': Bool(90300, None),
+    'track_activities': Bool(90300, None),
     'track_activity_query_size': (
-        (90300, 110000, 'integer', 100, 102400, None),
-        (110000, 130000, 'integer', 100, 102400, 'B'),
-        (130000, None, 'integer', 100, 1048576, 'B')
+        Integer(90300, 110000, 100, 102400, None),
+        Integer(110000, 130000, 100, 102400, 'B'),
+        Integer(130000, None, 100, 1048576, 'B')
     ),
-    'track_commit_timestamp': (90500, None, 'bool'),
-    'track_counts': (90300, None, 'bool'),
-    'track_functions': (90300, None, 'enum', ('none', 'pl', 'all')),
-    'track_io_timing': (90300, None, 'bool'),
-    'transaction_deferrable': (90300, None, 'bool'),
-    'transaction_isolation': (90300, None, 'enum', ('serializable', 'repeatable read',
-                                                    'read committed', 'read uncommitted')),
-    'transaction_read_only': (90300, None, 'bool'),
-    'transform_null_equals': (90300, None, 'bool'),
-    'unix_socket_directories': (90300, None, 'string'),
-    'unix_socket_group': (90300, None, 'string'),
-    'unix_socket_permissions': (90300, None, 'integer', 0, 511, None),
-    'update_process_title': (90300, None, 'bool'),
-    'vacuum_cleanup_index_scale_factor': (110000, None, 'real', 0, 1e+10, None),
+    'track_commit_timestamp': Bool(90500, None),
+    'track_counts': Bool(90300, None),
+    'track_functions': Enum(90300, None, ('none', 'pl', 'all')),
+    'track_io_timing': Bool(90300, None),
+    'transaction_deferrable': Bool(90300, None),
+    'transaction_isolation': Enum(90300, None, ('serializable', 'repeatable read',
+                                                'read committed', 'read uncommitted')),
+    'transaction_read_only': Bool(90300, None),
+    'transform_null_equals': Bool(90300, None),
+    'unix_socket_directories': String(90300, None),
+    'unix_socket_group': String(90300, None),
+    'unix_socket_permissions': Integer(90300, None, 0, 511, None),
+    'update_process_title': Bool(90300, None),
+    'vacuum_cleanup_index_scale_factor': Real(110000, None, 0, 1e+10, None),
     'vacuum_cost_delay': (
-        (90300, 120000, 'integer', 0, 100, 'ms'),
-        (120000, None, 'real', 0, 100, 'ms')
+        Integer(90300, 120000, 0, 100, 'ms'),
+        Real(120000, None, 0, 100, 'ms')
     ),
-    'vacuum_cost_limit': (90300, None, 'integer', 1, 10000, None),
-    'vacuum_cost_page_dirty': (90300, None, 'integer', 0, 10000, None),
-    'vacuum_cost_page_hit': (90300, None, 'integer', 0, 10000, None),
-    'vacuum_cost_page_miss': (90300, None, 'integer', 0, 10000, None),
-    'vacuum_defer_cleanup_age': (90300, None, 'integer', 0, 1000000, None),
-    'vacuum_freeze_min_age': (90300, None, 'integer', 0, 1000000000, None),
-    'vacuum_freeze_table_age': (90300, None, 'integer', 0, 2000000000, None),
-    'vacuum_multixact_freeze_min_age': (90300, None, 'integer', 0, 1000000000, None),
-    'vacuum_multixact_freeze_table_age': (90300, None, 'integer', 0, 2000000000, None),
-    'wal_buffers': (90300, None, 'integer', -1, 262143, '8kB'),
-    'wal_compression': (90500, None, 'bool'),
-    'wal_consistency_checking': (100000, None, 'string'),
-    'wal_init_zero': (120000, None, 'bool'),
-    'wal_keep_segments': (90300, 130000, 'integer', 0, 2147483647, None),
-    'wal_keep_size': (130000, None, 'integer', 0, 2147483647, 'MB'),
+    'vacuum_cost_limit': Integer(90300, None, 1, 10000, None),
+    'vacuum_cost_page_dirty': Integer(90300, None, 0, 10000, None),
+    'vacuum_cost_page_hit': Integer(90300, None, 0, 10000, None),
+    'vacuum_cost_page_miss': Integer(90300, None, 0, 10000, None),
+    'vacuum_defer_cleanup_age': Integer(90300, None, 0, 1000000, None),
+    'vacuum_freeze_min_age': Integer(90300, None, 0, 1000000000, None),
+    'vacuum_freeze_table_age': Integer(90300, None, 0, 2000000000, None),
+    'vacuum_multixact_freeze_min_age': Integer(90300, None, 0, 1000000000, None),
+    'vacuum_multixact_freeze_table_age': Integer(90300, None, 0, 2000000000, None),
+    'wal_buffers': Integer(90300, None, -1, 262143, '8kB'),
+    'wal_compression': Bool(90500, None),
+    'wal_consistency_checking': String(100000, None),
+    'wal_init_zero': Bool(120000, None),
+    'wal_keep_segments': Integer(90300, 130000, 0, 2147483647, None),
+    'wal_keep_size': Integer(130000, None, 0, 2147483647, 'MB'),
     'wal_level': (
-        (90300, 90400, 'enum', ('minimal', 'archive', 'hot_standby')),
-        (90400, 90600, 'enum', ('minimal', 'archive', 'hot_standby', 'logical')),
-        (90600, None, 'enum', ('minimal', 'replica', 'logical'))
+        Enum(90300, 90400, ('minimal', 'archive', 'hot_standby')),
+        Enum(90400, 90600, ('minimal', 'archive', 'hot_standby', 'logical')),
+        Enum(90600, None, ('minimal', 'replica', 'logical'))
     ),
-    'wal_log_hints': (90400, None, 'bool'),
-    'wal_receiver_create_temp_slot': (130000, None, 'bool'),
-    'wal_receiver_status_interval': (90300, None, 'integer', 0, 2147483, 's'),
-    'wal_receiver_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
-    'wal_recycle': (120000, None, 'bool'),
-    'wal_retrieve_retry_interval': (90500, None, 'integer', 1, 2147483647, 'ms'),
-    'wal_sender_timeout': (90300, None, 'integer', 0, 2147483647, 'ms'),
-    'wal_skip_threshold': (130000, None, 'integer', 0, 2147483647, 'kB'),
-    'wal_sync_method': (90300, None, 'enum', ('fsync', 'fdatasync', 'open_sync', 'open_datasync')),
-    'wal_writer_delay': (90300, None, 'integer', 1, 10000, 'ms'),
-    'wal_writer_flush_after': (90600, None, 'integer', 0, 2147483647, '8kB'),
-    'work_mem': (90300, None, 'integer', 64, 2147483647, 'kB'),
-    'xmlbinary': (90300, None, 'enum', ('base64', 'hex')),
-    'xmloption': (90300, None, 'enum', ('content', 'document')),
-    'zero_damaged_pages': (90300, None, 'bool')
+    'wal_log_hints': Bool(90400, None),
+    'wal_receiver_create_temp_slot': Bool(130000, None),
+    'wal_receiver_status_interval': Integer(90300, None, 0, 2147483, 's'),
+    'wal_receiver_timeout': Integer(90300, None, 0, 2147483647, 'ms'),
+    'wal_recycle': Bool(120000, None),
+    'wal_retrieve_retry_interval': Integer(90500, None, 1, 2147483647, 'ms'),
+    'wal_sender_timeout': Integer(90300, None, 0, 2147483647, 'ms'),
+    'wal_skip_threshold': Integer(130000, None, 0, 2147483647, 'kB'),
+    'wal_sync_method': Enum(90300, None, ('fsync', 'fdatasync', 'open_sync', 'open_datasync')),
+    'wal_writer_delay': Integer(90300, None, 1, 10000, 'ms'),
+    'wal_writer_flush_after': Integer(90600, None, 0, 2147483647, '8kB'),
+    'work_mem': Integer(90300, None, 64, 2147483647, 'kB'),
+    'xmlbinary': Enum(90300, None, ('base64', 'hex')),
+    'xmloption': Enum(90300, None, ('content', 'document')),
+    'zero_damaged_pages': Bool(90300, None)
 })
 
 
 recovery_parameters = CaseInsensitiveDict({
-    'archive_cleanup_command': (90300, None, 'string'),
-    'pause_at_recovery_target': (90300, 90500, 'bool'),
-    'primary_conninfo': (90300, None, 'string'),
-    'primary_slot_name': (90400, None, 'string'),
-    'promote_trigger_file': (120000, None, 'string'),
-    'recovery_end_command': (90300, None, 'string'),
-    'recovery_min_apply_delay': (90400, None, 'integer', 0, 2147483647, 'ms'),
-    'recovery_target': (90400, None, 'enum', ('immediate',)),
-    'recovery_target_action': (90500, None, 'enum', ('pause', 'promote', 'shutdown')),
-    'recovery_target_inclusive': (90300, None, 'bool'),
-    'recovery_target_lsn': (100000, None, 'string'),
-    'recovery_target_name': (90400, None, 'string'),
-    'recovery_target_time': (90300, None, 'string'),
-    'recovery_target_timeline': (90300, None, 'string'),
-    'recovery_target_xid': (90300, None, 'string'),
-    'restore_command': (90300, None, 'string'),
-    'standby_mode': (90300, 120000, 'bool'),
-    'trigger_file': (90300, 120000, 'string')
+    'archive_cleanup_command': String(90300, None),
+    'pause_at_recovery_target': Bool(90300, 90500),
+    'primary_conninfo': String(90300, None),
+    'primary_slot_name': String(90400, None),
+    'promote_trigger_file': String(120000, None),
+    'recovery_end_command': String(90300, None),
+    'recovery_min_apply_delay': Integer(90400, None, 0, 2147483647, 'ms'),
+    'recovery_target': Enum(90400, None, ('immediate',)),
+    'recovery_target_action': Enum(90500, None, ('pause', 'promote', 'shutdown')),
+    'recovery_target_inclusive': Bool(90300, None),
+    'recovery_target_lsn': String(100000, None),
+    'recovery_target_name': String(90400, None),
+    'recovery_target_time': String(90300, None),
+    'recovery_target_timeline': String(90300, None),
+    'recovery_target_xid': String(90300, None),
+    'restore_command': String(90300, None),
+    'standby_mode': Bool(90300, 120000),
+    'trigger_file': String(90300, 120000)
 })
-
-
-def transform_bool(name, value):
-    bool_value = parse_bool(value)
-    if bool_value is not None:
-        return value
-    logger.warning('Removing bool parameter=%s from the config due to the invalid value=%s', name, value)
-
-
-def _transform_number(name, value, validator):
-    func = parse_int if validator[2] == 'int' else parse_real
-    num_value = func(value, validator[5])
-    if num_value is not None:
-        if num_value < validator[3]:
-            logger.warning('Value=%s of parameter=%s is too low, increasing to %s%s',
-                           value, name, validator[3], validator[5] or '')
-            return validator[3]
-        if num_value > validator[4]:
-            logger.warning('Value=%s of parameter=%s is too big, decreasing to %s%s',
-                           value, name, validator[4], validator[5] or '')
-            return validator[4]
-        return value
-    logger.warning('Removing %s parameter=%s from the config due to the invalid value=%s', validator[2], name, value)
-
-
-def transform_enum(name, value, validator):
-    if str(value).lower() in validator[3]:
-        return value
-    logger.warning('Removing enum parameter=%s from the config due to the invalid value=%s', name, value)
 
 
 def _transform_parameter_value(validators, version, name, value):
     validators = validators.get(name)
     if validators:
         for validator in (validators if isinstance(validators[0], tuple) else [validators]):
-            if version >= validator[0] and (validator[1] is None or version < validator[1]):
-                converters = {
-                    'bool': lambda v1, v2, v3: transform_bool(v1, v2),
-                    'integer': _transform_number,
-                    'real': _transform_number,
-                    'enum': transform_enum,
-                    'string': lambda v1, v2, v3: v2
-                }
-                return (converters.get(validator[2]) or converters['string'])(name, value, validator)
+            if version >= validator.version_from and\
+                    (validator.version_till is None or version < validator.version_till):
+                return validator.transform(name, value)
     logger.warning('Removing unexpected parameter=%s value=%s from the config', name, value)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -165,8 +165,9 @@ class PostgresInit(unittest.TestCase):
                    'search_path': 'public', 'hot_standby': 'on', 'max_wal_senders': 5,
                    'wal_keep_segments': 8, 'wal_log_hints': 'on', 'max_locks_per_transaction': 64,
                    'max_worker_processes': 8, 'max_connections': 100, 'max_prepared_transactions': 0,
-                   'track_commit_timestamp': 'off', 'unix_socket_directories': '/tmp', 'trigger_file': 'bla',
-                   'stats_temp_directory': '/tmp'}
+                   'track_commit_timestamp': 'off', 'unix_socket_directories': '/tmp',
+                   'trigger_file': 'bla', 'stats_temp_directory': '/tmp', 'zero_damaged_pages': '',
+                   'max_stack_depth': 'Z', 'vacuum_cost_limit': -1, 'vacuum_cost_delay': 200}
 
     @patch('psycopg2.connect', psycopg2_connect)
     @patch('patroni.postgresql.CallbackExecutor', Mock())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -167,6 +167,7 @@ class PostgresInit(unittest.TestCase):
                    'max_worker_processes': 8, 'max_connections': 100, 'max_prepared_transactions': 0,
                    'track_commit_timestamp': 'off', 'unix_socket_directories': '/tmp',
                    'trigger_file': 'bla', 'stats_temp_directory': '/tmp', 'zero_damaged_pages': '',
+                   'force_parallel_mode': '1', 'constraint_exclusion': '',
                    'max_stack_depth': 'Z', 'vacuum_cost_limit': -1, 'vacuum_cost_delay': 200}
 
     @patch('psycopg2.connect', psycopg2_connect)


### PR DESCRIPTION
So far Patroni was performing a comparison of the old value (in the `pg_settings`) with the new value (from Patroni configuration or from DCS) in order to figure out if reload or restart is required when the parameter has been changed. If the given parameter was missing in the `pg_settings` Patroni was ignoring it and not writing into the `postgresql.conf`.

In case if Postgres is not running, no validation has been performed and parameters and values were written into the config as it is.

It is not a very common mistake, but people tend to mistype parameter names or values.
Also, it happens that some parameters are removed in specific Postgres versions and some new are added (e.g. `checkpoint_segments` replaced with `min_wal_size` and `max_wal_size` in 9.5 or` wal_keep_segments` was replaced with `wal_keep_size` in 13).

Writing nonexistent parameters or invalid values into the `postgresql.conf` makes postgres unstartable.
This change doesn't solve the issue 100%, but at least approaching this goal very close.