### PR TITLE
 Fix small issues with ignore-slots feature

### DIFF
--- a/features/steps/cascading_replication.py
+++ b/features/steps/cascading_replication.py
@@ -37,7 +37,8 @@ def check_member(context, name, key, value, time_limit):
         except Exception:
             pass
         time.sleep(1)
-    assert False, "{0} does not have {1}={2} (found {3}) in dcs after {4} seconds".format(name, key, value, dcs_value, time_limit)
+    assert False, "{0} does not have {1}={2} (found {3}) in dcs after {4} seconds".format(name, key, value,
+                                                                                          dcs_value, time_limit)
 
 
 @step('there is a non empty {key:w} key in DCS after {time_limit:d} seconds')

--- a/features/steps/slots.py
+++ b/features/steps/slots.py
@@ -5,26 +5,32 @@ import psycopg2 as pg
 @step('I create a logical replication slot {slot_name} on {pg_name:w} with the {plugin:w} plugin')
 def create_logical_replication_slot(context, slot_name, pg_name, plugin):
     try:
-        output = context.pctl.query(pg_name, "SELECT pg_create_logical_replication_slot('{0}', '{1}'), current_database()".format(slot_name, plugin))
+        output = context.pctl.query(pg_name, ("SELECT pg_create_logical_replication_slot('{0}', '{1}'),"
+                                              " current_database()").format(slot_name, plugin))
         print(output.fetchone())
     except pg.Error as e:
         print(e)
         assert False, "Error creating slot {0} on {1} with plugin {2}".format(slot_name, pg_name, plugin)
 
+
 @then('{pg_name:w} has a logical replication slot named {slot_name} with the {plugin:w} plugin')
 def has_logical_replication_slot(context, pg_name, slot_name, plugin):
     try:
-        row = context.pctl.query(pg_name, "SELECT slot_type, plugin FROM pg_replication_slots WHERE slot_name = '{0}'".format(slot_name)).fetchone()
+        row = context.pctl.query(pg_name, ("SELECT slot_type, plugin FROM pg_replication_slots"
+                                           " WHERE slot_name = '{0}'").format(slot_name)).fetchone()
         assert row, "Couldn't find replication slot named {0}".format(slot_name)
         assert row[0] == "logical", "Found replication slot named {0} but wasn't a logical slot".format(slot_name)
-        assert row[1] == plugin, "Found replication slot named {0} but was using plugin {1} rather than {2}".format(slot_name, row[1], plugin)
-    except pg.Error as e:
+        assert row[1] == plugin, ("Found replication slot named {0} but was using plugin "
+                                  "{1} rather than {2}").format(slot_name, row[1], plugin)
+    except pg.Error:
         assert False, "Error looking for slot {0} on {1} with plugin {2}".format(slot_name, pg_name, plugin)
 
+
 @then('{pg_name:w} does not have a logical replication slot named {slot_name}')
-def has_logical_replication_slot(context, pg_name, slot_name):
+def does_not_have_logical_replication_slot(context, pg_name, slot_name):
     try:
-        row = context.pctl.query(pg_name, "SELECT 1 FROM pg_replication_slots WHERE slot_name = '{0}'".format(slot_name)).fetchone()
+        row = context.pctl.query(pg_name, ("SELECT 1 FROM pg_replication_slots"
+                                           " WHERE slot_name = '{0}'").format(slot_name)).fetchone()
         assert not row, "Found unexpected replication slot named {0}".format(slot_name)
-    except pg.Error as e:
+    except pg.Error:
         assert False, "Error looking for slot {0} on {1}".format(slot_name, pg_name)

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -48,7 +48,7 @@ class SlotsHandler(object):
         return cursor.rowcount == 1
 
     def sync_replication_slots(self, cluster):
-        if self._postgresql.major_version >= 90400:
+        if self._postgresql.major_version >= 90400 and cluster.config:
             try:
                 self.load_replication_slots()
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -306,7 +306,8 @@ class TestPostgresql(BaseTestPostgresql):
     def test_sync_replication_slots(self):
         self.p.start()
         config = ClusterConfig(1, {'slots': {'test_3': {'database': 'a', 'plugin': 'b'},
-                                             'A': 0, 'ls': 0, 'b': {'type': 'logical', 'plugin': '1'}}}, 1)
+                                             'A': 0, 'ls': 0, 'b': {'type': 'logical', 'plugin': '1'}},
+                                   'ignore_slots': [{'name': 'blabla'}]}, 1)
         cluster = Cluster(True, config, self.leader, 0, [self.me, self.other, self.leadermem], None, None, None)
         with mock.patch('patroni.postgresql.Postgresql._query', Mock(side_effect=psycopg2.OperationalError)):
             self.p.slots_handler.sync_replication_slots(cluster)


### PR DESCRIPTION
When there is no config key in DCS Patroni shouldn't try accessing ignore_slots, otherwise an exception is raised.

In addition to that implement missing unit-tests and fix linting issues in behave tests.