### PR TITLE
Handle expired token for etcd lease_grant (#2331)

### DIFF
--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -315,6 +315,7 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
     def prefix(self, key, retry=None):
         return self.range(key, prefix_range_end(key), retry)
 
+    @_handle_auth_errors
     def lease_grant(self, ttl, retry=None):
         return self.call_rpc('/lease/grant', {'TTL': ttl}, retry)['ID']
 


### PR DESCRIPTION
If pass an expired token for lease_grant, it will
report `invalid auth token` error.

For lease_keepalive, etcd server don't check token
header at all.