### PR TITLE
Docs: document the need for special configuration for symlinked pg_wal

### DIFF
--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -143,6 +143,10 @@ possible to specify a ``basebackup`` configuration section. Same rules as with t
 namely, only long (with --) options should be specified there. Not all parameters make sense, if you override a connection
 string or provide an option to created tar-ed or compressed base backups, patroni won't be able to make a replica out
 of it. There is no validation performed on the names or values of the parameters passed to the ``basebackup`` section.
+Also note that in case symlinks are used for the WAL folder it is up to the user to specify the correct ``--waldir``
+path as an option, so that after replica buildup or re-initialization the symlink would persist. This option is supported
+only since v10 though.
+
 You can specify basebackup parameters as either a map (key-value pairs) or a list of elements, where each element
 could be either a key-value pair or a single key (for options that does not receive any values, for instance, ``--verbose``).
 Consider those 2 examples:
@@ -162,6 +166,7 @@ and
         basebackup:
             - verbose
             - max-rate: '100M'
+            - waldir: /pg-wal-mount/external-waldir
 
 If all replica creation methods fail, Patroni will try again all methods in order during the next event loop cycle.
 

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -112,6 +112,7 @@ postgresql:
   basebackup:
       - verbose
       - max-rate: 100M
+#      - waldir: /pg-wal-mount/external-waldir # only needed in case pg_wal is symlinked outside of data_dir
   # Additional fencing script executed after acquiring the leader lock but before promoting the replica
   #pre_promote: /path/to/pre_promote.sh
 


### PR DESCRIPTION
If an existing instance was configured with WAL residing outside of
PGDATA then currently a 'reinit' would lose such symlinks. So add some
bits of information on that to draw attention to this cornercase issue
and also add the --waldir option to the sample `postgresql.basebackup`
configuration sections to increase visibility.

Discussion: https://github.com/zalando/patroni/issues/1817