### PR TITLE
fix AttributeError no attribute 'leader'

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -796,7 +796,7 @@ class Ha(object):
 
         # When in sync mode, only last known master and sync standby are allowed to promote automatically.
         all_known_members = self.cluster.members + self.old_cluster.members
-        if self.is_synchronous_mode() and self.cluster.sync.leader:
+        if self.is_synchronous_mode() and self.cluster.sync and self.cluster.sync.leader:
             if not self.cluster.sync.matches(self.state_handler.name):
                 return False
             # pick between synchronous candidates so we minimize unnecessary failovers/demotions


### PR DESCRIPTION
Hi when I was using Raft DC and sync mode I have encountered:
```
2022-02-14 12:58:56,025 WARNING: Loop time exceeded, rescheduling immediately.
2022-02-14 12:59:02,043 ERROR: Unexpected exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/patroni/ha.py", line 1502, in run_cycle
    info = self._run_cycle()
  File "/usr/local/lib/python3.9/dist-packages/patroni/ha.py", line 1464, in _run_cycle
    ret = self.process_unhealthy_cluster()
  File "/usr/local/lib/python3.9/dist-packages/patroni/ha.py", line 970, in process_unhealthy_cluster
    if self.is_healthiest_node():
  File "/usr/local/lib/python3.9/dist-packages/patroni/ha.py", line 799, in is_healthiest_node
    if self.is_synchronous_mode() and self.cluster.sync.leader:
AttributeError: 'NoneType' object has no attribute 'leader'
2022-02-14 12:59:02,043 INFO: Unexpected exception raised, please report it as a BUG
2022-02-14 12:59:02,044 WARNING: Loop time exceeded, rescheduling immediately.
...
```

Basically it doesn't proceed past this point. 