### PR TITLE
Start etcd with V2 API enabled for V2 etcd acceptance tests

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -441,7 +441,7 @@ class AbstractEtcdController(AbstractDcsController):
         self._client_cls = client_cls
 
     def _start(self):
-        return subprocess.Popen(["etcd", "--data-dir", self._work_directory],
+        return subprocess.Popen(["etcd", "--enable-v2=true", "--data-dir", self._work_directory],
                                 stdout=self._log, stderr=subprocess.STDOUT)
 
     def _is_running(self):


### PR DESCRIPTION
Otherwise, the etcd (not etcd3) behave tests fail to connect:
```
Jan 02 09:56:18 HOOK-ERROR in before_all: AssertionError: etcd instance is not available for queries after 5 seconds
```