### PR TITLE
Update patroni.service

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -14,7 +14,8 @@ Group=postgres
 # Read in configuration file if it exists, otherwise proceed
 EnvironmentFile=-/etc/patroni_env.conf
 
-# WorkingDirectory=~
+# the default is the user's home directory, and if you want to change it, you must provide an absolute path.
+# WorkingDirectory=/home/sameuser
 
 # Where to send early-startup messages from the server
 # This is normally controlled by the global default set by systemd

--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -14,7 +14,7 @@ Group=postgres
 # Read in configuration file if it exists, otherwise proceed
 EnvironmentFile=-/etc/patroni_env.conf
 
-WorkingDirectory=~
+# WorkingDirectory=~
 
 # Where to send early-startup messages from the server
 # This is normally controlled by the global default set by systemd


### PR DESCRIPTION
Issue  #1688

If "WorkingDirectory" not set, defaults to the respective user's home directory if run as user.

User = postgres

fixed:
systemd[1]: [/etc/systemd/system/patroni.service:14] Not an absolute path, ignoring: ~