### PR TITLE
Handle missing timelines in history file when deciding to rewind

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -1011,7 +1011,7 @@ class Kubernetes(AbstractDCS):
     def touch_member(self, data, permanent=False):
         cluster = self.cluster
         if cluster and cluster.leader and cluster.leader.name == self._name:
-            role = 'promoted' if data['role'] in ('replica', 'promoted') else 'master'
+            role = 'master'
         elif data['state'] == 'running' and data['role'] != 'master':
             role = data['role']
         else:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -192,9 +192,6 @@ class Ha(object):
                 'version': self.patroni.version
             }
 
-            # following two lines are mainly necessary for consul, to avoid creation of master service
-            if data['role'] == 'master' and not self.is_leader():
-                data['role'] = 'promoted'
             if self.is_leader() and not self._rewind.checkpoint_after_promote():
                 data['checkpoint_after_promote'] = False
             tags = self.get_effective_tags()

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -161,11 +161,11 @@ class Rewind(object):
         if local_timeline is None or local_lsn is None:
             return
 
-        if isinstance(leader, Leader):
-            if leader.member.data.get('role') != 'master':
-                return
-        # standby cluster
-        elif not self.check_leader_is_not_in_recovery(self._conn_kwargs(leader, self._postgresql.config.replication)):
+        if isinstance(leader, Leader) and leader.member.data.get('role') != 'master':
+            return
+
+        if not self.check_leader_is_not_in_recovery(
+                self._conn_kwargs(leader, self._postgresql.config.rewind_credentials)):
             return
 
         history = need_rewind = None

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -189,29 +189,23 @@ class Rewind(object):
 
         if history is not None:
             history = list(parse_history(history))
-            idx = None
-            for i, (parent_timeline, _, _) in enumerate(history):
+            for i, (parent_timeline, switchpoint, _) in enumerate(history):
                 if parent_timeline == local_timeline:
-                    idx = i
-                    break
+                    # We don't need to rewind when:
+                    # 1. for replica: replayed location is not ahead of switchpoint
+                    # 2. for the former primary: end of checkpoint record is the same as switchpoint
+                    if in_recovery:
+                        need_rewind = local_lsn > switchpoint
+                    elif local_lsn >= switchpoint:
+                        need_rewind = True
+                    else:
+                        need_rewind = switchpoint != self._get_checkpoint_end(local_timeline, local_lsn)
                 elif parent_timeline > local_timeline:
-                    break
-                else:
-                    idx = i
-
-            if idx is not None:
-                switchpoint = history[idx][1]
-
-                # We don't need to rewind when:
-                # 1. for replica: replayed location is not ahead of switchpoint
-                # 2. for the former primary: end of checkpoint record is the same as switchpoint
-                if in_recovery:
-                    need_rewind = local_lsn > switchpoint
-                elif local_lsn >= switchpoint:
                     need_rewind = True
-                else:
-                    need_rewind = switchpoint != self._get_checkpoint_end(local_timeline, local_lsn)
-            self._log_master_history(history, idx or i)
+                    break
+            else:
+                need_rewind = True
+            self._log_master_history(history, i)
 
         self._state = need_rewind and REWIND_STATUS.NEED or REWIND_STATUS.NOT_NEED
 


### PR DESCRIPTION
When restore_command is configured Postgres is trying to fetch/apply all possible WAL segments and also fetch history files in order to select the correct timeline. It could result in a situation where the new history file will be missing some timelines.

Example:
- node1 demotes/crashes on timeline 1
- node2 promotes to timeline 2 and archives `00000002.history` and crashes
- node1 recovers as a replica, "replays" `00000002.history` and promotes to timeline 3

As a result, the `00000003.history` will not have the line with timeline 2, because it never replayed any WAL segment from it.
The `pg_rewind` tool is supposed to correctly handle such case when rewinding node2 from node1, but Patroni when deciding whether the rewind should happen was searching for the exact timeline in the history file from the new primary.

The solution is to assume that rewind is required if the current replica timeline is missing.

In addition to that this PR makes sure that the primary isn't running in recovery before starting the procedure of rewind check.

Close https://github.com/zalando/patroni/issues/2118 and https://github.com/zalando/patroni/issues/2124