### PR TITLE
Handle the TypeError exception

### DIFF
--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -109,6 +109,10 @@ class TestSlotsHandler(BaseTestPostgresql):
         self.s.copy_logical_slots(self.cluster, ['ls'])
         self.assertEqual(self.s.sync_replication_slots(self.cluster, False), [])
         with patch.object(MockCursor, 'rowcount', PropertyMock(return_value=1), create=True):
+            with patch.object(MockCursor, 'fetchone', Mock(side_effect=[(None,), Exception])):
+                self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, False, None))
+            with patch.object(MockCursor, 'fetchone', Mock(side_effect=[(None,), (False,)])):
+                self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, False, None))
             self.s.check_logical_slots_readiness(self.cluster, False, None)
 
     @patch.object(Postgresql, 'stop', Mock(return_value=True))


### PR DESCRIPTION
```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

It could happen when the replica didn't start to stream using the replication slot on the primary.

Also, it could be the symptom of a different issue: `hot_standby_feedback` is disabled.

The last one we can check and show the annoying error in the log.