### PR TITLE
Allow custom pager support in patronictl edit-config 

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1092,7 +1092,7 @@ def show_diff(before_editing, after_editing):
             wrap = True
             if find_executable('less'):
                 pager = None
-            else
+            else:
                 pager = 'more.com' if sys.platform == 'win32' else 'more'
             pager_options = None
 

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -7,7 +7,6 @@ import codecs
 import datetime
 import dateutil.parser
 import dateutil.tz
-import ydiff
 import copy
 import difflib
 import io
@@ -21,6 +20,10 @@ import sys
 import tempfile
 import time
 import yaml
+try:
+    import ydiff
+except ImportError:
+    import cdiff as ydiff
 
 from click import ClickException
 from collections import defaultdict

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1087,7 +1087,8 @@ def show_diff(before_editing, after_editing):
             width = 80
             tab_width = 8
             wrap = True
-            pager = 'more.com' if (sys.platform == 'win32') else None
+            if not find_executable('less'):
+                pager = 'more.com' if sys.platform == 'win32' else 'more'
             pager_options = None
 
         ydiff.markup_to_pager(ydiff.PatchStream(buf), opts)

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -20,10 +20,6 @@ import sys
 import tempfile
 import time
 import yaml
-try:
-    import ydiff
-except ImportError:
-    import cdiff as ydiff
 
 from click import ClickException
 from collections import defaultdict
@@ -37,6 +33,10 @@ from patroni.request import PatroniRequest
 from patroni.version import __version__
 from prettytable import ALL, FRAME, PrettyTable
 from six.moves.urllib_parse import urlparse
+try:
+    from ydiff import markup_to_pager, PatchStream
+except ImportError:  # pragma: no cover
+    from cdiff import markup_to_pager, PatchStream
 
 CONFIG_DIR_PATH = click.get_app_dir('patroni')
 CONFIG_FILE_PATH = os.path.join(CONFIG_DIR_PATH, 'patronictl.yaml')

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1,4 +1,4 @@
-﻿'''
+'''
 Patroni Control
 '''
 

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1,4 +1,4 @@
-'''
+﻿'''
 Patroni Control
 '''
 
@@ -7,7 +7,7 @@ import codecs
 import datetime
 import dateutil.parser
 import dateutil.tz
-import cdiff
+import ydiff
 import copy
 import difflib
 import io
@@ -1086,7 +1086,12 @@ def show_diff(before_editing, after_editing):
             side_by_side = False
             width = 80
             tab_width = 8
-        cdiff.markup_to_pager(cdiff.PatchStream(buf), opts)
+            wrap = True
+            if (sys.platform == 'win32'):
+                pager = 'more.com'
+                pager_options = None
+
+        ydiff.markup_to_pager(ydiff.PatchStream(buf), opts)
     else:
         for line in unified_diff:
             click.echo(line.rstrip('\n'))

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1090,11 +1090,13 @@ def show_diff(before_editing, after_editing):
             width = 80
             tab_width = 8
             wrap = True
-            if not find_executable('less'):
+            if find_executable('less'):
+                pager = None
+            else
                 pager = 'more.com' if sys.platform == 'win32' else 'more'
             pager_options = None
 
-        ydiff.markup_to_pager(ydiff.PatchStream(buf), opts)
+        markup_to_pager(PatchStream(buf), opts)
     else:
         for line in unified_diff:
             click.echo(line.rstrip('\n'))

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1087,9 +1087,8 @@ def show_diff(before_editing, after_editing):
             width = 80
             tab_width = 8
             wrap = True
-            if (sys.platform == 'win32'):
-                pager = 'more.com'
-                pager_options = None
+            pager = 'more.com' if (sys.platform == 'win32') else None
+            pager_options = None
 
         ydiff.markup_to_pager(ydiff.PatchStream(buf), opts)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-﻿urllib3[secure]>=1.19.1,!=1.21
+urllib3[secure]>=1.19.1,!=1.21
 boto
 PyYAML
 six >= 1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3[secure]>=1.19.1,!=1.21
+﻿urllib3[secure]>=1.19.1,!=1.21
 boto
 PyYAML
 six >= 1.7
@@ -10,4 +10,4 @@ prettytable>=0.7
 python-dateutil
 pysyncobj>=0.3.5
 psutil>=2.0.0
-cdiff
+ydiff>=1.2.0

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -561,7 +561,7 @@ class TestCtl(unittest.TestCase):
         self.assertRaises(PatroniCtlException, apply_config_changes, before_editing, config, ['a'])
 
     @patch('sys.stdout.isatty', return_value=False)
-    @patch('cdiff.markup_to_pager')
+    @patch('patroni.ctl.markup_to_pager')
     def test_show_diff(self, mock_markup_to_pager, mock_isatty):
         show_diff("foo:\n  bar: 1\n", "foo:\n  bar: 2\n")
         mock_markup_to_pager.assert_not_called()
@@ -569,6 +569,9 @@ class TestCtl(unittest.TestCase):
         mock_isatty.return_value = True
         show_diff("foo:\n  bar: 1\n", "foo:\n  bar: 2\n")
         mock_markup_to_pager.assert_called_once()
+
+        with patch('patroni.ctl.find_executable', Mock(return_value=None)):
+            show_diff("foo:\n  bar: 1\n", "foo:\n  bar: 2\n")
 
         # Test that unicode handling doesn't fail with an exception
         show_diff(b"foo:\n  bar: \xc3\xb6\xc3\xb6\n".decode('utf-8'),


### PR DESCRIPTION
Adds the possibility for `patronictl edit-config` custom pager support.

Fixes #1695 

Mentioned in [patroni-windows-packaging #16](https://github.com/cybertec-postgresql/patroni-windows-packaging/issues/16)