### PR TITLE
Fix the way extensions are treated while finding executables in WIN32

### DIFF
--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -519,8 +519,8 @@ def enable_keepalive(sock, timeout, idle, cnt=3):
 def find_executable(executable, path=None):
     _, ext = os.path.splitext(executable)
 
-    if (sys.platform == 'win32') and (ext != '.exe'):
-        executable = executable + '.exe'
+    if (sys.platform == 'win32') and (ext == ''):
+        executable = executable + '.exe'  # Set default WIN extension
 
     if os.path.isfile(executable):
         return executable


### PR DESCRIPTION
In the `find_executable()` function we split the extension of the file name passed from the base of the file name. In the case of WIN32, patroni will append a `.exe` if the current extension is not `.exe`.

This brings the wrong behavior given that `more` in WIN32 is `more.com` and not `more.exe`. This also makes the pager setting from `ctl.py` fail as the code changes `more.com` (hardcoded in `ctl.py`) for `more.com.exe`.

This change adjusts the behavior only to add the `.exe` if the executable variable doesn't have an extension.

A better solution would be to *not* modify the name of the executable that is being passed, as that is what we are looking for. But that might have other consequences, so it would require further testing.

Signed-off-by: Martín Marqués <martin.marques@enterprisedb.com>