### PR TITLE
Add dcs_last_seen field to API

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -288,6 +288,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_postgres_timeline counter")
         metrics.append("patroni_postgres_timeline{0} {1}".format(scope_label, postgres.get('timeline', 0)))
 
+        metrics.append("# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully by Patroni.")
+        metrics.append("# TYPE patroni_dcs_last_seen gauge")
+        metrics.append("patroni_dcs_last_seen{0} {1}".format(scope_label, postgres.get('dcs_last_seen', 0)))
+
         self._write_response(200, '\n'.join(metrics)+'\n', content_type='text/plain')
 
     def _read_json_content(self, body_is_optional=False):

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -583,9 +583,6 @@ class RestApiHandler(BaseHTTPRequestHandler):
         try:
             cluster = self.server.patroni.dcs.cluster
 
-            if cluster:
-                postgresql.dcs_last_seen = cluster.dcs_last_seen
-
             if postgresql.state not in ('running', 'restarting', 'starting'):
                 raise RetryFailedError('')
             stmt = ("SELECT " + postgresql.POSTMASTER_START_TIME + ", " + postgresql.TL_LSN + ","
@@ -603,7 +600,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': postgresql.server_version,
                 'cluster_unlocked': bool(not cluster or cluster.is_unlocked()),
-                'dcs_last_seen': postgresql.dcs_last_seen,
+                'dcs_last_seen': self.server.patroni.ha.dcs_last_seen,
                 'xlog': ({
                     'received_location': row[4] or row[3],
                     'replayed_location': row[3],

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -600,7 +600,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': postgresql.server_version,
                 'cluster_unlocked': bool(not cluster or cluster.is_unlocked()),
-                'dcs_last_seen': self.server.patroni.ha.dcs_last_seen,
+                'dcs_last_seen': self.server.patroni.dcs.last_seen,
                 'xlog': ({
                     'received_location': row[4] or row[3],
                     'replayed_location': row[3],

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -288,7 +288,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_postgres_timeline counter")
         metrics.append("patroni_postgres_timeline{0} {1}".format(scope_label, postgres.get('timeline', 0)))
 
-        metrics.append("# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully by Patroni.")
+        metrics.append("# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully"
+                       " by Patroni.")
         metrics.append("# TYPE patroni_dcs_last_seen gauge")
         metrics.append("patroni_dcs_last_seen{0} {1}".format(scope_label, postgres.get('dcs_last_seen', 0)))
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -583,6 +583,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         try:
             cluster = self.server.patroni.dcs.cluster
 
+            if cluster:
+                postgresql.dcs_last_seen = cluster.dcs_last_seen
+
             if postgresql.state not in ('running', 'restarting', 'starting'):
                 raise RetryFailedError('')
             stmt = ("SELECT " + postgresql.POSTMASTER_START_TIME + ", " + postgresql.TL_LSN + ","
@@ -600,6 +603,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
                 'role': 'replica' if row[1] == 0 else 'master',
                 'server_version': postgresql.server_version,
                 'cluster_unlocked': bool(not cluster or cluster.is_unlocked()),
+                'dcs_last_seen': postgresql.dcs_last_seen,
                 'xlog': ({
                     'received_location': row[4] or row[3],
                     'replayed_location': row[3],

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -652,6 +652,7 @@ class AbstractDCS(object):
         self._cluster_valid_till = 0
         self._cluster_thread_lock = Lock()
         self._last_lsn = ''
+        self._dcs_last_seen = 0
         self._last_status = {}
         self.event = Event()
 
@@ -721,6 +722,10 @@ class AbstractDCS(object):
     @property
     def loop_wait(self):
         return self._loop_wait
+
+    @property
+    def dcs_last_seen(self):
+        return self._dcs_last_seen
 
     @abc.abstractmethod
     def _load_cluster(self):

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -652,7 +652,7 @@ class AbstractDCS(object):
         self._cluster_valid_till = 0
         self._cluster_thread_lock = Lock()
         self._last_lsn = ''
-        self._dcs_last_seen = 0
+        self._last_seen = 0
         self._last_status = {}
         self.event = Event()
 
@@ -724,8 +724,8 @@ class AbstractDCS(object):
         return self._loop_wait
 
     @property
-    def dcs_last_seen(self):
-        return self._dcs_last_seen
+    def last_seen(self):
+        return self._last_seen
 
     @abc.abstractmethod
     def _load_cluster(self):
@@ -748,6 +748,8 @@ class AbstractDCS(object):
         except Exception:
             self.reset_cluster()
             raise
+
+        self._last_seen = int(time.time())
 
         with self._cluster_thread_lock:
             self._cluster = cluster

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -78,7 +78,6 @@ class Ha(object):
         self._start_timeout = None
         self._async_executor = AsyncExecutor(self.state_handler.cancellable, self.wakeup)
         self.watchdog = patroni.watchdog
-        self.dcs_last_seen = 0
 
         # Each member publishes various pieces of information to the DCS using touch_member. This lock protects
         # the state and publishing procedure to have consistent ordering and avoid publishing stale values.
@@ -230,10 +229,6 @@ class Ha(object):
 
             if self.is_paused():
                 data['pause'] = True
-
-            # Note time we last updated DCS
-            self.dcs_last_seen = int(time.time())
-            data['dcs_last_seen'] = self.dcs_last_seen
 
             return self.dcs.touch_member(data)
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -41,7 +41,8 @@ class _MemberStatus(namedtuple('_MemberStatus', ['member', 'reachable', 'in_reco
         timeline = json.get('timeline', 0)
         dcs_last_seen = json.get('dcs_last_seen', 0)
         wal = not is_master and max(json['xlog'].get('received_location', 0), json['xlog'].get('replayed_location', 0))
-        return cls(member, True, not is_master, dcs_last_seen, timeline, wal, json.get('tags', {}), json.get('watchdog_failed', False))
+        return cls(member, True, not is_master, dcs_last_seen, timeline, wal,
+                   json.get('tags', {}), json.get('watchdog_failed', False))
 
     @classmethod
     def unknown(cls, member):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,7 +77,7 @@ class MockHa(object):
 
     @staticmethod
     def fetch_nodes_statuses(members):
-        return [_MemberStatus(None, True, None, 0, None, {}, False)]
+        return [_MemberStatus(None, True, None, 0, 0, None, {}, False)]
 
     @staticmethod
     def schedule_future_restart(data):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,6 +54,7 @@ class MockHa(object):
 
     state_handler = MockPostgresql()
     watchdog = MockWatchdog()
+    dcs_last_seen = 0
 
     @staticmethod
     def is_leader():

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -80,13 +80,14 @@ def get_standby_cluster_initialized_with_only_leader(failover=None, sync=None):
     )
 
 
-def get_node_status(reachable=True, in_recovery=True, timeline=2,
-                    wal_position=10, nofailover=False, watchdog_failed=False):
+def get_node_status(reachable=True, in_recovery=True, dcs_last_seen=0,
+                    timeline=2, wal_position=10, nofailover=False,
+                    watchdog_failed=False):
     def fetch_node_status(e):
         tags = {}
         if nofailover:
             tags['nofailover'] = True
-        return _MemberStatus(e, reachable, in_recovery, timeline, wal_position, tags, watchdog_failed)
+        return _MemberStatus(e, reachable, in_recovery, dcs_last_seen, timeline, wal_position, tags, watchdog_failed)
     return fetch_node_status
 
 


### PR DESCRIPTION
This field notes the last time (as unix epoch) a cluster member has
successfully communicated with the DCS. This is useful to identify and/or
analyse network partitions.

Also, expose dcs_last_seen in the MemberStatus class and its from_api_response
method.