### PR TITLE
The Consul TTL is off by twice from reality

### DIFF
--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -272,7 +272,7 @@ class Consul(AbstractDCS):
 
     @property
     def ttl(self):
-        return self._client.http.ttl
+        return self._client.http.ttl * 2
 
     def set_retry_timeout(self, retry_timeout):
         self._retry.deadline = retry_timeout

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -272,7 +272,7 @@ class Consul(AbstractDCS):
 
     @property
     def ttl(self):
-        return self._client.http.ttl * 2
+        return self._client.http.ttl * 2  # we multiply the value by 2 because it was divided in the `set_ttl()` method
 
     def set_retry_timeout(self, retry_timeout):
         self._retry.deadline = retry_timeout


### PR DESCRIPTION
we use `ttl/2.0` when setting the value on the HTTPClient, but forgot to multiply the current value by 2.