### PR TITLE
Rearrange tests

### DIFF
--- a/.github/workflows/install_deps.py
+++ b/.github/workflows/install_deps.py
@@ -110,7 +110,7 @@ def install_etcd():
 
 
 def install_postgres():
-    version = os.environ.get('PGVERSION', '12.1-1')
+    version = os.environ.get('PGVERSION', '14.1-1')
     platform = {'darwin': 'osx', 'win32': 'windows-x64', 'cygwin': 'windows-x64'}[sys.platform]
     name = 'postgresql-{0}-{1}-binaries.zip'.format(version, platform)
     get_file('http://get.enterprisedb.com/postgresql/' + name, name)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,15 +30,6 @@ jobs:
       run: python .github/workflows/run_tests.py
       if: matrix.os != 'windows'
 
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.5
-    - name: Install dependencies
-      run: python .github/workflows/install_deps.py
-    - name: Run tests and flake8
-      run: python .github/workflows/run_tests.py
-
     - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
@@ -75,6 +66,15 @@ jobs:
     - name: Run tests and flake8
       run: python .github/workflows/run_tests.py
 
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10
+    - name: Install dependencies
+      run: python .github/workflows/install_deps.py
+    - name: Run tests and flake8
+      run: python .github/workflows/run_tests.py
+
     - name: Combine coverage
       run: python .github/workflows/run_tests.py combine
 
@@ -97,8 +97,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [2.7, 3.5, 3.8]
+        python-version: [2.7, 3.6, 3.9]
         dcs: [etcd, etcd3, consul, exhibitor, kubernetes, raft]
+    if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
 
     steps:
     - uses: actions/checkout@v1
@@ -114,7 +115,7 @@ jobs:
       run: python .github/workflows/run_tests.py
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install coveralls
       run: python -m pip install coveralls
     - name: Upload Coverage
@@ -129,7 +130,7 @@ jobs:
     env:
       DCS: ${{ matrix.dcs }}
       ETCDVERSION: 3.3.13
-      PGVERSION: 12.1-1  # for windows and macos
+      PGVERSION: 14.1-1  # for windows and macos
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,7 +126,7 @@ jobs:
       run: python -m coveralls --service=github
 
   behavem:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}-10.15
     env:
       DCS: ${{ matrix.dcs }}
       ETCDVERSION: 3.3.13

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,15 +88,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.github_token }}
       run: python -m coveralls --service=github
 
-    - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@master
-      env:
-        SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: coverage.xml
-      if: ${{ matrix.os == 'ubuntu' && env.SECRETS_AVAILABLE == 'true' }}
-
   behave:
     runs-on: ${{ matrix.os }}-latest
     env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -132,41 +132,41 @@ jobs:
       run: python -m coveralls --service=github
       if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
 
-  behavem:
-    runs-on: ${{ matrix.os }}-10.15
-    env:
-      DCS: ${{ matrix.dcs }}
-      ETCDVERSION: 3.3.13
-      PGVERSION: 14.1-1  # for windows and macos
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos]  #, windows]
-        python-version: [3.7]
-        dcs: [etcd, etcd3, raft]
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: python .github/workflows/install_deps.py
-    - name: Run behave tests
-      run: python .github/workflows/run_tests.py
-    - name: Install coveralls
-      run: python -m pip install coveralls
-    - name: Upload Coverage
-      env:
-        COVERALLS_FLAG_NAME: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}
-        COVERALLS_PARALLEL: 'true'
-        GITHUB_TOKEN: ${{ secrets.github_token }}
-      run: python -m coveralls --service=github
+#  behavem:
+#    runs-on: ${{ matrix.os }}-latest
+#    env:
+#      DCS: ${{ matrix.dcs }}
+#      ETCDVERSION: 3.3.13
+#      PGVERSION: 14.1-1  # for windows and macos
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [macos]  #, windows]
+#        python-version: [3.7]
+#        dcs: [etcd, etcd3, raft]
+#
+#    steps:
+#    - uses: actions/checkout@v1
+#    - name: Set up Python
+#      uses: actions/setup-python@v2
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#    - name: Install dependencies
+#      run: python .github/workflows/install_deps.py
+#    - name: Run behave tests
+#      run: python .github/workflows/run_tests.py
+#    - name: Install coveralls
+#      run: python -m pip install coveralls
+#    - name: Upload Coverage
+#      env:
+#        COVERALLS_FLAG_NAME: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}
+#        COVERALLS_PARALLEL: 'true'
+#        GITHUB_TOKEN: ${{ secrets.github_token }}
+#      run: python -m coveralls --service=github
 
   coveralls-finish:
     name: Finalize coveralls.io
-    needs: [unit, behave, behavem]
+    needs: [unit, behave]  #, behavem]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,31 +99,38 @@ jobs:
         os: [ubuntu]
         python-version: [2.7, 3.6, 3.9]
         dcs: [etcd, etcd3, consul, exhibitor, kubernetes, raft]
-    if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
 
     steps:
     - uses: actions/checkout@v1
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Add postgresql apt repo
       run: sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Install dependencies
       run: python .github/workflows/install_deps.py
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Run behave tests
       run: python .github/workflows/run_tests.py
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - uses: actions/setup-python@v2
       with:
         python-version: 3.10
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Install coveralls
       run: python -m pip install coveralls
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Upload Coverage
       env:
         COVERALLS_FLAG_NAME: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: 'true'
         GITHUB_TOKEN: ${{ secrets.github_token }}
       run: python -m coveralls --service=github
