### PR TITLE
Ignore 403s when access to Kubernetes Service is not needed

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -950,7 +950,8 @@ class Kubernetes(AbstractDCS):
             if not self._api.create_namespaced_service(self._namespace, body):
                 return
         except Exception as e:
-            if not isinstance(e, k8s_client.rest.ApiException) or e.status != 409:  # Service already exists
+            if not isinstance(e, k8s_client.rest.ApiException) or e.status != 409 or e.status != 403:
+                # Service already exists
                 return logger.exception('create_config_service failed')
         self._should_create_config_service = False
 


### PR DESCRIPTION
When running patroni on Kubernetes the logs are spammed with access errors checking if the Service exists.  According to the [documentation](https://github.com/zalando/patroni/blob/0b1b1e3b542714b47634391f7dbb00016d885bff/kubernetes/patroni_k8s.yaml#L190-L193) access to the Service is not needed.  This is an attempt to fix issue #1132 or at least do not log when the ServiceAccount doesn't have access to Service.