### PR TITLE
Print "no action" run_cycle message at most every minute

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -171,7 +171,7 @@ class Ha(object):
     def has_lock(self, info=True):
         lock_owner = self.cluster.leader and self.cluster.leader.name
         if info:
-            logger.info('Lock owner: %s; I am %s', lock_owner, self.state_handler.name)
+            logger.debug('Lock owner: %s; I am %s', lock_owner, self.state_handler.name)
         return lock_owner == self.state_handler.name
 
     def get_effective_tags(self):


### PR DESCRIPTION
I was getting annoyed at the overly chatty Patroni log if there are now problems and `loop_wait` is at the default 10 seconds.

So this prints the "no action.[...]" line only once every minute.