### PR TITLE
Compatibility with the latest flake8

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 psycopg2-binary
 behave
 coverage
-flake8
+flake8>=3.0.0
 mock
 pytest-cov
 pytest

--- a/setup.py
+++ b/setup.py
@@ -93,12 +93,10 @@ class Flake8(_Command):
         return [package for package in self.package_files()] + ['tests', 'setup.py']
 
     def run(self):
-        from flake8.main import application
+        from flake8.main.cli import main
 
         logging.getLogger().setLevel(logging.ERROR)
-        flake8 = application.Application()
-        flake8.run(self.targets())
-        flake8.exit()
+        main(self.targets())
 
 
 class PyTest(_Command):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -35,7 +35,7 @@ def mock_ioctl(fd, op, arg=None, mutate_flag=False):
     sys.stderr.write("Ioctl %d %d %r\n" % (fd, op, arg))
     if op == linuxwd.WDIOC_GETSUPPORT:
         sys.stderr.write("Get support\n")
-        assert(mutate_flag is True)
+        assert (mutate_flag is True)
         arg.options = sum(map(linuxwd.WDIOF.get, ['SETTIMEOUT', 'KEEPALIVEPING']))
         arg.identity = (ctypes.c_ubyte*32)(*map(ord, 'Mock Watchdog'))
     elif op == linuxwd.WDIOC_GETTIMEOUT:


### PR DESCRIPTION
Require flake8 at least 3.0.0 and just call main()