### PR TITLE
Add Patronis default postgres configs to the sample yml files

### DIFF
--- a/postgres0.yml
+++ b/postgres0.yml
@@ -57,10 +57,15 @@ bootstrap:
       parameters:
 #        wal_level: hot_standby
 #        hot_standby: "on"
+#        max_connections: 100
+#        max_worker_processes: 8
 #        wal_keep_segments: 8
 #        max_wal_senders: 10
 #        max_replication_slots: 10
+#        max_prepared_transactions: 0
+#        max_locks_per_transaction: 64
 #        wal_log_hints: "on"
+#        track_commit_timestamp: "off"
 #        archive_mode: "on"
 #        archive_timeout: 1800s
 #        archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -51,10 +51,15 @@ bootstrap:
       parameters:
 #        wal_level: hot_standby
 #        hot_standby: "on"
+#        max_connections: 100
+#        max_worker_processes: 8
 #        wal_keep_segments: 8
 #        max_wal_senders: 10
 #        max_replication_slots: 10
+#        max_prepared_transactions: 0
+#        max_locks_per_transaction: 64
 #        wal_log_hints: "on"
+#        track_commit_timestamp: "off"
 #        archive_mode: "on"
 #        archive_timeout: 1800s
 #        archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -51,10 +51,15 @@ bootstrap:
       parameters:
 #        wal_level: hot_standby
 #        hot_standby: "on"
+#        max_connections: 100
+#        max_worker_processes: 8
 #        wal_keep_segments: 8
 #        max_wal_senders: 10
 #        max_replication_slots: 10
+#        max_prepared_transactions: 0
+#        max_locks_per_transaction: 64
 #        wal_log_hints: "on"
+#        track_commit_timestamp: "off"
 #        archive_mode: "on"
 #        archive_timeout: 1800s
 #        archive_command: mkdir -p ../wal_archive && test ! -f ../wal_archive/%f && cp %p ../wal_archive/%f


### PR DESCRIPTION
This adds the default postgres settings enforced by Patroni to the `postgres{n}.yml` files provided in the repo. The documentation does call out the defaults that Patroni will set, but it can be missed if you (like me) download postgres0.yml and use that as a starting point. Hopefully the extra commented out configs serve as a visual cue to save the next person from the same mistake :)