### PR TITLE
Correct log message for PG restart on replication config changes

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -426,7 +426,8 @@ class Ha(object):
             change_required, restart_required = self.state_handler.config.check_recovery_conf(node_to_follow)
             if change_required:
                 if restart_required:
-                    self._async_executor.try_run_async('changing primary_conninfo and restarting',
+                    self._async_executor.try_run_async('replication-related parameters (such as primary_conninfo, restore_command) has recently changed, '
+                                                       'restarting PostgreSQL to apply the changes',
                                                        self.state_handler.follow, args=(node_to_follow, role))
                 else:
                     self.state_handler.follow(node_to_follow, role, do_reload=True)


### PR DESCRIPTION
When some replication-related changes happen (e.g., restore_command
is changed), Patroni restarts Postgres and the following can bee seen in logs:

INFO: changing primary_conninfo and restarting in progress   

This message is misleading because it mentions one particular parameter
but the change could happen with a different one (e.g., restore_command).

This is a quick improvement that makes the messaging better. In the future,
it would make sense to report the diff of changes (hence, particular root cause
of the restart) that is analyzed in config.py:record_missmatch.