### PR TITLE
Handle AttributeError in etcd.py

### DIFF
--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -404,7 +404,7 @@ class EtcdClient(AbstractEtcdClientWithFailover):
         if self.http is not None:
             try:
                 self.http.clear()
-            except (ReferenceError, TypeError):
+            except (ReferenceError, TypeError, AttributeError):
                 pass
 
     def _prepare_get_members(self, etcd_nodes):


### PR DESCRIPTION
When the__del__() method is executed the python interpreter already unloaded some of the modules that are still used down the http.clear() method.
The only we could do in this case - silence some exceptions like ReferenceError, TypeError, AttributeError.

Close https://github.com/zalando/patroni/issues/1785