### PR TITLE
Fix cluster initialization crash with some specific initial password

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -264,7 +264,7 @@ class Postgresql(object):
         cursor = None
         try:
             cursor = self._connection.cursor()
-            cursor.execute(sql, params)
+            cursor.execute(sql, params or None)
             return cursor
         except psycopg.Error as e:
             if cursor and cursor.connection.closed == 0:

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -91,7 +91,7 @@ bootstrap:
   # Some additional users users which needs to be created after initializing new cluster
   users:
     admin:
-      password: admin
+      password: admin%
       options:
         - createrole
         - createdb

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -85,7 +85,7 @@ bootstrap:
   # Some additional users users which needs to be created after initializing new cluster
   users:
     admin:
-      password: admin
+      password: admin%
       options:
         - createrole
         - createdb

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -82,7 +82,7 @@ bootstrap:
   # Some additional users users which needs to be created after initializing new cluster
   users:
     admin:
-      password: admin
+      password: admin%
       options:
         - createrole
         - createdb


### PR DESCRIPTION
Fix cluster initialization crash when users configuration contain passwords with `%` character. 

See #2209 for more information.