### PR TITLE
Submit coverage to codacy only if secret is available

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,10 +90,12 @@ jobs:
 
     - name: Run codacy-coverage-reporter
       uses: codacy/codacy-coverage-reporter-action@master
+      env:
+        SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage.xml
-      if: matrix.os == 'ubuntu'
+      if: ${{ matrix.os == 'ubuntu' && env.SECRETS_AVAILABLE == 'true' }}
 
   behave:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
If PR is open from the external GH repo secrets are not set due to security reasons. It makes codacy coverage report to fail.