### PR TITLE
Add conditional on cluster_unlocked, cause it's failing if not initialized

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -280,9 +280,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_postgres_server_version gauge")
         metrics.append("patroni_postgres_server_version {0} {1}".format(scope_label, postgres.get('server_version', 0)))
 
-        metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
-        metrics.append("# TYPE patroni_cluster_unlocked gauge")
-        metrics.append("patroni_cluster_unlocked{0} {1}".format(scope_label, int(postgres.get('cluster_unlocked', 0))))
+        if 'cluster_unlocked' in postgres:
+            metrics.append("# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.")
+            metrics.append("# TYPE patroni_cluster_unlocked gauge")
+            metrics.append("patroni_cluster_unlocked{0} {1}".format(scope_label, int(postgres['cluster_unlocked'])))
 
         metrics.append("# HELP patroni_postgres_timeline Postgres timeline of this node (if running), 0 otherwise.")
         metrics.append("# TYPE patroni_postgres_timeline counter")


### PR DESCRIPTION
**Describe the bug**

We are using the prometheus metric endpoint and we want to create alerts to ensure our cluster is working properly.
And we got an issue while retrieving the data while the node is in failure state.

In the `api.py` file, we do not check if the `postgres` parameter is "fully" instanciated and we print it
<https://github.com/zalando/patroni/blob/v2.1.1/patroni/api.py#L283_L285>
```python
# api.py
metrics.append("patroni_cluster_unlocked{0} {1}".format(scope_label, int(postgres['cluster_unlocked'])))
```
When there is an error at the start, of the cluster, only the `state` and the `role` are given.
<https://github.com/zalando/patroni/blob/v2.1.1/patroni/api.py#L630>
```python
return {'state': state, 'role': postgresql.role}
```

When requesting the API, there is no error on `/patroni`,
but there is an error while requesting  `/metrics`

```bash
root@postgresql-dev-b:/home/vagrant# curl -s https://node-dev-a:8008/patroni | jq
{
  "state": "start failed",
  "role": "replica",
  "database_system_identifier": "7033311346503755640",
  "patroni": {
    "version": "2.1.1",
    "scope": "postgresql_dev"
  }
}
root@postgresql-dev-b:/home/vagrant# curl https://postgresql-dev-a:8008/metrics
curl: (52) Empty reply from server
```

**To Reproduce**

* Instanciate a patroni cluster once with the given configuration, ensure to redirect logs to a directory to simulate the startup failure
* Stop patroni
* Change the ownership of the directory (example `chown root: /var/log/postgresql`)
* Start patroni

**Expected behavior**
The api `/metrics` return all the data

Screenshots
If applicable, add screenshots to help explain your problem.

**Environment**
We are using the installation from python

**Patroni configuration file**

patronictl show-config

``` yaml
loop_wait: 10
master_start_timeout: 300
master_stop_timeout: 0
max_timelines_history: false
maximum_lag_on_failover: 1048576
maximum_lag_on_syncnode: -1
postgresql:
  parameters:
    archive_command: pgbackrest --stanza=postgresql_stanza_dev archive-push %p
    archive_mode: 'on'
    archive_timeout: 1800s
    hot_standby: 'on'
    listen_addresses: '*'
    log_directory: /var/log/postgresql # Redirect the logs
    logging_collector: 'on'
    max_connections: '100'
    max_locks_per_transaction: '64'
    max_prepared_transactions: '0'
    max_replication_slots: '10'
    max_wal_senders: '10'
    max_worker_processes: '7'
    stats_temp_directory: /var/run/postgresql/13-main.pg_stat_tmp
    track_commit_timestamp: 'off'
    wal_level: replica
    wal_log_hints: 'on'
  use_pg_rewind: true
  use_slots: false
retry_timeout: 10
synchronous_mode: false
synchronous_mode_strict: false
synchronous_node_count: 1
ttl: 30
```

Have you checked Patroni logs?

