### PR TITLE
Fix bug with unix socket connections

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -879,13 +879,13 @@ class ConfigHandler(object):
         tcp_local_address = self._get_tcp_local_address()
         netloc = self._config.get('connect_address') or tcp_local_address + ':' + port
 
+        unix_local_address = {'port': port}
         unix_socket_directories = self._server_parameters.get('unix_socket_directories')
-        # fallback to tcp if unix_socket_directories is set, but there are no sutable values
-        unix_local_address = unix_socket_directories and\
-            self._get_unix_local_address(unix_socket_directories) or tcp_local_address
+        if unix_socket_directories is not None:
+            # fallback to tcp if unix_socket_directories is set, but there are no sutable values
+            unix_local_address['host'] = self._get_unix_local_address(unix_socket_directories) or tcp_local_address
 
         tcp_local_address = {'host': tcp_local_address, 'port': port}
-        unix_local_address = {'host': unix_local_address, 'port': port}
 
         self._local_address = unix_local_address if self._config.get('use_unix_socket') else tcp_local_address
         self.local_replication_address = unix_local_address\

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -492,6 +492,14 @@ class TestPostgresql(BaseTestPostgresql):
         self.p.reload_config(config)
         self.p.config.resolve_connection_addresses()
 
+    def test_resolve_connection_addresses(self):
+        self.p.config._config['use_unix_socket'] = self.p.config._config['use_unix_socket_repl'] = True
+        self.p.config.resolve_connection_addresses()
+        self.assertEqual(self.p.config.local_replication_address, {'host': '/tmp', 'port': '5432'})
+        self.p.config._server_parameters.pop('unix_socket_directories')
+        self.p.config.resolve_connection_addresses()
+        self.assertEqual(self.p.config._local_address, {'port': '5432'})
+
     @patch.object(Postgresql, '_version_file_exists', Mock(return_value=True))
     def test_get_major_version(self):
         with patch.object(builtins, 'open', mock_open(read_data='9.4')):


### PR DESCRIPTION
When the unix_socket_directories is not known Patroni was immediately going back to tcp connection via the localhost.

The bug was introduced in https://github.com/zalando/patroni/pull/1865