### PR TITLE
[cosmetic] log lines from stdout/stderr in case of pg_basebackup error

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -248,14 +248,17 @@ class Bootstrap(object):
             if not self._postgresql.data_directory_empty():
                 self._postgresql.remove_data_directory()
             try:
+                results = {}
                 ret = self._postgresql.cancellable.call([self._postgresql.pgcommand('pg_basebackup'),
                                                          '--pgdata=' + self._postgresql.data_dir, '-X', 'stream',
-                                                         '--dbname=' + conn_url] + user_options, env=env)
+                                                         '--dbname=' + conn_url] + user_options, env=env, communicate=results)
                 if ret == 0:
                     break
                 else:
                     logger.error('Error when fetching backup: pg_basebackup exited with code=%s', ret)
-
+                    logger.info(' stdout=%s', results['stdout'].decode('utf-8'))
+                    logger.info(' stderr=%s', results['stderr'].decode('utf-8'))
+                    
             except Exception as e:
                 logger.error('Error when fetching backup with pg_basebackup: %s', e)
 


### PR DESCRIPTION
Hi,

During creating replica via pg_basebackup method, if pg_basebackup fails, Patroni logs only exit code (ex. exit code 1). 
This fix enhances logging in case of pg_basebackup error. 

Before: 
```
2020-10-20 13:30:42,332 ERROR: Error when fetching backup: pg_basebackup exited with code=1
2020-10-20 13:30:42,332 WARNING: Trying again in 5 seconds
```

After:
```
2020-10-20 13:38:17,231 ERROR: Error when fetching backup: pg_basebackup exited with code=1
2020-10-20 13:38:17,232 INFO:  stdout=
2020-10-20 13:38:17,232 INFO:  stderr=pg_basebackup: error: could not connect to server: could not connect to server: No route to host
        Is the server running on host "192.168.x.y" and accepting
        TCP/IP connections on port 5432?
```

In particular example, pg_basebackup can't connect to leader due to firewall misconfiguration. But it's hard to identify without stderr.

Thanks!
