### PR TITLE
Add selector to StatefulSet definition

### DIFF
--- a/kubernetes/patroni_k8s.yaml
+++ b/kubernetes/patroni_k8s.yaml
@@ -20,6 +20,10 @@ metadata:
 spec:
   replicas: 3
   serviceName: *cluster_name
+  selector:
+    matchLabels:
+      application: patroni
+      cluster-name: *cluster_name
   template:
     metadata:
       labels:


### PR DESCRIPTION
This adds the `selector` to the Patroni Kubernetes StatefulSet spec

Without it, one gets errors like
```
error: error validating "patroni_k8s.yaml": error validating data: ValidationError(StatefulSet.spec): missing required field "selector" in io.k8s.api.apps.v1.StatefulSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```
(as mentioned in #1867)