### PR TITLE
Don't interrupt restart or promote if lost leader lock in pause

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1182,7 +1182,7 @@ class Ha(object):
                     return 'terminated crash recovery because of startup timeout'
 
             return 'updated leader lock during ' + self._async_executor.scheduled_action
-        elif not self.state_handler.bootstrapping:
+        elif not self.state_handler.bootstrapping and not self.is_paused():
             # Don't have lock, make sure we are not promoting or starting up a master in the background
             if self._async_executor.scheduled_action == 'promote':
                 with self._async_response:

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -501,6 +501,9 @@ class TestHa(PostgresInit):
                     self.assertEqual(self.ha.run_cycle(), 'lost leader lock during restart')
                     mock_terminate.assert_called()
 
+            self.ha.is_paused = true
+            self.assertEqual(self.ha.run_cycle(), 'PAUSE: restart in progress')
+
     def test_manual_failover_from_leader(self):
         self.ha.fetch_node_status = get_node_status()
         self.ha.has_lock = true


### PR DESCRIPTION
In pause it is allowed to run postgres as master without lock.