### PR TITLE
Silence unhandled exceptions in Thread.run() during unit-tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -14,6 +14,7 @@ class TestCallbackExecutor(unittest.TestCase):
 
         ce = CallbackExecutor()
         ce._kill_children = Mock(side_effect=Exception)
+        ce._invoke_excepthook = Mock()
         self.assertIsNone(ce.call([]))
         ce.join()
 
@@ -30,5 +31,6 @@ class TestCallbackExecutor(unittest.TestCase):
         mock_popen.side_effect = Exception
         ce = CallbackExecutor()
         ce._condition.wait = Mock(side_effect=[None, Exception])
+        ce._invoke_excepthook = Mock()
         self.assertIsNone(ce.call([]))
         ce.join()

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -110,6 +110,7 @@ class TestDnsCachingResolver(unittest.TestCase):
     @patch('socket.getaddrinfo', Mock(side_effect=socket.gaierror))
     def test_run(self):
         r = DnsCachingResolver()
+        r._invoke_excepthook = Mock()
         self.assertIsNone(r.resolve_async('', 0))
         r.join()
 


### PR DESCRIPTION
Python 3.8 changed the way how exceptions raised from the Thread.run() method are handled.
It resulted in unit-tests showing a couple of warnings. They are not important and we just silence them.