### PR TITLE
make the CA bundle configurable for in-cluster Kubernetes config 

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -105,6 +105,7 @@ Kubernetes
 -  **PATRONI\_KUBERNETES\_USE\_ENDPOINTS**: (optional) if set to true, Patroni will use Endpoints instead of ConfigMaps to run leader elections and keep cluster state.
 -  **PATRONI\_KUBERNETES\_POD\_IP**: (optional) IP address of the pod Patroni is running in. This value is required when `PATRONI_KUBERNETES_USE_ENDPOINTS` is enabled and is used to populate the leader endpoint subsets when the pod's PostgreSQL is promoted.
 -  **PATRONI\_KUBERNETES\_PORTS**: (optional) if the Service object has the name for the port, the same name must appear in the Endpoint object, otherwise service won't work. For example, if your service is defined as ``{Kind: Service, spec: {ports: [{name: postgresql, port: 5432, targetPort: 5432}]}}``, then you have to set ``PATRONI_KUBERNETES_PORTS='[{"name": "postgresql", "port": 5432}]'`` and Patroni will use it for updating subsets of the leader Endpoint. This parameter is used only if `PATRONI_KUBERNETES_USE_ENDPOINTS` is set.
+-  **PATRONI\_KUBERNETES\_CACERT**: (optional) Specifies the file with the CA_BUNDLE file with certificates of trusted CAs to use while verifying Kubernetes API SSL certs. If not provided, patroni will use the value provided by the ServiceAccount secret.
 
 Raft
 ----

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -204,6 +204,7 @@ Kubernetes
 -  **use\_endpoints**: (optional) if set to true, Patroni will use Endpoints instead of ConfigMaps to run leader elections and keep cluster state.
 -  **pod\_ip**: (optional) IP address of the pod Patroni is running in. This value is required when `use_endpoints` is enabled and is used to populate the leader endpoint subsets when the pod's PostgreSQL is promoted.
 -  **ports**: (optional) if the Service object has the name for the port, the same name must appear in the Endpoint object, otherwise service won't work. For example, if your service is defined as ``{Kind: Service, spec: {ports: [{name: postgresql, port: 5432, targetPort: 5432}]}}``, then you have to set ``kubernetes.ports: [{"name": "postgresql", "port": 5432}]`` and Patroni will use it for updating subsets of the leader Endpoint. This parameter is used only if `kubernetes.use_endpoints` is set.
+-  **cacert**: (optional) Specifies the file with the CA_BUNDLE file with certificates of trusted CAs to use while verifying Kubernetes API SSL certs. If not provided, patroni will use the value provided by the ServiceAccount secret.
 
 
 .. _raft_settings:


### PR DESCRIPTION
For instances where the full CA chain is not provided by the `ServiceAccount` secret, allow the location to be overridden by an environment variable.

`SSL_CERT_FILE` is the generally accepted environment variable to override the system CA bundle:
* https://pkg.go.dev/crypto/x509#SystemCertPool
* https://www.openssl.org/docs/manmaster/man7/openssl-env.html

An alternative environment variable to use could be the name of the variable used in the code already, `SERVICE_CERT_FILENAME`; this could avoid an potential inadvertent changes in the off-chance that someone already has `SSL_CERT_FILE` set and doesn't want Patroni using it.

The official Python Kubernetes client allows configuring an alternative CA bundle already: https://github.com/kubernetes-client/python/blob/d8f283e7483848647804eab345645106b6fb357d/kubernetes/client/configuration.py#L135

fixes https://github.com/zalando/patroni/issues/1758