### PR TITLE
Add compatibility with PG 14 in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Patroni is a template for you to create your own customized, high-availability s
 
 We call Patroni a "template" because it is far from being a one-size-fits-all or plug-and-play replication system. It will have its own caveats. Use wisely.
 
-Currently supported PostgreSQL versions: 9.3 to 13.
+Currently supported PostgreSQL versions: 9.3 to 14.
 
 **Note to Kubernetes users**: Patroni can run natively on top of Kubernetes. Take a look at the `Kubernetes <https://github.com/zalando/patroni/blob/master/docs/kubernetes.rst>`__ chapter of the Patroni documentation.
 


### PR DESCRIPTION
Patroni documentation has already been updated with PG 14 support information.
It was just missing in the repository README.