### PR TITLE
Avoid unnecessary updates of the member ZNode in Zookeeper

### DIFF
--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -213,6 +213,7 @@ class TestZooKeeper(unittest.TestCase):
         self.zk.touch_member({'retry': 'retry'})
         self.zk._fetch_cluster = True
         self.zk.get_cluster()
+        self.zk.touch_member({'retry': 'retry'})
         self.zk.touch_member({'conn_url': 'postgres://repuser:rep-pass@localhost:5434/postgres',
                               'api_url': 'http://127.0.0.1:8009/patroni'})
 


### PR DESCRIPTION
When deciding whether the ZNode should be updated we rely on the cached version of the cluster, which is updated only when members ZNodes are deleted/created or the `/status`, `/sync`, `/failover`, `/config`, or `/history` ZNodes are updated.

I.e. after the update of the current member ZNode succeeded the cache becomes stale and all further updates are always performed even if the value didn't change. In order to solve it, we introduce the new attribute in the Zookeeper class and will use it for memorizing the actual value and for later comparison.