+      if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
 
   behavem:
     runs-on: ${{ matrix.os }}-10.15

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -132,41 +132,41 @@ jobs:
       run: python -m coveralls --service=github
       if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
 
-#  behavem:
-#    runs-on: ${{ matrix.os }}-latest
-#    env:
-#      DCS: ${{ matrix.dcs }}
-#      ETCDVERSION: 3.3.13
-#      PGVERSION: 14.1-1  # for windows and macos
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [macos]  #, windows]
-#        python-version: [3.7]
-#        dcs: [etcd, etcd3, raft]
-#
-#    steps:
-#    - uses: actions/checkout@v1
-#    - name: Set up Python
-#      uses: actions/setup-python@v2
-#      with:
-#        python-version: ${{ matrix.python-version }}
-#    - name: Install dependencies
-#      run: python .github/workflows/install_deps.py
-#    - name: Run behave tests
-#      run: python .github/workflows/run_tests.py
-#    - name: Install coveralls
-#      run: python -m pip install coveralls
-#    - name: Upload Coverage
-#      env:
-#        COVERALLS_FLAG_NAME: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}
-#        COVERALLS_PARALLEL: 'true'
-#        GITHUB_TOKEN: ${{ secrets.github_token }}
-#      run: python -m coveralls --service=github
+  behavem:
+    runs-on: ${{ matrix.os }}-10.15
+    env:
+      DCS: ${{ matrix.dcs }}
+      ETCDVERSION: 3.3.13
+      PGVERSION: 14.1-1  # for windows and macos
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos]  #, windows]
+        python-version: [3.7]
+        dcs: [etcd, etcd3, raft]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: python .github/workflows/install_deps.py
+    - name: Run behave tests
+      run: python .github/workflows/run_tests.py
+    - name: Install coveralls
+      run: python -m pip install coveralls
+    - name: Upload Coverage
+      env:
+        COVERALLS_FLAG_NAME: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}
+        COVERALLS_PARALLEL: 'true'
+        GITHUB_TOKEN: ${{ secrets.github_token }}
+      run: python -m coveralls --service=github
 
   coveralls-finish:
     name: Finalize coveralls.io
-    needs: [unit, behave]  #, behavem]
+    needs: [unit, behave, behavem]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: python .github/workflows/install_deps.py
     - name: Run tests and flake8
@@ -119,7 +119,7 @@ jobs:
       if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
       if: matrix.python-version != 2.7 || matrix.dcs != 'kubernetes'
     - name: Install coveralls
       run: python -m pip install coveralls

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -51,11 +51,11 @@ Scenario: check the scheduled restart
 	Given I issue a PATCH request to http://127.0.0.1:8008/config with {"postgresql": {"parameters": {"superuser_reserved_connections": "6"}}}
 	Then I receive a response code 200
 		And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 5 seconds
-	Given I issue a scheduled restart at http://127.0.0.1:8008 in 3 seconds with {"role": "replica"}
+	Given I issue a scheduled restart at http://127.0.0.1:8008 in 5 seconds with {"role": "replica"}
 	Then I receive a response code 202
 		And I sleep for 4 seconds
 		And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 10 seconds
-	Given I issue a scheduled restart at http://127.0.0.1:8008 in 3 seconds with {"restart_pending": "True"}
+	Given I issue a scheduled restart at http://127.0.0.1:8008 in 5 seconds with {"restart_pending": "True"}
 	Then I receive a response code 202
 		And Response on GET http://127.0.0.1:8008/patroni does not contain pending_restart after 10 seconds
 		And postgres0 role is the primary after 10 seconds

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -104,12 +104,12 @@ Scenario: check the switchover via the API in the pause mode
 	Then I receive a response code 503
 
 Scenario: check the scheduled switchover
-	Given I issue a scheduled switchover from postgres1 to postgres0 in 3 seconds
+	Given I issue a scheduled switchover from postgres1 to postgres0 in 10 seconds
 	Then I receive a response returncode 1
 	And I receive a response output "Can't schedule switchover in the paused state"
 	When I run patronictl.py resume batman
 	Then I receive a response returncode 0
-	Given I issue a scheduled switchover from postgres1 to postgres0 in 3 seconds
+	Given I issue a scheduled switchover from postgres1 to postgres0 in 5 seconds
 	Then I receive a response returncode 0
 	And postgres0 is a leader after 20 seconds
 	And postgres0 role is the primary after 10 seconds

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -53,7 +53,7 @@ Scenario: check the scheduled restart
 		And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 5 seconds
 	Given I issue a scheduled restart at http://127.0.0.1:8008 in 5 seconds with {"role": "replica"}
 	Then I receive a response code 202
-		And I sleep for 4 seconds
+		And I sleep for 8 seconds
 		And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 10 seconds
 	Given I issue a scheduled restart at http://127.0.0.1:8008 in 5 seconds with {"restart_pending": "True"}
 	Then I receive a response code 202


### PR DESCRIPTION
- remove codacy steps: they removed legacy organizations and there seems to be no easy way of installing codacy app to the Zalando GH.
- Don't run behave on MacOS: recently worker became way to slow
- Disable behave for combination of kubernetes and python 2.7
- Remove python 3.5 (it will be removed by GH from workers in January) and add 3.10
- Run behave with 3.6 and 3.9 instead of 3.5 and 3.8