### PR TITLE
Feature: Plugin for an additional health check

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -106,6 +106,13 @@ class Postgresql(object):
         # Last known running process
         self._postmaster_proc = None
 
+        self._liveness_executor = CallbackExecutor()
+        self.__lv_called = False
+        self.__lv_failures = 0
+        self._lv_lock = Lock()
+        self.stop_retry = Retry(max_tries=10, deadline=config['retry_timeout']*10,
+                                max_delay=1, retry_exceptions=(psycopg2.Error, TimeoutExpired))
+
         if self.is_running():
             self.set_state('running')
             self.set_role('master' if self.is_leader() else 'replica')
@@ -136,6 +143,17 @@ class Postgresql(object):
     @property
     def callback(self):
         return self.config.get('callbacks') or {}
+
+    @property
+    def liveness(self):
+        return self.config.get('liveness') or {}
+
+    @property
+    def liveness_cmd(self):
+        return self.liveness and shlex.split(self.liveness['probe']) + \
+               [self.config.local_connect_kwargs['host'],
+                self.config.local_connect_kwargs['port'],
+                self.config.local_connect_kwargs['database']] or []
 
     @property
     def wal_dir(self):
@@ -372,6 +390,25 @@ class Postgresql(object):
     def cb_called(self):
         return self.__cb_called
 
+    @property
+    def lv_called(self):
+        return self.__lv_called if self.liveness else True
+
+    @property
+    def lv_failures(self):
+        return self.__lv_failures
+
+    def lv_failures_incr(self):
+        if self.liveness['max_failures'] > 0:
+            self.__lv_failures += 1
+        self.__lv_called = False
+        return None
+
+    def reset_lv_failures(self):
+        self.__lv_failures = 0
+        self.__lv_called = False
+        return None
+
     def call_nowait(self, cb_name):
         """ pick a callback command and call it without waiting for it to finish """
         if self.bootstrapping:
@@ -411,6 +448,39 @@ class Postgresql(object):
 
     def is_starting(self):
         return self.state == 'starting'
+
+    def liveness_terminate(self):
+        """Terminate Liveness plugin async probe."""
+        if self._liveness_executor._process is not None and self._liveness_executor._process.is_running():
+            logger.info('Terminating liveness process')
+            self._liveness_executor._kill_process()
+            self._liveness_executor._kill_children()
+
+    def liveness_check(self):
+        """Liveness plugin probe async call."""
+        try:
+            if self.lv_called or (self.role != 'master' and self.state != 'running'):
+                return None
+            with self._lv_lock:
+                if self.lv_called:
+                    return None
+                self.__lv_called = True
+            with self._liveness_executor._lock:
+                if not self._liveness_executor._start_process(self.liveness_cmd, close_fds=True):
+                    logger.error('Unable to start process for liveness probe')
+                    return self.reset_lv_failures()
+            if self._liveness_executor._process.wait(timeout=self.liveness['timeout']) != 0:
+                logger.error('Liveness Probe failed')
+                return self.lv_failures_incr()
+            return self.reset_lv_failures()
+        except TimeoutExpired:
+            logger.error("Timeout during liveness probe")
+            self.liveness_terminate()
+            return self.lv_failures_incr()
+        except Exception:
+            logger.error("Exception during liveness probe")
+            self.liveness_terminate()
+            return self.reset_lv_failures()
 
     def wait_for_port_open(self, postmaster, timeout):
         """Waits until PostgreSQL opens ports."""


### PR DESCRIPTION
## Feature: Plugin for an additional health check

Patroni keeps a persistent Postgres connection for health checks. If the postmaster doesn't respond or hang for some reason (Issue described in [1371](https://github.com/zalando/patroni/issues/1371)), the query will continue to run normally though the leader is in an unhealthy state.

**Change**:
Plugin for an additional health check on the leader. 

```
....
postgresql:
liveness:
  probe: /..../db_conn.py
  max_failures: 20
  timeout: 3
  interval: 300
callbacks:
  on_role_change: /.../xyz.py
connect_address: abc1:4335
....
```

**probe**: The plugin process should be very quick and should not engage the thread for a long time. It could be a very simple one making a new connection request to the master. The plugin call could be an expensive operation & may add overhead if it runs through each run cycle.
**interval**: Patroni should run the plugin at a specified interval to reduce the overhead.
**timeout**: The time Patroni allowed to wait for the plugin process to complete. It should terminate the process if it exceeds the timeout.
**max_failures**: Maximum failures Patroni can tolerate (Patroni should not take action when the value set to <= 0, it can initiate failover if the value set to >0  and if the # of failures > max_failures).

Will add feature/test-case if the proposed changes look good. Thanks.