### PR TITLE
[fix] add database name into connection string for rewinding

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1509,7 +1509,7 @@ class Ha(object):
             data = {k: v for k, v in cluster_params.items() if k in RemoteMember.allowed_keys()}
             data['no_replication_slot'] = 'primary_slot_name' not in cluster_params
             conn_kwargs = member.conn_kwargs() if member else \
-                {k: cluster_params[k] for k in ('host', 'port') if k in cluster_params}
+                {k: cluster_params[k] for k in ('host', 'port', 'database') if k in cluster_params}
             if conn_kwargs:
                 data['conn_kwargs'] = conn_kwargs
 


### PR DESCRIPTION
Hi,

During configuration of standby cluster, we faced issue with error "psycopg2.OperationalError: FATAL:  database "patroni" does not exist". It's reproduced if username differs from database name (ex. user for rewind - patroni, database - postgres). Root cause is missing / empty database parameter in connection string of remote leader. The fix is simple: just to add "database" in connection parameters (parameter is present in DCS, but not used).

Here is stack trace from try block:
```
Stack (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.6/site-packages/patroni/async_executor.py", line 97, in run
    wakeup = func(*args) if args else func()
  File "/usr/lib/python3.6/site-packages/patroni/postgresql/rewind.py", line 344, in execute
    leader_status = self._postgresql.checkpoint(leader.conn_kwargs(self._postgresql.config.superuser))
  File "/usr/lib/python3.6/site-packages/patroni/postgresql/__init__.py", line 531, in checkpoint
    logger.exception('Exception during CHECKPOINT', stack_info=True, exc_info=True)
  File "/usr/lib/python3.6/site-packages/patroni/log.py", line 25, in error_exception
    logger_obj.error(msg, *args, exc_info=exc_info, **kwargs)
```

Standby cluster configuration is typical:
```
bootstrap: 
  dcs:
    standby_cluster:
      host: <IPADDRESS>
      port: 5432
      primary_slot_name: patroni
      create_replica_methods:
      - basebackup
```

But for authentication we use users different from "postgres" (database name):
```
  authentication:
    replication:
      username: replicator
      password: replicator
    superuser:
      username: patroni
      password: patroni
    rewind:
      username: patroni
      password: patroni
```