### PR TITLE
Declare proxy_address as optional

### DIFF
--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -370,7 +370,7 @@ schema = Schema({
   "postgresql": {
     "listen": validate_host_port_listen_multiple_hosts,
     "connect_address": validate_connect_address,
-    "proxy_address": validate_connect_address,
+    Optional("proxy_address"): validate_connect_address,
     "authentication": {
       "replication": userattributes,
       "superuser": userattributes,


### PR DESCRIPTION
It's effectively non-required when used in patroni/postgresql/config.py. This breaks most configuration files in the wild, starting from the examples:

    $ patroni --validate-config postgres0.yml
    restapi.connect_address 127.0.0.1:8008 didn't pass validation: 'must not contain "127.0.0.1", "0.0.0.0", "*", "::1", "localhost"'
    etcd.host 127.0.0.1:2379 didn't pass validation: '127.0.0.1:2379 is not reachable'
    postgresql.connect_address 127.0.0.1:5432 didn't pass validation: 'must not contain "127.0.0.1", "0.0.0.0", "*", "::1", "localhost"'
    postgresql.proxy_address  is not defined.