### PR TITLE
Quick attempt at Prometheus

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -251,9 +251,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_cluster_unlocked gauge")
         metrics.append("patroni_cluster_unlocked {0}".format(int(postgres['cluster_unlocked'])))
 
-        metrics.append("# HELP patroni_timeline Current Postgres timeline of this node (if running), 0 otherwise.")
-        metrics.append("# TYPE patroni_timeline counter")
-        metrics.append("patroni_timeline {0}".format(postgres.get('timeline', 0)))
+        metrics.append("# HELP patroni_postgres_timeline Current Postgres timeline of this node (if running), 0 otherwise.")
+        metrics.append("# TYPE patroni_postgres_timeline counter")
+        metrics.append("patroni_postgres_timeline {0}".format(postgres.get('timeline', 0)))
 
         self._write_response(200, '\n'.join(metrics)+'\n', content_type='text/plain')
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -182,7 +182,14 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
     def do_GET_metrics(self):
         postgres = self.get_postgresql_status(True)
+        patroni = self.server.patroni
+
         metrics = []
+
+        # This obviously doesn't scale; maybe we do 2.0.2 => 002 000 002
+        metrics.append("# HELP patroni_version Patroni semver without periods.")
+        metrics.append("# TYPE patroni_version gauge")
+        metrics.append("patroni_version {0}".format(patroni.version).replace('.', ''))
 
         metrics.append("# HELP patroni_postgres_running Value is 1 if Postgres is running, 0 otherwise.")
         metrics.append("# TYPE patroni_postgres_running gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -186,10 +186,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics = []
 
-        # This obviously doesn't scale; maybe we do 2.0.2 => 002 000 002
         metrics.append("# HELP patroni_version Patroni semver without periods.")
         metrics.append("# TYPE patroni_version gauge")
-        metrics.append("patroni_version {0}".format(patroni.version).replace('.', ''))
+        padded_semver = ''.join([x.zfill(2) for x in patroni.version.split('.')]) # 2.0.2 => 020002
+        metrics.append("patroni_version {0}".format(padded_semver).replace('.', ''))
 
         metrics.append("# HELP patroni_postgres_running Value is 1 if Postgres is running, 0 otherwise.")
         metrics.append("# TYPE patroni_postgres_running gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -45,7 +45,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         self.wfile.write(body.encode('utf-8'))
 
     def _write_json_response(self, status_code, response):
-        self._write_response(status_code, json.dumps(response), content_type='application/json')
+        self._write_response(status_code, json.dumps(response, default=str), content_type='application/json')
 
     def check_auth(func):
         """Decorator function to check authorization header or client certificates
@@ -550,7 +550,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             if postgresql.state not in ('running', 'restarting', 'starting'):
                 raise RetryFailedError('')
             stmt = ("SELECT " + postgresql.POSTMASTER_START_TIME + ", " + postgresql.TL_LSN + ","
-                    " pg_catalog.to_char(pg_catalog.pg_last_xact_replay_timestamp(), 'YYYY-MM-DD HH24:MI:SS.MS TZ'),"
+                    " pg_catalog.pg_last_xact_replay_timestamp(),"
                     " pg_catalog.array_to_json(pg_catalog.array_agg(pg_catalog.row_to_json(ri))) "
                     "FROM (SELECT (SELECT rolname FROM pg_authid WHERE oid = usesysid) AS usename,"
                     " application_name, client_addr, w.state, sync_state, sync_priority"

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -188,7 +188,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_version Patroni semver without periods.")
         metrics.append("# TYPE patroni_version gauge")
-        padded_semver = ''.join([x.zfill(2) for x in patroni.version.split('.')]) # 2.0.2 => 020002
+        padded_semver = ''.join([x.zfill(2) for x in patroni.version.split('.')])  # 2.0.2 => 020002
         metrics.append("patroni_version {0}".format(padded_semver).replace('.', ''))
 
         metrics.append("# HELP patroni_postgres_running Value is 1 if Postgres is running, 0 otherwise.")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -230,7 +230,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.")
         metrics.append("# TYPE patroni_xlog_paused gauge")
         metrics.append("patroni_xlog_paused {0}".format(
-                        int(postgres.get('xlog', {}).get('paused', 0))))
+                        int(postgres.get('xlog', {}).get('paused', 0) == True)))
 
         metrics.append("# HELP patroni_server_version Version of Patroni.")
         metrics.append("# TYPE patroni_server_version gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -561,28 +561,16 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
             row = self.query(stmt.format(postgresql.wal_name, postgresql.lsn_name), retry=retry)[0]
 
-            try:
-                postmaster_start_time = datetime.datetime.strptime(row[0], '%Y-%m-%d %H:%M:%S.%f %Z')
-                postmaster_start_time = postmaster_start_time.replace(tzinfo=tzutc)
-            except (TypeError, ValueError):
-                postmaster_start_time = row[0]
-
-            try:
-                replayed_timestamp = datetime.datetime.strptime(row[6], '%Y-%m-%d %H:%M:%S.%f %Z')
-                replayed_timestamp = replayed_timestamp.replace(tzinfo=tzutc)
-            except (TypeError, ValueError):
-                replayed_timestamp = row[6]
-
             result = {
                 'state': postgresql.state,
-                'postmaster_start_time': postmaster_start_time,
+                'postmaster_start_time': row[0],
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': postgresql.server_version,
                 'cluster_unlocked': bool(not cluster or cluster.is_unlocked()),
                 'xlog': ({
                     'received_location': row[4] or row[3],
                     'replayed_location': row[3],
-                    'replayed_timestamp': replayed_timestamp,
+                    'replayed_timestamp': row[6],
                     'paused': row[5]} if row[1] == 0 else {
                     'location': row[2]
                 })

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -231,9 +231,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_xlog_replayed_timestamp Current timestamp of the replayed"
                        " Postgres transaction log, 0 if null.")
         metrics.append("# TYPE patroni_xlog_replayed_timestamp gauge")
-        xlog_replayed_timestamp = postgres.get('xlog', {}).get('replayed_timestamp', 0)
+        xlog_replayed_timestamp = postgres.get('xlog', {}).get('replayed_timestamp')
         metrics.append("patroni_xlog_replayed_timestamp {0}".format(
-                        xlog_replayed_timestamp if xlog_replayed_timestamp is not None else 0))
+                        xlog_replayed_timestamp.strftime('%s.%f') if xlog_replayed_timestamp is not None else 0))
 
         metrics.append("# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.")
         metrics.append("# TYPE patroni_xlog_paused gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -230,7 +230,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_xlog_replayed_timestamp Current timestamp of the replayed"
                        " Postgres transaction log, 0 if null.")
-        metrics.append("# TYPE patroni_xlog_received_timestamp counter")
+        metrics.append("# TYPE patroni_xlog_replayed_timestamp counter")
         xlog_replayed_timestamp = postgres.get('xlog', {}).get('replayed_timestamp', 0)
         metrics.append("patroni_xlog_replayed_timestamp {0}".format(
                         xlog_replayed_timestamp if xlog_replayed_timestamp is not None else 0))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -188,7 +188,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_postgres_running gauge")
         metrics.append("patroni_postgres_running {0}".format(int(postgres['state'] == 'running')))
 
-        metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
+        metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Postgres started.")
         metrics.append("# TYPE patroni_postmaster_start_time counter")
         try:
             postmaster_epoch_start_time = int(datetime.datetime.strptime(

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -561,16 +561,28 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
             row = self.query(stmt.format(postgresql.wal_name, postgresql.lsn_name), retry=retry)[0]
 
+            try:
+                postmaster_start_time = datetime.datetime.strptime(row[0], '%Y-%m-%d %H:%M:%S.%f %Z')
+                postmaster_start_time = postmaster_start_time.replace(tzinfo=tzutc)
+            except (TypeError, ValueError):
+                postmaster_start_time = row[0]
+
+            try:
+                replayed_timestamp = datetime.datetime.strptime(row[6], '%Y-%m-%d %H:%M:%S.%f %Z')
+                replayed_timestamp = replayed_timestamp.replace(tzinfo=tzutc)
+            except (TypeError, ValueError):
+                replayed_timestamp = row[6]
+
             result = {
                 'state': postgresql.state,
-                'postmaster_start_time': row[0],
+                'postmaster_start_time': postmaster_start_time,
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': postgresql.server_version,
                 'cluster_unlocked': bool(not cluster or cluster.is_unlocked()),
                 'xlog': ({
                     'received_location': row[4] or row[3],
                     'replayed_location': row[3],
-                    'replayed_timestamp': row[6],
+                    'replayed_timestamp': replayed_timestamp,
                     'paused': row[5]} if row[1] == 0 else {
                     'location': row[2]
                 })

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -545,8 +545,6 @@ class RestApiHandler(BaseHTTPRequestHandler):
     def get_postgresql_start_time_epoch(self, retry=False):
         postgresql = self.server.patroni.postgresql
         try:
-            cluster = self.server.patroni.dcs.cluster
-
             if postgresql.state not in ('running', 'restarting', 'starting'):
                 raise RetryFailedError('')
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -188,17 +188,15 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_running gauge")
         metrics.append("patroni_running {0}".format(int(postgres['state'] == 'running')))
 
+        metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
+        metrics.append("# TYPE patroni_postmaster_start_time counter")
         try:
-            postmaster_epoch_start_time = int(
-                datetime.datetime.strptime(
-                    postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z"
-                ).strftime('%s')
-            )
-            metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
-            metrics.append("# TYPE patroni_postmaster_start_time counter")
+            postmaster_epoch_start_time = int(datetime.datetime.strptime(
+                postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z"
+            ).strftime('%s'))
             metrics.append("patroni_postmaster_start_time {0}".format(postmaster_epoch_start_time))
         except ValueError:
-            pass
+            metrics.append("patroni_postmaster_start_time 0")
 
         metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
         metrics.append("# TYPE patroni_master gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -201,7 +201,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
         metrics.append("# TYPE patroni_master gauge")
         metrics.append("patroni_master {0}".format(int(postgres['role'] == 'master')))
-        metrics.append("# HELP patroni_xlog_location Current location of the PostgreSQL"
+
+        metrics.append("# HELP patroni_xlog_location Current location of the Postgres"
                        " transaction log, 0 if this node is not the leader.")
         metrics.append("# TYPE patroni_xlog_location counter")
         metrics.append("patroni_xlog_location {0}".format(postgres.get('xlog', {}).get('location', 0)))
@@ -213,8 +214,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
         metrics.append("# TYPE patroni_replica gauge")
         metrics.append("patroni_replica {0}".format(int(postgres['role'] == 'replica')))
+
         metrics.append("# HELP patroni_xlog_received_location Current location of the received"
-                       " PostgreSQL transaction log, 0 if this node is not a replica.")
+                       " Postgres transaction log, 0 if this node is not a replica.")
         metrics.append("# TYPE patroni_xlog_received_location counter")
         metrics.append("patroni_xlog_received_location {0}".format(
                         postgres.get('xlog', {}).get('received_location', 0)))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -207,14 +207,14 @@ class RestApiHandler(BaseHTTPRequestHandler):
             metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
             metrics.append("# TYPE patroni_master gauge")
             metrics.append("patroni_master 1")
-            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")
+            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")  # noqa: E501
             metrics.append("# TYPE patroni_xlog_location counter")
             metrics.append("patroni_xlog_location {0}".format(postgres['xlog']['location']))
         else:
             metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
             metrics.append("# TYPE patroni_master gauge")
             metrics.append("patroni_master 0")
-            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")
+            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")  # noqa: E501
             metrics.append("# TYPE patroni_xlog_location counter")
             metrics.append("patroni_xlog_location 0")
 
@@ -222,14 +222,14 @@ class RestApiHandler(BaseHTTPRequestHandler):
             metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
             metrics.append("# TYPE patroni_replica gauge")
             metrics.append("patroni_replica 1")
-            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")
+            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")  # noqa: E501
             metrics.append("# TYPE patroni_xlog_received_location counter")
             metrics.append("patroni_xlog_received_location {0}".format(postgres['xlog']['received_location']))
         else:
             metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
             metrics.append("# TYPE patroni_replica gauge")
             metrics.append("patroni_replica 0")
-            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")
+            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")  # noqa: E501
             metrics.append("# TYPE patroni_xlog_received_location counter")
             metrics.append("patroni_xlog_received_location 0")
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -227,6 +227,11 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("patroni_xlog_replayed_location {0}".format(
                         postgres.get('xlog', {}).get('replayed_location', 0)))
 
+        metrics.append("# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.")
+        metrics.append("# TYPE patroni_xlog_paused gauge")
+        metrics.append("patroni_xlog_paused {0}".format(
+                        int(postgres.get('xlog', {}).get('paused', 0))))
+
         metrics.append("# HELP patroni_server_version Version of Patroni.")
         metrics.append("# TYPE patroni_server_version gauge")
         metrics.append("patroni_server_version {0}".format(postgres['server_version']))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -184,9 +184,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         postgres = self.get_postgresql_status(True)
         metrics = []
 
-        metrics.append("# HELP patroni_running Value is 1 if Patroni/Postgres is up, 0 otherwise.")
-        metrics.append("# TYPE patroni_running gauge")
-        metrics.append("patroni_running {0}".format(int(postgres['state'] == 'running')))
+        metrics.append("# HELP patroni_postgres_running Value is 1 if Postgres is running, 0 otherwise.")
+        metrics.append("# TYPE patroni_postgres_running gauge")
+        metrics.append("patroni_postgres_running {0}".format(int(postgres['state'] == 'running')))
 
         metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
         metrics.append("# TYPE patroni_postmaster_start_time counter")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -197,7 +197,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Postgres started.")
         metrics.append("# TYPE patroni_postmaster_start_time gauge")
-        metrics.append("patroni_postmaster_start_time {0}".format(int(self.get_postgresql_start_time_epoch(False))))
+        metrics.append("patroni_postmaster_start_time {0}".format(postgres['postmaster_start_time'].strftime('%s.%f')))
 
         metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
         metrics.append("# TYPE patroni_master gauge")
@@ -230,7 +230,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_xlog_replayed_timestamp Current timestamp of the replayed"
                        " Postgres transaction log, 0 if null.")
-        metrics.append("# TYPE patroni_xlog_replayed_timestamp counter")
+        metrics.append("# TYPE patroni_xlog_replayed_timestamp gauge")
         xlog_replayed_timestamp = postgres.get('xlog', {}).get('replayed_timestamp', 0)
         metrics.append("patroni_xlog_replayed_timestamp {0}".format(
                         xlog_replayed_timestamp if xlog_replayed_timestamp is not None else 0))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -246,7 +246,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
         metrics.append("# TYPE patroni_cluster_unlocked gauge")
-        metrics.append("patroni_cluster_unlocked {0}".format(int(postgres['cluster_unlocked'] == 'true')))
+        metrics.append("patroni_cluster_unlocked {0}".format(int(postgres['cluster_unlocked'])))
 
         metrics.append("# HELP patroni_timeline Current Postgres timeline number of this node.")
         metrics.append("# TYPE patroni_timeline counter")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -237,8 +237,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_xlog_replayed_timestamp Current timestamp of the replayed"
                        " Postgres transaction log, 0 if null.")
         metrics.append("# TYPE patroni_xlog_received_timestamp counter")
+        xlog_replayed_timestamp = postgres.get('xlog', {}).get('replayed_timestamp', 0)
         metrics.append("patroni_xlog_replayed_timestamp {0}".format(
-                        int(postgres.get('xlog', {}).get('replayed_timestamp', 0) is not None)))
+                        xlog_replayed_timestamp if xlog_replayed_timestamp is not None else 0))
 
         metrics.append("# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.")
         metrics.append("# TYPE patroni_xlog_paused gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -210,7 +210,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
         metrics.append("# TYPE patroni_replica gauge")
-        metrics.append("patroni_replica 1")
+        metrics.append("patroni_replica {0}".format(int(postgres['role'] == 'replica')))
         metrics.append("# HELP patroni_xlog_received_location Current location of the received"
                        " PostgreSQL transaction log, 0 if this node is not a replica.")
         metrics.append("# TYPE patroni_xlog_received_location counter")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -224,7 +224,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_xlog_replayed_location Current location of the replayed"
                        " Postgres transaction log, 0 if this node is not a replica.")
-        metrics.append("# TYPE patroni_xlog_received_location counter")
+        metrics.append("# TYPE patroni_xlog_replayed_location counter")
         metrics.append("patroni_xlog_replayed_location {0}".format(
                         postgres.get('xlog', {}).get('replayed_location', 0)))
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -230,7 +230,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.")
         metrics.append("# TYPE patroni_xlog_paused gauge")
         metrics.append("patroni_xlog_paused {0}".format(
-                        int(postgres.get('xlog', {}).get('paused', 0) == True)))
+                        int(postgres.get('xlog', {}).get('paused', False) is True)))
 
         metrics.append("# HELP patroni_server_version Version of Patroni.")
         metrics.append("# TYPE patroni_server_version gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -191,10 +191,14 @@ class RestApiHandler(BaseHTTPRequestHandler):
         else:
             metrics.append("patroni_running 0")
 
-        postmaster_epoch_start_time = int(datetime.datetime.strptime(postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z").timestamp())
-        metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
-        metrics.append("# TYPE patroni_postmaster_start_time counter")
-        metrics.append("patroni_postmaster_start_time {0}".format(postmaster_epoch_start_time))
+        try:
+            postmaster_epoch_start_time = int(datetime.datetime.strptime(
+                postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z").timestamp())
+            metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
+            metrics.append("# TYPE patroni_postmaster_start_time counter")
+            metrics.append("patroni_postmaster_start_time {0}".format(postmaster_epoch_start_time))
+        except ValueError:
+            pass
 
         if postgres['role'] == 'master':
             metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -234,6 +234,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("patroni_xlog_replayed_location {0}".format(
                         postgres.get('xlog', {}).get('replayed_location', 0)))
 
+        metrics.append("# HELP patroni_xlog_replayed_timestamp Current timestamp of the replayed"
+                       " Postgres transaction log, 0 if null.")
+        metrics.append("# TYPE patroni_xlog_received_timestamp counter")
+        metrics.append("patroni_xlog_replayed_timestamp {0}".format(
+                        int(postgres.get('xlog', {}).get('replayed_timestamp', 0) is not None)))
+
         metrics.append("# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.")
         metrics.append("# TYPE patroni_xlog_paused gauge")
         metrics.append("patroni_xlog_paused {0}".format(

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -206,7 +206,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_xlog_location counter")
         metrics.append("patroni_xlog_location {0}".format(postgres.get('xlog', {}).get('location', 0)))
 
-        metrics.append("# HELP patroni_standby_leader Value is 1 if this node is the leader, 0 otherwise.")
+        metrics.append("# HELP patroni_standby_leader Value is 1 if this node is the standby_leader, 0 otherwise.")
         metrics.append("# TYPE patroni_standby_leader gauge")
         metrics.append("patroni_standby_leader {0}".format(int(postgres['role'] == 'standby_leader')))
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -221,6 +221,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("patroni_xlog_received_location {0}".format(
                         postgres.get('xlog', {}).get('received_location', 0)))
 
+        metrics.append("# HELP patroni_xlog_replayed_location Current location of the replayed"
+                       " Postgres transaction log, 0 if this node is not a replica.")
+        metrics.append("# TYPE patroni_xlog_received_location counter")
+        metrics.append("patroni_xlog_replayed_location {0}".format(
+                        postgres.get('xlog', {}).get('replayed_location', 0)))
+
         metrics.append("# HELP patroni_server_version Version of Patroni.")
         metrics.append("# TYPE patroni_server_version gauge")
         metrics.append("patroni_server_version {0}".format(postgres['server_version']))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -251,7 +251,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_cluster_unlocked gauge")
         metrics.append("patroni_cluster_unlocked {0}".format(int(postgres['cluster_unlocked'])))
 
-        metrics.append("# HELP patroni_postgres_timeline Current Postgres timeline of this node (if running), 0 otherwise.")
+        metrics.append("# HELP patroni_postgres_timeline Postgres timeline of this node (if running), 0 otherwise.")
         metrics.append("# TYPE patroni_postgres_timeline counter")
         metrics.append("patroni_postgres_timeline {0}".format(postgres.get('timeline', 0)))
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -208,6 +208,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_xlog_location counter")
         metrics.append("patroni_xlog_location {0}".format(postgres.get('xlog', {}).get('location', 0)))
 
+        metrics.append("# HELP patroni_standby_leader Value is 1 if this node is the leader, 0 otherwise.")
+        metrics.append("# TYPE patroni_standby_leader gauge")
+        metrics.append("patroni_standby_leader {0}".format(int(postgres['role'] == 'standby_leader')))
+
         metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
         metrics.append("# TYPE patroni_replica gauge")
         metrics.append("patroni_replica {0}".format(int(postgres['role'] == 'replica')))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -239,9 +239,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("patroni_xlog_paused {0}".format(
                         int(postgres.get('xlog', {}).get('paused', False) is True)))
 
-        metrics.append("# HELP patroni_server_version Version of Patroni.")
-        metrics.append("# TYPE patroni_server_version gauge")
-        metrics.append("patroni_server_version {0}".format(postgres['server_version']))
+        metrics.append("# HELP patroni_postgres_server_version Version of Postgres.")
+        metrics.append("# TYPE patroni_postgres_server_version gauge")
+        metrics.append("patroni_postgres_server_version {0}".format(postgres['server_version']))
 
         metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
         metrics.append("# TYPE patroni_cluster_unlocked gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -186,10 +186,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_running Value is 1 if Patroni/Postgres is up, 0 otherwise.")
         metrics.append("# TYPE patroni_running gauge")
-        if postgres['state'] == 'running':
-            metrics.append("patroni_running 1")
-        else:
-            metrics.append("patroni_running 0")
+        metrics.append("patroni_running {0}".format(int(postgres['state'] == 'running')))
 
         try:
             postmaster_epoch_start_time = int(
@@ -203,35 +200,22 @@ class RestApiHandler(BaseHTTPRequestHandler):
         except ValueError:
             pass
 
-        if postgres['role'] == 'master':
-            metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
-            metrics.append("# TYPE patroni_master gauge")
-            metrics.append("patroni_master 1")
-            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")  # noqa: E501
-            metrics.append("# TYPE patroni_xlog_location counter")
-            metrics.append("patroni_xlog_location {0}".format(postgres['xlog']['location']))
-        else:
-            metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
-            metrics.append("# TYPE patroni_master gauge")
-            metrics.append("patroni_master 0")
-            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")  # noqa: E501
-            metrics.append("# TYPE patroni_xlog_location counter")
-            metrics.append("patroni_xlog_location 0")
+        metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
+        metrics.append("# TYPE patroni_master gauge")
+        metrics.append("patroni_master {0}".format(int(postgres['role'] == 'master')))
+        metrics.append("# HELP patroni_xlog_location Current location of the PostgreSQL"
+                       " transaction log, 0 if this node is not the leader.")
+        metrics.append("# TYPE patroni_xlog_location counter")
+        metrics.append("patroni_xlog_location {0}".format(postgres.get('xlog', {}).get('location', 0)))
 
-        if postgres['role'] == 'replica':
-            metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
-            metrics.append("# TYPE patroni_replica gauge")
-            metrics.append("patroni_replica 1")
-            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")  # noqa: E501
-            metrics.append("# TYPE patroni_xlog_received_location counter")
-            metrics.append("patroni_xlog_received_location {0}".format(postgres['xlog']['received_location']))
-        else:
-            metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
-            metrics.append("# TYPE patroni_replica gauge")
-            metrics.append("patroni_replica 0")
-            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")  # noqa: E501
-            metrics.append("# TYPE patroni_xlog_received_location counter")
-            metrics.append("patroni_xlog_received_location 0")
+        metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
+        metrics.append("# TYPE patroni_replica gauge")
+        metrics.append("patroni_replica 1")
+        metrics.append("# HELP patroni_xlog_received_location Current location of the received"
+                       " PostgreSQL transaction log, 0 if this node is not a replica.")
+        metrics.append("# TYPE patroni_xlog_received_location counter")
+        metrics.append("patroni_xlog_received_location {0}".format(
+                        postgres.get('xlog', {}).get('received_location', 0)))
 
         metrics.append("# HELP patroni_server_version Version of Patroni.")
         metrics.append("# TYPE patroni_server_version gauge")
@@ -239,10 +223,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
         metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
         metrics.append("# TYPE patroni_cluster_unlocked gauge")
-        if postgres['cluster_unlocked']:
-            metrics.append("patroni_cluster_unlocked 1")
-        else:
-            metrics.append("patroni_cluster_unlocked 0")
+        metrics.append("patroni_cluster_unlocked {0}".format(int(postgres['cluster_unlocked'] == 'true')))
 
         metrics.append("# HELP patroni_timeline Current Postgres timeline number of this node.")
         metrics.append("# TYPE patroni_timeline counter")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -542,24 +542,6 @@ class RestApiHandler(BaseHTTPRequestHandler):
         retry = Retry(delay=1, retry_exceptions=PostgresConnectionException)
         return retry(self.server.query, sql, *params)
 
-    def get_postgresql_start_time_epoch(self, retry=False):
-        postgresql = self.server.patroni.postgresql
-        try:
-            if postgresql.state not in ('running', 'restarting', 'starting'):
-                raise RetryFailedError('')
-
-            stmt = ("SELECT extract(epoch from pg_catalog.pg_postmaster_start_time())")
-
-            row = self.query(stmt, retry=retry)[0]
-
-            if row[0]:
-                return row[0]
-            else:
-                return 0
-
-        except (psycopg2.Error, RetryFailedError, PostgresConnectionException):
-            return 0
-
     def get_postgresql_status(self, retry=False):
         postgresql = self.server.patroni.postgresql
         try:

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -196,7 +196,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("patroni_postgres_running {0}".format(int(postgres['state'] == 'running')))
 
         metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Postgres started.")
-        metrics.append("# TYPE patroni_postmaster_start_time counter")
+        metrics.append("# TYPE patroni_postmaster_start_time gauge")
         metrics.append("patroni_postmaster_start_time {0}".format(int(self.get_postgresql_start_time_epoch(False))))
 
         metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -192,8 +192,11 @@ class RestApiHandler(BaseHTTPRequestHandler):
             metrics.append("patroni_running 0")
 
         try:
-            postmaster_epoch_start_time = int(datetime.datetime.strptime(
-                postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z").timestamp())
+            postmaster_epoch_start_time = int(
+                datetime.datetime.strptime(
+                    postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z"
+                ).strftime('%s')
+            )
             metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
             metrics.append("# TYPE patroni_postmaster_start_time counter")
             metrics.append("patroni_postmaster_start_time {0}".format(postmaster_epoch_start_time))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -184,61 +184,61 @@ class RestApiHandler(BaseHTTPRequestHandler):
         postgres = self.get_postgresql_status(True)
         metrics = []
 
-        metrics.append("HELP patroni_running Value is 1 if Patroni/Postgres is up, 0 otherwise.")
-        metrics.append("TYPE patroni_running gauge")
+        metrics.append("# HELP patroni_running Value is 1 if Patroni/Postgres is up, 0 otherwise.")
+        metrics.append("# TYPE patroni_running gauge")
         if postgres['state'] == 'running':
             metrics.append("patroni_running 1")
         else:
             metrics.append("patroni_running 0")
 
         postmaster_epoch_start_time = int(datetime.datetime.strptime(postgres['postmaster_start_time'], "%Y-%m-%d %H:%M:%S.%f %Z").timestamp())
-        metrics.append("HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
-        metrics.append("TYPE patroni_postmaster_start_time counter")
+        metrics.append("# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.")
+        metrics.append("# TYPE patroni_postmaster_start_time counter")
         metrics.append("patroni_postmaster_start_time {0}".format(postmaster_epoch_start_time))
 
         if postgres['role'] == 'master':
-            metrics.append("HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
-            metrics.append("TYPE patroni_master gauge")
+            metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
+            metrics.append("# TYPE patroni_master gauge")
             metrics.append("patroni_master 1")
-            metrics.append("HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")
-            metrics.append("TYPE patroni_xlog_location counter")
+            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")
+            metrics.append("# TYPE patroni_xlog_location counter")
             metrics.append("patroni_xlog_location {0}".format(postgres['xlog']['location']))
         else:
-            metrics.append("HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
-            metrics.append("TYPE patroni_master gauge")
+            metrics.append("# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.")
+            metrics.append("# TYPE patroni_master gauge")
             metrics.append("patroni_master 0")
-            metrics.append("HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")
-            metrics.append("TYPE patroni_xlog_location counter")
+            metrics.append("# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.")
+            metrics.append("# TYPE patroni_xlog_location counter")
             metrics.append("patroni_xlog_location 0")
 
         if postgres['role'] == 'replica':
-            metrics.append("HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
-            metrics.append("TYPE patroni_replica gauge")
+            metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
+            metrics.append("# TYPE patroni_replica gauge")
             metrics.append("patroni_replica 1")
-            metrics.append("HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")
-            metrics.append("TYPE patroni_xlog_received_location counter")
+            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")
+            metrics.append("# TYPE patroni_xlog_received_location counter")
             metrics.append("patroni_xlog_received_location {0}".format(postgres['xlog']['received_location']))
         else:
-            metrics.append("HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
-            metrics.append("TYPE patroni_replica gauge")
+            metrics.append("# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.")
+            metrics.append("# TYPE patroni_replica gauge")
             metrics.append("patroni_replica 0")
-            metrics.append("HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")
-            metrics.append("TYPE patroni_xlog_received_location counter")
+            metrics.append("# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.")
+            metrics.append("# TYPE patroni_xlog_received_location counter")
             metrics.append("patroni_xlog_received_location 0")
 
-        metrics.append("HELP patroni_server_version Version of Patroni.")
-        metrics.append("TYPE patroni_server_version gauge")
+        metrics.append("# HELP patroni_server_version Version of Patroni.")
+        metrics.append("# TYPE patroni_server_version gauge")
         metrics.append("patroni_server_version {0}".format(postgres['server_version']))
 
-        metrics.append("HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
-        metrics.append("TYPE patroni_cluster_unlocked gauge")
+        metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
+        metrics.append("# TYPE patroni_cluster_unlocked gauge")
         if postgres['cluster_unlocked']:
             metrics.append("patroni_cluster_unlocked 1")
         else:
             metrics.append("patroni_cluster_unlocked 0")
 
-        metrics.append("HELP patroni_timeline Current Postgres timeline number of this node.")
-        metrics.append("TYPE patroni_timeline counter")
+        metrics.append("# HELP patroni_timeline Current Postgres timeline number of this node.")
+        metrics.append("# TYPE patroni_timeline counter")
         metrics.append("patroni_timeline {0}".format(postgres['timeline']))
 
         self._write_response(200, '\n'.join(metrics)+'\n', content_type='text/plain')

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -48,7 +48,7 @@ def null_context():
 
 class Postgresql(object):
 
-    POSTMASTER_START_TIME = "pg_catalog.to_char(pg_catalog.pg_postmaster_start_time(), 'YYYY-MM-DD HH24:MI:SS.MS TZ')"
+    POSTMASTER_START_TIME = "pg_catalog.pg_postmaster_start_time()"
     TL_LSN = ("CASE WHEN pg_catalog.pg_is_in_recovery() THEN 0 "
               "ELSE ('x' || pg_catalog.substr(pg_catalog.pg_{0}file_name("
               "pg_catalog.pg_current_{0}_{1}()), 1, 8))::bit(32)::int END, "  # master timeline
@@ -865,10 +865,10 @@ class Postgresql(object):
         try:
             query = "SELECT " + self.POSTMASTER_START_TIME
             if current_thread().ident == self.__thread_ident:
-                return self.query(query).fetchone()[0]
+                return self.query(query).fetchone()[0].isoformat(sep=' ')
             with self.connection().cursor() as cursor:
                 cursor.execute(query)
-                return cursor.fetchone()[0]
+                return cursor.fetchone()[0].isoformat(sep=' ')
         except psycopg2.Error:
             return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ import urllib3
 from patroni.dcs import Leader, Member
 from patroni.postgresql import Postgresql
 from patroni.postgresql.config import ConfigHandler
-from patroni.utils import RetryFailedError
+from patroni.utils import RetryFailedError, tzutc
 
 
 class SleepException(Exception):
@@ -99,7 +99,7 @@ class MockCursor(object):
         elif sql.startswith('SELECT pg_catalog.pg_postmaster_start_time'):
             replication_info = '[{"application_name":"walreceiver","client_addr":"1.2.3.4",' +\
                                '"state":"streaming","sync_state":"async","sync_priority":0}]'
-            now = datetime.datetime.now()
+            now = datetime.datetime.now(tzutc)
             self.results = [(now, 0, '', 0, '', False, now, replication_info)]
         elif sql.startswith('SELECT name, setting'):
             self.results = [('wal_segment_size', '2048', '8kB', 'integer', 'internal'),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -99,7 +99,7 @@ class MockCursor(object):
         elif sql.startswith('SELECT pg_catalog.pg_postmaster_start_time'):
             replication_info = '[{"application_name":"walreceiver","client_addr":"1.2.3.4",' +\
                                '"state":"streaming","sync_state":"async","sync_priority":0}]'
-            now = str(datetime.datetime.now(tzutc).strftime('%Y-%m-%d %H:%M:%S.%f %Z'))
+            now = datetime.datetime.now(tzutc)
             self.results = [(now, 0, '', 0, '', False, now, replication_info)]
         elif sql.startswith('SELECT name, setting'):
             self.results = [('wal_segment_size', '2048', '8kB', 'integer', 'internal'),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -99,7 +99,7 @@ class MockCursor(object):
         elif sql.startswith('SELECT pg_catalog.pg_postmaster_start_time'):
             replication_info = '[{"application_name":"walreceiver","client_addr":"1.2.3.4",' +\
                                '"state":"streaming","sync_state":"async","sync_priority":0}]'
-            now = datetime.datetime.now(tzutc)
+            now = str(datetime.datetime.now(tzutc).strftime('%Y-%m-%d %H:%M:%S.%f %Z'))
             self.results = [(now, 0, '', 0, '', False, now, replication_info)]
         elif sql.startswith('SELECT name, setting'):
             self.results = [('wal_segment_size', '2048', '8kB', 'integer', 'internal'),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import shutil
 import unittest
@@ -95,10 +96,11 @@ class MockCursor(object):
             self.results = [(1, 2, 1, 0, False, 1, 1, None, None)]
         elif sql.startswith('SELECT pg_catalog.pg_is_in_recovery()'):
             self.results = [(False, 2)]
-        elif sql.startswith('SELECT pg_catalog.to_char'):
+        elif sql.startswith('SELECT pg_catalog.pg_postmaster_start_time'):
             replication_info = '[{"application_name":"walreceiver","client_addr":"1.2.3.4",' +\
                                '"state":"streaming","sync_state":"async","sync_priority":0}]'
-            self.results = [('', 0, '', 0, '', '', False, replication_info)]
+            now = datetime.datetime.now()
+            self.results = [(now, 0, '', 0, '', False, now, replication_info)]
         elif sql.startswith('SELECT name, setting'):
             self.results = [('wal_segment_size', '2048', '8kB', 'integer', 'internal'),
                             ('wal_block_size', '8192', None, 'integer', 'internal'),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,6 +196,8 @@ class TestRestApiHandler(unittest.TestCase):
             self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /patroni'))
         with patch.object(MockHa, 'is_standby_cluster', Mock(return_value=True)):
             MockRestApiServer(RestApiHandler, 'GET /standby_leader')
+        with patch.object(RestApiServer, 'query', Mock(return_value="# HELP patroni_running Value is 1 or 0.\n# TYPE patroni_running gauge\npatroni_running 1")):
+            self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /patroni'))
 
     def test_do_OPTIONS(self):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'OPTIONS / HTTP/1.0'))
@@ -235,6 +237,10 @@ class TestRestApiHandler(unittest.TestCase):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /config'))
         mock_dcs.cluster.config = None
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /config'))
+
+    @patch.object(MockPatroni, 'dcs')
+    def test_do_GET_metrics(self, mock_dcs):
+        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /metrics'))
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_PATCH_config(self, mock_dcs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,8 +196,12 @@ class TestRestApiHandler(unittest.TestCase):
             self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /patroni'))
         with patch.object(MockHa, 'is_standby_cluster', Mock(return_value=True)):
             MockRestApiServer(RestApiHandler, 'GET /standby_leader')
-        with patch.object(RestApiServer, 'query', Mock(return_value="# HELP patroni_running Value is 1 or 0.\n# TYPE patroni_running gauge\npatroni_running 1")):
-            self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /patroni'))
+        with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={
+            'state': 'running', 'postmaster_start_time': '2021-02-20 02:07:35.662 UTC',
+            'role': 'master', 'server_version': '100015', 'cluster_unlocked': 'false',
+            'timeline': '14', 'xlog': { 'location': '50337208' }
+            })):
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
 
     def test_do_OPTIONS(self):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'OPTIONS / HTTP/1.0'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,7 @@ class MockPostgresql(object):
     pending_restart = True
     wal_name = 'wal'
     lsn_name = 'lsn'
-    POSTMASTER_START_TIME = 'pg_catalog.to_char(pg_catalog.pg_postmaster_start_time'
+    POSTMASTER_START_TIME = 'pg_catalog.pg_postmaster_start_time()'
     TL_LSN = 'CASE WHEN pg_catalog.pg_is_in_recovery()'
 
     @staticmethod
@@ -39,7 +39,7 @@ class MockPostgresql(object):
 
     @staticmethod
     def postmaster_start_time():
-        return str(postmaster_start_time)
+        return postmaster_start_time
 
     @staticmethod
     def replica_cached_timeline(_):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -199,8 +199,14 @@ class TestRestApiHandler(unittest.TestCase):
         with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={
             'state': 'running', 'postmaster_start_time': '2021-02-20 02:07:35.662 UTC',
             'role': 'master', 'server_version': '100015', 'cluster_unlocked': 'false',
-            'timeline': '14', 'xlog': { 'location': '50337208' }
-            })):
+            'timeline': '14', 'xlog': {'location': '50337208'}}
+        )):
+            MockRestApiServer(RestApiHandler, 'GET /metrics')
+        with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={
+            'state': 'running', 'postmaster_start_time': '2021-02-20 02:07:35.662 UTC',
+            'role': 'replica', 'server_version': '100015', 'cluster_unlocked': 'false',
+            'timeline': '14', 'xlog': {'received_location': '50337208'}}
+        )):
             MockRestApiServer(RestApiHandler, 'GET /metrics')
 
     def test_do_OPTIONS(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,18 +196,6 @@ class TestRestApiHandler(unittest.TestCase):
             self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /patroni'))
         with patch.object(MockHa, 'is_standby_cluster', Mock(return_value=True)):
             MockRestApiServer(RestApiHandler, 'GET /standby_leader')
-        with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={
-            'state': 'running', 'postmaster_start_time': '2021-02-20 02:07:35.662 UTC',
-            'role': 'master', 'server_version': '100015', 'cluster_unlocked': 'false',
-            'timeline': '14', 'xlog': {'location': '50337208'}}
-        )):
-            MockRestApiServer(RestApiHandler, 'GET /metrics')
-        with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={
-            'state': 'running', 'postmaster_start_time': '2021-02-20 02:07:35.662 UTC',
-            'role': 'replica', 'server_version': '100015', 'cluster_unlocked': 'false',
-            'timeline': '14', 'xlog': {'received_location': '50337208'}}
-        )):
-            MockRestApiServer(RestApiHandler, 'GET /metrics')
 
     def test_do_OPTIONS(self):
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'OPTIONS / HTTP/1.0'))

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,3 +1,4 @@
+import datetime
 import mock  # for the mock.call method, importing it without a namespace breaks python3
 import os
 import psutil
@@ -522,8 +523,9 @@ class TestPostgresql(BaseTestPostgresql):
             self.assertEqual(self.p.get_major_version(), 0)
 
     def test_postmaster_start_time(self):
-        with patch.object(MockCursor, "fetchone", Mock(return_value=('foo', True, '', '', '', '', False))):
-            self.assertEqual(self.p.postmaster_start_time(), 'foo')
+        now = datetime.datetime.now()
+        with patch.object(MockCursor, "fetchone", Mock(return_value=(now, True, '', '', '', '', False))):
+            self.assertEqual(self.p.postmaster_start_time(), now.isoformat(sep=' '))
             t = Thread(target=self.p.postmaster_start_time)
             t.start()
             t.join()


### PR DESCRIPTION
Let's talk about this for #318, I had a little bit of downtime this evening to start something.

Here's hitting my leader:

```bash
❯ curl -s xxx:8008/metrics
# HELP patroni_running Value is 1 if Patroni/Postgres is up, 0 otherwise.
# TYPE patroni_running gauge
patroni_running 1
# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.
# TYPE patroni_postmaster_start_time counter
patroni_postmaster_start_time 1613786855
# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.
# TYPE patroni_master gauge
patroni_master 1
# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.
# TYPE patroni_xlog_location counter
patroni_xlog_location 50337208
# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.
# TYPE patroni_replica gauge
patroni_replica 0
# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.
# TYPE patroni_xlog_received_location counter
patroni_xlog_received_location 0
# HELP patroni_server_version Version of Patroni.
# TYPE patroni_server_version gauge
patroni_server_version 100015
# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.
# TYPE patroni_cluster_unlocked gauge
patroni_cluster_unlocked 0
# HELP patroni_timeline Current Postgres timeline number of this node.
# TYPE patroni_timeline counter
patroni_timeline 14
```

Here's hitting my replica:

```bash
❯ curl -s yyy:8008/metrics
# HELP patroni_running Value is 1 if Patroni/Postgres is up, 0 otherwise.
# TYPE patroni_running gauge
patroni_running 1
# HELP patroni_postmaster_start_time Epoch seconds since Patroni/Postgres started.
# TYPE patroni_postmaster_start_time counter
patroni_postmaster_start_time 1613786867
# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.
# TYPE patroni_master gauge
patroni_master 0
# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.
# TYPE patroni_xlog_location counter
patroni_xlog_location 0
# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.
# TYPE patroni_replica gauge
patroni_replica 1
# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.
# TYPE patroni_xlog_received_location counter
patroni_xlog_received_location 50337208
# HELP patroni_server_version Version of Patroni.
# TYPE patroni_server_version gauge
patroni_server_version 100015
# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.
# TYPE patroni_cluster_unlocked gauge
patroni_cluster_unlocked 0
# HELP patroni_timeline Current Postgres timeline number of this node.
# TYPE patroni_timeline counter
patroni_timeline 14
```

Here's my cluster topology:

```bash
(patroni) postgres@db1:~$ patronictl -c /etc/patroni/config.yml topology
+ Cluster: postgres (6931151304255215270) ---+----+-----------+
| Member | Host          | Role    | State   | TL | Lag in MB |
+--------+---------------+---------+---------+----+-----------+
| db1    | xxx | Leader  | running | 14 |           |
| + db2  | yyy | Replica | running | 14 |         0 |
+--------+---------------+---------+---------+----+-----------+
```