### PR TITLE
Ensure watchdog configuration matches bootstrap.dcs config and log changes

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -23,9 +23,9 @@ class Patroni(AbstractPatroniDaemon):
 
         self.version = __version__
         self.dcs = get_dcs(self.config)
-        self.watchdog = Watchdog(self.config)
         self.load_dynamic_configuration()
 
+        self.watchdog = Watchdog(self.config)
         self.postgresql = Postgresql(self.config['postgresql'])
         self.api = RestApiServer(self, self.config['restapi'])
         self.request = PatroniRequest(self.config, True)
@@ -43,7 +43,8 @@ class Patroni(AbstractPatroniDaemon):
                 if cluster and cluster.config and cluster.config.data:
                     if self.config.set_dynamic_configuration(cluster.config):
                         self.dcs.reload_config(self.config)
-                        self.watchdog.reload_config(self.config)
+                        if getattr(self, "watchdog", None):
+                            self.watchdog.reload_config(self.config)
                 elif not self.config.dynamic_configuration and 'bootstrap' in self.config:
                     if self.config.set_dynamic_configuration(self.config['bootstrap']['dcs']):
                         self.dcs.reload_config(self.config)

--- a/patroni/watchdog/base.py
+++ b/patroni/watchdog/base.py
@@ -215,6 +215,10 @@ class Watchdog(object):
                     self._activate()
                 if self.config.timeout != self.active_config.timeout:
                     self.impl.set_timeout(self.config.timeout)
+                    if self.is_running:
+                        logger.info("{0} updated with {1} second timeout, timing slack {2} seconds"
+                                    .format(self.impl.describe(), self.impl.get_timeout(), self.config.timing_slack))
+                self.active_config = self.config
         except WatchdogError as e:
             logger.error("Error while sending keepalive: %s", e)
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -164,6 +164,13 @@ class TestWatchdog(unittest.TestCase):
 
         watchdog.reload_config({'ttl': 60, 'loop_wait': 15, 'watchdog': {'mode': 'required'}})
         watchdog.keepalive()
+        self.assertTrue(watchdog.is_running)
+        self.assertEqual(watchdog.config.timeout, 60 - 5)
+
+        watchdog.reload_config({'ttl': 60, 'loop_wait': 15, 'watchdog': {'mode': 'required', 'safety_margin': -1}})
+        watchdog.keepalive()
+        self.assertTrue(watchdog.is_running)
+        self.assertEqual(watchdog.config.timeout, 60 // 2)
 
 
 class TestNullWatchdog(unittest.TestCase):


### PR DESCRIPTION
Fix issue of patroni configuring watchdog with defaults when bootstrapping a new cluster rather than taking configuration used to bootstrap the DCS.
Also log changes to watchdog configuration based on calculated timeout value.

Ref #2470 