### PR TITLE
Propagate parameters 'token' from config file patronictl.yaml

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -89,7 +89,7 @@ def get_dcs(config):
                     if key.lower() == name and inspect.isclass(item) and issubclass(item, AbstractDCS):
                         # propagate some parameters
                         config[name].update({p: config[p] for p in ('namespace', 'name', 'scope', 'loop_wait',
-                                             'patronictl', 'ttl', 'retry_timeout') if p in config})
+                                             'patronictl', 'ttl', 'retry_timeout', 'token') if p in config})
                         return item(config[name])
             except ImportError:
                 logger.debug('Failed to import %s', module_name)


### PR DESCRIPTION
Если Consul настроен на авторизацию с помощью токена, то patronictl не может взаимодействовать с Consul, т.к. не обрабатывает параметр token из конфигурационного файла. Заставить работать patronictl можно задав переменную окружения CONSUL_HTTP_TOKEN (export CONSUL_HTTP_TOKEN=ololo), но удобнее все-таки задать токен в конфигурационном файле. Список параметров, передаваемых consul-клиенту жёстко прописан в коде. Данный PR расширяет список параметров дополнительным параметром 'token'.


------------------
yandex translate
------------------
If Consul is configured to authorize with a token, patronictl cannot interact with Consul because it does not process the token parameter from the configuration file. You can make patronictl work by setting the environment variable CONSUL_HTTP_TOKEN (export CONSUL_HTTP_TOKEN=ololo), but it is still more convenient to set the token in the configuration file. The list of parameters passed to the consul client is hardcoded in the code. This PR extends the list of parameters with an additional parameter 'token'.