### PR TITLE
Make backup copies of configuration files in config_dir

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -362,7 +362,7 @@ class ConfigHandler(object):
             try:
                 for f in self._configuration_to_save:
                     config_file = os.path.join(self._config_dir, f)
-                    backup_file = os.path.join(self._postgresql.data_dir, f + '.backup')
+                    backup_file = os.path.join(self._config_dir, f + '.backup')
                     if os.path.isfile(config_file):
                         shutil.copy(config_file, backup_file)
             except IOError:
@@ -374,7 +374,7 @@ class ConfigHandler(object):
         try:
             for f in self._configuration_to_save:
                 config_file = os.path.join(self._config_dir, f)
-                backup_file = os.path.join(self._postgresql.data_dir, f + '.backup')
+                backup_file = os.path.join(self._config_dir, f + '.backup')
                 if not os.path.isfile(config_file):
                     if os.path.isfile(backup_file):
                         shutil.copy(backup_file, config_file)


### PR DESCRIPTION
Before, the .backup files were always stored in the data directory. However, if
there is a distinct configuration directory, it seems logical to put them
there. If config_dir is not configured, it defaults back to the data directory,
so this will not change things for setups where postgresql.conf is in the data
directory.

On the other hand, it will help with setups where postgresql.conf is outside
the data directory and has local changes. In this case, those no longer get
overwritten on boostrap/clone from the primary's backup configuration file that
is streamed to the boostrapped node.

Close #2370