### PR TITLE
Optimize checkpoint after promote

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1282,6 +1282,7 @@ class Ha(object):
         if not self.watchdog.activate():
             logger.error('Cancelling bootstrap because watchdog activation failed')
             self.cancel_initialization()
+        self._rewind.ensure_checkpoint_after_promote(self.wakeup)
         self.dcs.initialize(create_new=(self.cluster.initialize is None), sysid=self.state_handler.sysid)
         self.dcs.set_config_value(json.dumps(self.patroni.config.dynamic_configuration, separators=(',', ':')))
         self.dcs.take_leader()

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -388,6 +388,7 @@ class Postgresql(object):
 
     def pg_control_timeline(self):
         try:
+
             return int(self.controldata().get("Latest checkpoint's TimeLineID"))
         except (TypeError, ValueError):
             logger.exception('Failed to parse timeline from pg_controldata output')

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -232,14 +232,11 @@ class Rewind(object):
                     with self._checkpoint_task:
                         if self._checkpoint_task.result:
                             self._state = REWIND_STATUS.CHECKPOINT
-                        if self._checkpoint_task.result is not False:
-                            return
+                elif self._postgresql.get_master_timeline() == self._postgresql.pg_control_timeline():
+                    self._state = REWIND_STATUS.CHECKPOINT
                 else:
                     self._checkpoint_task = CriticalTask()
-                    return Thread(target=self.__checkpoint, args=(self._checkpoint_task, wakeup)).start()
-
-            if self._postgresql.get_master_timeline() == self._postgresql.pg_control_timeline():
-                self._state = REWIND_STATUS.CHECKPOINT
+                    Thread(target=self.__checkpoint, args=(self._checkpoint_task, wakeup)).start()
 
     def checkpoint_after_promote(self):
         return self._state == REWIND_STATUS.CHECKPOINT


### PR DESCRIPTION
1. Avoid doing CHECKPOINT if `pg_control` is already updated.
2. Explicitly call ensure_checkpoint_after_promote() right after the bootstrap finished successfully.