### PR TITLE
Allow to omit the RAFT port (#1759)

### DIFF
--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -237,6 +237,9 @@ Raft
 
     A: Yes, on the third node you can run ``patroni_raft_controller`` (without Patroni and PostgreSQL). In such setup one can temporary loose one node without affecting the primary.
 
+  - Q: Do I need to specify a port?
+
+    A: No, if you omit the port, Patroni will prepend the startup API port with 1 (i.e. add 10000 to it).
 
 .. _postgresql_settings:
 

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -88,7 +88,7 @@ def get_dcs(config):
                     if key.lower() == name and inspect.isclass(item) and issubclass(item, AbstractDCS):
                         # propagate some parameters
                         config[name].update({p: config[p] for p in ('namespace', 'name', 'scope', 'loop_wait',
-                                             'patronictl', 'ttl', 'retry_timeout') if p in config})
+                                             'patronictl', 'ttl', 'retry_timeout', 'restapi') if p in config})
                         return item(config[name])
             except ImportError:
                 logger.debug('Failed to import %s', module_name)

--- a/patroni/dcs/raft.py
+++ b/patroni/dcs/raft.py
@@ -268,6 +268,9 @@ class Raft(AbstractDCS):
         super(Raft, self).__init__(config)
         self._ttl = int(config.get('ttl') or 30)
 
+        # Set a default port if no ports were specified in config
+        self._default_port(config)
+
         self_addr = config.get('self_addr')
         partner_addrs = config.get('partner_addrs', [])
         if self._ctl:
@@ -292,6 +295,19 @@ class Raft(AbstractDCS):
                 logger.info('waiting on raft')
         self._sync_obj.forceLogCompaction()
         self.set_retry_timeout(int(config.get('retry_timeout') or 10))
+
+    def _default_port(self, config):
+        # Prepend '1' to the API port, i.e. use '18008' if the API port is '8008'
+        port = '1' + config['restapi']['listen'].rsplit(':', 1)[1]
+        n = 0
+        for addr in config['partner_addrs']:
+            if ":" not in addr:
+                config['partner_addrs'][n] = addr + ':' + port
+                n += 1
+        if ":" not in config['self_addr']:
+            config['self_addr'] = config['self_addr'] + ':' + port
+        if ":" not in config['bind_addr']:
+            config['bind_addr'] = config['bind_addr'] + ':' + port
 
     def _on_set(self, key, value):
         leader = (self._sync_obj.get(self.leader_path) or {}).get('value')


### PR DESCRIPTION
If no ports are specified for self_addr, bind_addr and/or partner_addrs, then
Patroni will self-assign the startup API port + 10000 as RAFT port.