### PR TITLE
Get rid of false warning about invalid parameter

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,6 +115,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Add postgresql apt repo
+      run: sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     - name: Install dependencies
       run: python .github/workflows/install_deps.py
     - name: Run behave tests

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -398,8 +398,8 @@ class ConfigHandler(object):
             f.writeline("include '{0}'\n".format(ConfigWriter.escape(include)))
             for name, value in sorted((configuration).items()):
                 value = transform_postgresql_parameter_value(self._postgresql.major_version, name, value)
-                if (not self._postgresql.bootstrap.running_custom_bootstrap or name != 'hba_file') \
-                        and name not in self._RECOVERY_PARAMETERS and value is not None:
+                if value is not None and\
+                        (name != 'hba_file' or not self._postgresql.bootstrap.running_custom_bootstrap):
                     f.write_param(name, value)
             # when we are doing custom bootstrap we assume that we don't know superuser password
             # and in order to be able to change it, we are opening trust access from a certain address

--- a/patroni/postgresql/validator.py
+++ b/patroni/postgresql/validator.py
@@ -511,6 +511,8 @@ def _transform_parameter_value(validators, version, name, value):
 def transform_postgresql_parameter_value(version, name, value):
     if '.' in name:
         return value
+    if name in recovery_parameters:
+        return None
     return _transform_parameter_value(parameters, version, name, value)
 
 


### PR DESCRIPTION
Despite all recovery parameters became GUCs in PostgreSQL 12, there are very good reasons to keep them separated in the Patroni internals.

While implementing PostgreSQL parameters validation in #1674 one little oversight occurred. The parameters validation happens before the recovery parameters are skipped from the list, which produces a false warning.

Close https://github.com/zalando/patroni/issues/1907