### PR TITLE
Run behave tests with Python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,15 +30,6 @@ jobs:
       run: python .github/workflows/run_tests.py
       if: matrix.os != 'windows'
 
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.5
-    - name: Install dependencies
-      run: python .github/workflows/install_deps.py
-    - name: Run tests and flake8
-      run: python .github/workflows/run_tests.py
-
     - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
@@ -106,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [2.7, 3.5, 3.8]
+        python-version: [2.7, 3.6, 3.9]
         dcs: [etcd, etcd3, consul, exhibitor, kubernetes, raft]
 
     steps:
@@ -121,12 +112,11 @@ jobs:
       run: python .github/workflows/install_deps.py
     - name: Run behave tests
       run: python .github/workflows/run_tests.py
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
     - name: Install coveralls
+      if: ${{ matrix.python-version == '3.9' }}
       run: python -m pip install coveralls
     - name: Upload Coverage
+      if: ${{ matrix.python-version == '3.9' }}
       env:
         COVERALLS_FLAG_NAME: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: 'true'
@@ -143,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos]  #, windows]
-        python-version: [3.7]
+        python-version: [3.9]
         dcs: [etcd, etcd3, raft]
 
     steps:


### PR DESCRIPTION
- Run behave tests with Python 3.9, instead of 3.8 on Linux
- Run behave tests with Python 3.9, instead of 3.7 on macOS
- Run behave tests with Python 3.6, instead of 3.5 on Linux since Python 3.5 reached EOL in 2020
- Stop to run uni tests with Python 3.5
- Push less number of code coverage from matrix jobs to coveralls
    - before this PR, 46 jobs https://coveralls.io/builds/38961070
    - with this PR, would be 33 jobs