### PR TITLE
Automatically skip some behave tests on legacy Postgres

### DIFF
--- a/.github/workflows/run_tests.py
+++ b/.github/workflows/run_tests.py
@@ -28,16 +28,15 @@ def main():
         version = versions.get(what)
         path = '/usr/lib/postgresql/{0}/bin:.'.format(version)
         unbuffer = ['timeout', '900', 'unbuffer']
-        args = ['--tags=-skip'] if what == 'etcd' else []
     else:
         path = os.path.abspath(os.path.join('pgsql', 'bin'))
         if sys.platform == 'darwin':
             path += ':.'
-        args = unbuffer = []
+        unbuffer = []
     env['PATH'] = path + os.pathsep + env['PATH']
     env['DCS'] = what
 
-    ret = subprocess.call(unbuffer + [sys.executable, '-m', 'behave'] + args, env=env)
+    ret = subprocess.call(unbuffer + [sys.executable, '-m', 'behave'], env=env)
 
     if ret != 0:
         if subprocess.call('grep . features/output/*_failed/*postgres?.*', shell=True) != 0:

--- a/features/environment.py
+++ b/features/environment.py
@@ -903,3 +903,11 @@ def after_feature(context, feature):
     context.dcs_ctl.cleanup_service_tree()
     if feature.status == 'failed':
         shutil.copytree(context.pctl.output_dir, context.pctl.output_dir + '_failed')
+
+
+def before_scenario(context, scenario):
+    if 'skip-legacy' in scenario.effective_tags:
+        for p in context.pctl._processes.values():
+            if p._conn and p._conn.server_version < 110000:
+                scenario.skip('Unsupported PostgreSQL version {0}'.format(p._conn.server_version))
+                break

--- a/features/environment.py
+++ b/features/environment.py
@@ -906,8 +906,8 @@ def after_feature(context, feature):
 
 
 def before_scenario(context, scenario):
-    if 'skip-legacy' in scenario.effective_tags:
+    if 'slot-advance' in scenario.effective_tags:
         for p in context.pctl._processes.values():
             if p._conn and p._conn.server_version < 110000:
-                scenario.skip('Unsupported PostgreSQL version {0}'.format(p._conn.server_version))
+                scenario.skip('pg_replication_slot_advance() is not supported on {0}'.format(p._conn.server_version))
                 break

--- a/features/standby_cluster.feature
+++ b/features/standby_cluster.feature
@@ -14,7 +14,7 @@ Feature: standby cluster
     Then "members/postgres0" key in DCS has state=running after 10 seconds
     And replication works from postgres1 to postgres0 after 15 seconds
 
-  @skip
+  @skip-legacy
   Scenario: check permanent logical slots are synced to the replica
     Given I run patronictl.py restart batman postgres1 --force
     Then Logical slot test_logical is in sync between postgres0 and postgres1 after 10 seconds

--- a/features/standby_cluster.feature
+++ b/features/standby_cluster.feature
@@ -14,7 +14,7 @@ Feature: standby cluster
     Then "members/postgres0" key in DCS has state=running after 10 seconds
     And replication works from postgres1 to postgres0 after 15 seconds
 
-  @skip-legacy
+  @slot-advance
   Scenario: check permanent logical slots are synced to the replica
     Given I run patronictl.py restart batman postgres1 --force
     Then Logical slot test_logical is in sync between postgres0 and postgres1 after 10 seconds


### PR DESCRIPTION
previously behave had to be started with `--tags=-skip` argument.