### PR TITLE
logging: Log no action messages at debug level

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -105,7 +105,11 @@ class Patroni(AbstractPatroniDaemon):
         super(Patroni, self).run()
 
     def _run_cycle(self):
-        logger.info(self.ha.run_cycle())
+        msg = self.ha.run_cycle()
+        if msg.startswith('no action'):
+            logger.debug(msg)
+        else:
+            logger.info(msg)
 
         if self.dcs.cluster and self.dcs.cluster.config and self.dcs.cluster.config.data \
                 and self.config.set_dynamic_configuration(self.dcs.cluster.config):


### PR DESCRIPTION
There's a few issues floating around about the verbosity of logged messages that start with 'no action'. PR #2161 attempts to resolve this by reducing how often the messages are printed. This PR instead changes the severity level which is easy enough to reconfigure.

This should fix #1154, #1800 and #621. It would also help with #1203.