### PR TITLE
Reload REST API certificate only on SIGHUP

### DIFF
--- a/patroni/__init__.py
+++ b/patroni/__init__.py
@@ -74,7 +74,7 @@ class Patroni(AbstractPatroniDaemon):
             if local:
                 self.tags = self.get_tags()
                 self.request.reload_config(self.config)
-            if local or self.api.reload_local_certificate():
+            if local or sighup and self.api.reload_local_certificate():
                 self.api.reload_config(self.config['restapi'])
             self.watchdog.reload_config(self.config)
             self.postgresql.reload_config(self.config['postgresql'], sighup)

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -646,10 +646,10 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
         self.patroni = patroni
         self.__listen = None
         self.__ssl_options = None
-        self.reload_config(config)
-        self.daemon = True
         self.__ssl_serial_number = None
         self._received_new_cert = False
+        self.reload_config(config)
+        self.daemon = True
 
     def query(self, sql, *params):
         cursor = None


### PR DESCRIPTION
And make sure that cert number is cached when the RestApiServer object is created.

Close https://github.com/zalando/patroni/issues/2003