### PR TITLE
Avoid running CHECKPOINT on remote master if credentials are missing

### DIFF
--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -431,7 +431,6 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: no action. I am (postgresql0)')
 
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))
-    @patch.object(Rewind, 'check_leader_has_run_checkpoint', Mock(return_value=True))
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))
     def test_follow_triggers_rewind(self):
         self.p.is_leader = false
@@ -793,7 +792,6 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(), 'promoted self to a standby leader by acquiring session lock')
 
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))
-    @patch.object(Rewind, 'check_leader_has_run_checkpoint', Mock(return_value=True))
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))
     def test_process_unhealthy_standby_cluster_as_cascade_replica(self):
         self.p.is_leader = false

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -431,6 +431,7 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(), 'PAUSE: no action. I am (postgresql0)')
 
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))
+    @patch.object(Rewind, 'check_leader_has_run_checkpoint', Mock(return_value=True))
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))
     def test_follow_triggers_rewind(self):
         self.p.is_leader = false
@@ -792,6 +793,7 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(), 'promoted self to a standby leader by acquiring session lock')
 
     @patch.object(Rewind, 'rewind_or_reinitialize_needed_and_possible', Mock(return_value=True))
+    @patch.object(Rewind, 'check_leader_has_run_checkpoint', Mock(return_value=True))
     @patch.object(Rewind, 'can_rewind', PropertyMock(return_value=True))
     def test_process_unhealthy_standby_cluster_as_cascade_replica(self):
         self.p.is_leader = false


### PR DESCRIPTION
This adds pg_start_backup and pg_stop_backup to the list of functions that are
granted to the rewind user on bootstrap, and uses the rewind credentials to run
those functions rather than `CHECKPOINT` itself in the checkpoint() function.

I wonder whether `checkpoint()` should figure out whether it is being run as a
superuser or not, and still run `CHECKPOINT` directly if it could?

See https://github.com/zalando/patroni/issues/2194#issuecomment-1025138990 for context.