### PR TITLE
Use replication credentials when checking leader status

### DIFF
--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -165,7 +165,7 @@ class Rewind(object):
             return
 
         if not self.check_leader_is_not_in_recovery(
-                self._conn_kwargs(leader, self._postgresql.config.rewind_credentials)):
+                self._conn_kwargs(leader, self._postgresql.config.replication)):
             return
 
         history = need_rewind = None


### PR DESCRIPTION
It could be that `remove_data_directory_on_diverged_timelines` is set, but there is no `rewind_credentials` defined and superuser access between nodes is not allowed.

Close https://github.com/zalando/patroni/issues/2162