```log
Nov 23 17:24:23 instance patroni[24823]: 2021-11-23 17:24:23,734 INFO: Selected new etcd server https://dcs-b:2379
Nov 23 17:24:23 instance patroni[24823]: 2021-11-23 17:24:23,734 INFO: Trying to authenticate on Etcd...
Nov 23 17:24:23 instance patroni[24823]: 2021-11-23 17:24:23,837 INFO: No PostgreSQL configuration items changed, nothing to reload.
Nov 23 17:24:33 instance patroni[24823]: 2021-11-23 17:24:33,940 WARNING: Postgresql is not running.
Nov 23 17:24:33 instance patroni[24823]: 2021-11-23 17:24:33,940 INFO: Lock owner: node-dev-d; I am node-dev-a
Nov 23 17:24:33 instance patroni[24823]: 2021-11-23 17:24:33,942 INFO: pg_controldata:
Nov 23 17:24:33 instance patroni[24823]:   pg_control version number: 1300
Nov 23 17:24:33 instance patroni[24823]:   Catalog version number: 202007201
Nov 23 17:24:33 instance patroni[24823]:   Database system identifier: 7033311346503755640
Nov 23 17:24:33 instance patroni[24823]:   Database cluster state: shut down in recovery
Nov 23 17:24:33 instance patroni[24823]:   pg_control last modified: Tue Nov 23 17:24:23 2021
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint location: 1/B10001B8
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's REDO location: 1/B1000180
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's REDO WAL file: 0000000900000001000000B1
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's TimeLineID: 9
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's PrevTimeLineID: 9
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's full_page_writes: on
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's NextXID: 0:350382
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's NextOID: 16445
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's NextMultiXactId: 1
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's NextMultiOffset: 0
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's oldestXID: 478
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's oldestXID's DB: 1
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's oldestActiveXID: 350382
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's oldestMultiXid: 1
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's oldestMulti's DB: 1
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's oldestCommitTsXid: 0
Nov 23 17:24:33 instance patroni[24823]:   Latest checkpoint's newestCommitTsXid: 0
Nov 23 17:24:33 instance patroni[24823]:   Time of latest checkpoint: Tue Nov 23 14:20:41 2021
Nov 23 17:24:33 instance patroni[24823]:   Fake LSN counter for unlogged rels: 0/3E8
Nov 23 17:24:33 instance patroni[24823]:   Minimum recovery ending location: 1/B2000000
Nov 23 17:24:33 instance patroni[24823]:   Min recovery ending loc's timeline: 9
Nov 23 17:24:33 instance patroni[24823]:   Backup start location: 0/0
Nov 23 17:24:33 instance patroni[24823]:   Backup end location: 0/0
Nov 23 17:24:33 instance patroni[24823]:   End-of-backup record required: no
Nov 23 17:24:33 instance patroni[24823]:   wal_level setting: replica
Nov 23 17:24:33 instance patroni[24823]:   wal_log_hints setting: on
Nov 23 17:24:33 instance patroni[24823]:   max_connections setting: 100
Nov 23 17:24:33 instance patroni[24823]:   max_worker_processes setting: 7
Nov 23 17:24:33 instance patroni[24823]:   max_wal_senders setting: 10
Nov 23 17:24:33 instance patroni[24823]:   max_prepared_xacts setting: 0
Nov 23 17:24:33 instance patroni[24823]:   max_locks_per_xact setting: 64
Nov 23 17:24:33 instance patroni[24823]:   track_commit_timestamp setting: off
Nov 23 17:24:33 instance patroni[24823]:   Maximum data alignment: 8
Nov 23 17:24:33 instance patroni[24823]:   Database block size: 8192
Nov 23 17:24:33 instance patroni[24823]:   Blocks per segment of large relation: 131072
Nov 23 17:24:33 instance patroni[24823]:   WAL block size: 8192
Nov 23 17:24:33 instance patroni[24823]:   Bytes per WAL segment: 16777216
Nov 23 17:24:33 instance patroni[24823]:   Maximum length of identifiers: 64
Nov 23 17:24:33 instance patroni[24823]:   Maximum columns in an index: 32
Nov 23 17:24:33 instance patroni[24823]:   Maximum size of a TOAST chunk: 1996
Nov 23 17:24:33 instance patroni[24823]:   Size of a large-object chunk: 2048
Nov 23 17:24:33 instance patroni[24823]:   Date/time type storage: 64-bit integers
Nov 23 17:24:33 instance patroni[24823]:   Float8 argument passing: by value
Nov 23 17:24:33 instance patroni[24823]:   Data page checksum version: 0
Nov 23 17:24:33 instance patroni[24823]:   Mock authentication nonce: 039244f45c2d26a8a83cce787dbfd234e59113c1612f503e128469c72704ca08
Nov 23 17:24:33 instance patroni[24823]: 2021-11-23 17:24:33,943 INFO: Lock owner: node-dev-d; I am node-dev-a
Nov 23 17:24:33 instance patroni[24823]: 2021-11-23 17:24:33,954 INFO: starting as a secondary
Nov 23 17:24:34 instance patroni[24823]: 2021-11-23 17:24:34.061 UTC [24840] FATAL:  could not open log file "/var/log/postgresql/postgresql-2021-11-23_172434.log": Permission denied
Nov 23 17:24:34 instance patroni[24823]: 2021-11-23 17:24:34.063 UTC [24840] LOG:  database system is shut down
Nov 23 17:24:34 instance patroni[24823]: 2021-11-23 17:24:34,062 INFO: postmaster pid=24840
Nov 23 17:24:34 instance patroni[24823]: localhost:5432 - no response
Nov 23 17:24:35 instance patroni[24823]: 2021-11-23 17:24:35,077 ERROR: postmaster is not running
Nov 23 17:24:35 instance patroni[24823]: 2021-11-23 17:24:35,079 INFO: Lock owner: node-dev-d; I am node-dev-a
Nov 23 17:24:35 instance patroni[24823]: 2021-11-23 17:24:35,082 INFO: failed to start postgres
Nov 23 17:24:40 instance patroni[24823]: 2021-11-23 17:24:40,399 WARNING: Exception happened during processing of request from X.X.X.X:45060
Nov 23 17:24:40 instance patroni[24823]: 2021-11-23 17:24:40,401 WARNING: Traceback (most recent call last):
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/lib/python3.7/socketserver.py", line 650, in process_request_thread
Nov 23 17:24:40 instance patroni[24823]:     self.finish_request(request, client_address)
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/lib/python3.7/socketserver.py", line 360, in finish_request
Nov 23 17:24:40 instance patroni[24823]:     self.RequestHandlerClass(request, client_address, self)
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/lib/python3.7/socketserver.py", line 720, in __init__
Nov 23 17:24:40 instance patroni[24823]:     self.handle()
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/lib/python3.7/http/server.py", line 426, in handle
Nov 23 17:24:40 instance patroni[24823]:     self.handle_one_request()
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/local/lib/python3.7/dist-packages/patroni/api.py", line 636, in handle_one_request
Nov 23 17:24:40 instance patroni[24823]:     BaseHTTPRequestHandler.handle_one_request(self)
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/lib/python3.7/http/server.py", line 414, in handle_one_request
Nov 23 17:24:40 instance patroni[24823]:     method()
Nov 23 17:24:40 instance patroni[24823]:   File "/usr/local/lib/python3.7/dist-packages/patroni/api.py", line 287, in do_GET_metrics
Nov 23 17:24:40 instance patroni[24823]:     metrics.append("patroni_cluster_unlocked{0} {1}".format(scope_label, int(postgres['cluster_unlocked'])))
Nov 23 17:24:40 instance patroni[24823]: KeyError: 'cluster_unlocked'
```

**Have you checked PostgreSQL logs?**
Not relevant here.

**Have you tried to use GitHub issue search?**
As Prometheus API is still freshly introduced, there is no issue about it.

**Additional context**

I've created a PR to fix the issue, I ensure the dictionary have the key `cluster_unlocked` before printing the value.