### PR TITLE
Fix bug in the post_bootstrap method()

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -130,7 +130,7 @@ class Bootstrap(object):
                 # (pghost empty or the default socket directory) connections coming from the local machine.
                 r['host'] = 'localhost'  # set it to localhost to write into pgpass
 
-            env = self._postgresql.config.write_pgpass(r) if 'password' in r else None
+            env = self._postgresql.config.write_pgpass(r)
             env['PGOPTIONS'] = '-c synchronous_commit=local'
 
             try:


### PR DESCRIPTION
The config.write_pgpass(r) should be called unconditionally, no matter whether the password defined in the config or not.

Close https://github.com/zalando/patroni/issues/1727