### PR TITLE
Track /status key updates

### DIFF
--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -426,8 +426,8 @@ class KVCache(Thread):
                 logger.debug('%s changed from %s to %s', key, old_value, new_value)
 
             # We also want to wake up HA loop on replicas if leader optime (or status key) was updated
-            if value_changed and \
-                    (key not in (self._optime_key, self._status_key) or self.get(self._leader_key) != self._name):
+            if value_changed and (key not in (self._optime_key, self._status_key) or
+                                  (self.get(self._leader_key) or {}).get('value') != self._name):
                 self._dcs.event.set()
 
     def _process_message(self, message):

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -372,6 +372,7 @@ class KVCache(Thread):
         self._config_key = base64_encode(dcs.config_path)
         self._leader_key = base64_encode(dcs.leader_path)
         self._optime_key = base64_encode(dcs.leader_optime_path)
+        self._status_key = base64_encode(dcs.status_path)
         self._name = base64_encode(dcs._name)
         self._is_ready = False
         self._response = None
@@ -418,14 +419,15 @@ class KVCache(Thread):
             new_value = kv.get('value')
 
             value_changed = old_value != new_value and \
-                (key == self._leader_key or key == self._optime_key and new_value is not None or
+                (key == self._leader_key or key in (self._optime_key, self._status_key) and new_value is not None or
                  key == self._config_key and old_value is not None and new_value is not None)
 
             if value_changed:
                 logger.debug('%s changed from %s to %s', key, old_value, new_value)
 
-            # We also want to wake up HA loop on replicas if leader optime was updated
-            if value_changed and (key != self._optime_key or self.get(self._leader_key) != self._name):
+            # We also want to wake up HA loop on replicas if leader optime (or status key) was updated
+            if value_changed and \
+                    (key not in (self._optime_key, self._status_key) or self.get(self._leader_key) != self._name):
                 self._dcs.event.set()
 
     def _process_message(self, message):

--- a/patroni/dcs/raft.py
+++ b/patroni/dcs/raft.py
@@ -264,7 +264,8 @@ class Raft(AbstractDCS):
         leader = (self._sync_obj.get(self.leader_path) or {}).get('value')
         if key == value['created'] == value['updated'] and \
                 (key.startswith(self.members_path) or key == self.leader_path and leader != self._name) or \
-                key == self.leader_optime_path and leader != self._name or key in (self.config_path, self.sync_path):
+                key in (self.leader_optime_path, self.status_path) and leader != self._name or \
+                key in (self.config_path, self.sync_path):
             self.event.set()
 
     def _on_delete(self, key):


### PR DESCRIPTION
The #1820 introduced a new key in DCS, named /status, which contains the leader optime and maybe flush LSN of logical slots.

In case of etcd3 and raft we should use updates of this key for syncing HA loop across nodes (before we were using /optime/leader).