### PR TITLE
Add log before demoting (which can take some time)

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -826,6 +826,8 @@ class Ha(object):
             'immediate-nolock': dict(stop='immediate', checkpoint=False, release=False, offline=False, async_req=True),
         }[mode]
 
+        logger.info('Demoting self (%s)', mode)
+
         self._rewind.trigger_check_diverged_lsn()
         self.state_handler.stop(mode_control['stop'], checkpoint=mode_control['checkpoint'],
                                 on_safepoint=self.watchdog.disable if self.watchdog.is_running else None,


### PR DESCRIPTION
While testing switchovers/failovers, I've noticed that it can take some time for the demote to finish and it might not be obvious from looking at the logs what exactly is going on.

So I propose to add a line at the beginning of the `demote` function.