### PR TITLE
Fix a litle bug around psycopg 3.0

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -599,7 +599,6 @@ class Postgresql(object):
                     if cur.fetchone()[0]:
                         return 'is_in_recovery=true'
                 cur.execute('CHECKPOINT')
-                return
         except psycopg.Error:
             logger.exception('Exception during CHECKPOINT')
             return 'not accessible or not healty'

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -598,7 +598,8 @@ class Postgresql(object):
                     cur.execute('SELECT pg_catalog.pg_is_in_recovery()')
                     if cur.fetchone()[0]:
                         return 'is_in_recovery=true'
-                return cur.execute('CHECKPOINT')
+                cur.execute('CHECKPOINT')
+                return
         except psycopg.Error:
             logger.exception('Exception during CHECKPOINT')
             return 'not accessible or not healty'

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -232,6 +232,7 @@ class Rewind(object):
                     with self._checkpoint_task:
                         if self._checkpoint_task.result:
                             self._state = REWIND_STATUS.CHECKPOINT
+                    self._checkpoint_task = None
                 elif self._postgresql.get_master_timeline() == self._postgresql.pg_control_timeline():
                     self._state = REWIND_STATUS.CHECKPOINT
                 else:

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -232,7 +232,7 @@ class Rewind(object):
                     with self._checkpoint_task:
                         if self._checkpoint_task.result is not None:
                             self._state = REWIND_STATUS.CHECKPOINT
-                    self._checkpoint_task = None
+                            self._checkpoint_task = None
                 elif self._postgresql.get_master_timeline() == self._postgresql.pg_control_timeline():
                     self._state = REWIND_STATUS.CHECKPOINT
                 else:

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -230,7 +230,7 @@ class Rewind(object):
             with self._checkpoint_task_lock:
                 if self._checkpoint_task:
                     with self._checkpoint_task:
-                        if self._checkpoint_task.result:
+                        if self._checkpoint_task.result is not None:
                             self._state = REWIND_STATUS.CHECKPOINT
                     self._checkpoint_task = None
                 elif self._postgresql.get_master_timeline() == self._postgresql.pg_control_timeline():


### PR DESCRIPTION
Cursor.execute now returns cursor itself, while in psycopg2 it was returning None