### PR TITLE
Add target_session_attrs=read-write to standby_leader primary_conninfo

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -484,7 +484,6 @@ class ConfigHandler(object):
         # (libpq client-side failover) making sure we hit the primary
         if 'target_session_attrs' not in ret and self._postgresql.major_version >= 100000:
             ret.setdefault('target_session_attrs', 'read-write')
-        logger.info('primary_conninfo_params, returning %s', ret)
         return ret
 
     def format_dsn(self, params, include_dbname=False):

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -482,7 +482,7 @@ class ConfigHandler(object):
             del ret['dbname']
         # Add target_session_attrs in case more than one hostname is specified
         # (libpq client-side failover) making sure we hit the primary
-        if not 'target_session_attrs' in ret and self._postgresql.major_version >= 100000:
+        if 'target_session_attrs' not in ret and self._postgresql.major_version >= 100000:
             ret.setdefault('target_session_attrs', 'read-write')
         logger.info('primary_conninfo_params, returning %s', ret)
         return ret

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -156,7 +156,7 @@ class Rewind(object):
             ret['dbname'] = self._postgresql.database
         # Add target_session_attrs in case more than one hostname is specified
         # (libpq client-side failover) making sure we hit the primary
-        if not 'target_session_attrs' in ret and self._postgresql.major_version >= 100000:
+        if 'target_session_attrs' not in ret and self._postgresql.major_version >= 100000:
             ret['target_session_attrs'] = 'read-write'
         return ret
 

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -154,6 +154,10 @@ class Rewind(object):
         ret = member.conn_kwargs(auth)
         if not ret.get('dbname'):
             ret['dbname'] = self._postgresql.database
+        # Add target_session_attrs in case more than one hostname is specified
+        # (libpq client-side failover) making sure we hit the primary
+        if not 'target_session_attrs' in ret and self._postgresql.major_version >= 100000:
+            ret['target_session_attrs'] = 'read-write'
         return ret
 
     def _check_timeline_and_lsn(self, leader):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -260,8 +260,8 @@ class TestPostgresql(BaseTestPostgresql):
         with patch('patroni.postgresql.config.ConfigHandler.primary_conninfo_params', Mock(return_value=conninfo)):
             mock_get_pg_settings.return_value['recovery_min_apply_delay'][1] = '1'
             self.assertEqual(self.p.config.check_recovery_conf(None), (True, True))
-            mock_get_pg_settings.return_value['primary_conninfo'][1] = 'host=1 passfile='\
-                + re.sub(r'([\'\\ ])', r'\\\1', self.p.config._pgpass)
+            mock_get_pg_settings.return_value['primary_conninfo'][1] = 'host=1 target_session_attrs=read-write'\
+                + ' passfile=' + re.sub(r'([\'\\ ])', r'\\\1', self.p.config._pgpass)
             mock_get_pg_settings.return_value['recovery_min_apply_delay'][1] = '0'
             self.assertEqual(self.p.config.check_recovery_conf(None), (True, True))
             self.p.config.write_recovery_conf({'standby_mode': 'on', 'primary_conninfo': conninfo.copy()})


### PR DESCRIPTION
This allows to have multiple hosts in a standby_cluster and ensures that the
standby leader follows the main cluster's new leader after a switchover.

Addresses #2189