### PR TITLE
Feature: Plugin for additional health check

### DIFF
--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -87,3 +87,6 @@ Upon changing these options, Patroni will read the relevant section of the confi
 run-time values.
 
 Patroni nodes are dumping the state of the DCS options to disk upon for every change of the configuration into the file ``patroni.dynamic.json`` located in the Postgres data directory. Only the master is allowed to restore these options from the on-disk dump if these are completely absent from the DCS or if they are invalid.
+
+
+


### PR DESCRIPTION
## Feature: Plugin for an additional health check

Patroni keeps a persistent Postgres connection for health checks. If the postmaster doesn't respond or hang for some reason (Issue described in [1371](https://github.com/zalando/patroni/issues/1371)), the query will continue to run normally though the leader is in an unhealthy state.

**Change**:
Plugin for an additional health check on the leader. 

```
....
postgresql:
liveness:
  probe: /..../db_conn.py
  max_failures: 20
  timeout: 3
  interval: 300
callbacks:
  on_role_change: /.../xyz.py
connect_address: abc1:4335
....
```

**probe**: The plugin process should be very quick and should not engage the thread for a long time. It could be a very simple one making a new connection request to the master. The plugin call could be an expensive operation & may add overhead if it runs through each run cycle.
**interval**: Patroni should run the plugin at a specified interval to reduce the overhead.
**timeout**: The time Patroni allowed to wait for the plugin process to complete. It should terminate the process if it exceeds the timeout.
**max_failures**: Maximum failures Patroni can tolerate (Patroni should not take action when the value set to <= 0, it can initiate failover if the value set to >0  and if the # of failures > max_failures).