### PR TITLE
Remove 'enable_group_by_reordering' from GUC validator

### DIFF
--- a/patroni/postgresql/validator.py
+++ b/patroni/postgresql/validator.py
@@ -200,7 +200,6 @@ parameters = CaseInsensitiveDict({
     'enable_async_append': Bool(140000, None),
     'enable_bitmapscan': Bool(90300, None),
     'enable_gathermerge': Bool(100000, None),
-    'enable_group_by_reordering': Bool(150000, None),
     'enable_hashagg': Bool(90300, None),
     'enable_hashjoin': Bool(90300, None),
     'enable_incremental_sort': Bool(130000, None),


### PR DESCRIPTION
The feature was recently reverted: https://github.com/postgres/postgres/commit/443df6e2db932a7cd6d85ddfb67e11a43345130d