### PR TITLE
Add metrics

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -293,6 +293,11 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_dcs_last_seen gauge")
         metrics.append("patroni_dcs_last_seen{0} {1}".format(scope_label, postgres.get('dcs_last_seen', 0)))
 
+        metrics.append("# HELP patroni_pending_restart Value is 1 if cluster need a restart, 0 if not.")
+        metrics.append("# TYPE patroni_pending_restart gauge")
+        metrics.append("patroni_pending_restart{0} {1}"
+                       .format(scope_label, int(patroni.postgresql.pending_restart == True)))
+
         self._write_response(200, '\n'.join(metrics)+'\n', content_type='text/plain')
 
     def _read_json_content(self, body_is_optional=False):

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -293,7 +293,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_dcs_last_seen gauge")
         metrics.append("patroni_dcs_last_seen{0} {1}".format(scope_label, postgres.get('dcs_last_seen', 0)))
 
-        metrics.append("# HELP patroni_pending_restart Value is 1 if cluster need a restart, 0 otherwise.")
+        metrics.append("# HELP patroni_pending_restart Value is 1 if cluster needs a restart, 0 otherwise.")
         metrics.append("# TYPE patroni_pending_restart gauge")
         metrics.append("patroni_pending_restart{0} {1}"
                        .format(scope_label, int(patroni.postgresql.pending_restart)))

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -293,10 +293,15 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_dcs_last_seen gauge")
         metrics.append("patroni_dcs_last_seen{0} {1}".format(scope_label, postgres.get('dcs_last_seen', 0)))
 
-        metrics.append("# HELP patroni_pending_restart Value is 1 if cluster need a restart, 0 if not.")
+        metrics.append("# HELP patroni_pending_restart Value is 1 if cluster need a restart, 0 otherwise.")
         metrics.append("# TYPE patroni_pending_restart gauge")
         metrics.append("patroni_pending_restart{0} {1}"
                        .format(scope_label, int(patroni.postgresql.pending_restart == True)))
+
+        metrics.append("# HELP patroni_is_paused Value is 1 if auto failover is disabled, 0 otherwise.")
+        metrics.append("# TYPE patroni_is_paused gauge")
+        metrics.append("patroni_is_paused{0} {1}"
+                       .format(scope_label, int(patroni.ha.is_paused() == True)))
 
         self._write_response(200, '\n'.join(metrics)+'\n', content_type='text/plain')
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -296,12 +296,12 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_pending_restart Value is 1 if cluster need a restart, 0 otherwise.")
         metrics.append("# TYPE patroni_pending_restart gauge")
         metrics.append("patroni_pending_restart{0} {1}"
-                       .format(scope_label, int(patroni.postgresql.pending_restart == True)))
+                       .format(scope_label, int(patroni.postgresql.pending_restart)))
 
         metrics.append("# HELP patroni_is_paused Value is 1 if auto failover is disabled, 0 otherwise.")
         metrics.append("# TYPE patroni_is_paused gauge")
         metrics.append("patroni_is_paused{0} {1}"
-                       .format(scope_label, int(patroni.ha.is_paused() == True)))
+                       .format(scope_label, int(patroni.ha.is_paused())))
 
         self._write_response(200, '\n'.join(metrics)+'\n', content_type='text/plain')
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -293,7 +293,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# TYPE patroni_dcs_last_seen gauge")
         metrics.append("patroni_dcs_last_seen{0} {1}".format(scope_label, postgres.get('dcs_last_seen', 0)))
 
-        metrics.append("# HELP patroni_pending_restart Value is 1 if cluster needs a restart, 0 otherwise.")
+        metrics.append("# HELP patroni_pending_restart Value is 1 if the node needs a restart, 0 otherwise.")
         metrics.append("# TYPE patroni_pending_restart gauge")
         metrics.append("patroni_pending_restart{0} {1}"
                        .format(scope_label, int(patroni.postgresql.pending_restart)))


### PR DESCRIPTION
This PR adds metrics for additional information : 
  - If a node or cluster is pending restart,
  - If the cluster management is paused. 

This may be useful for Prometheus/Grafana monitoring.
Addresses #2198