### PR TITLE
Warn the user when the required watchdog is not healthy

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -782,6 +782,7 @@ class Ha(object):
             return self.manual_failover_process_no_leader()
 
         if not self.watchdog.is_healthy:
+            logger.warning('Watchdog device is not usable')
             return False
 
         # When in sync mode, only last known master and sync standby are allowed to promote automatically.


### PR DESCRIPTION
When the watchdog device is not writable or missing in required mode,
the member cannot be promoted. It only keeps logging that it is not the
healthiest member. Add a warning to show the user where to search for
this misconfiguration.