### PR TITLE
Bump postgres version to 11 when running  github action tests

### DIFF
--- a/.github/workflows/mapping.py
+++ b/.github/workflows/mapping.py
@@ -1,1 +1,1 @@
-versions = {'etcd': '9.6', 'etcd3': '14', 'consul': '13', 'exhibitor': '12', 'raft': '11', 'kubernetes': '15'}
+versions = {'etcd': '11', 'etcd3': '14', 'consul': '13', 'exhibitor': '12', 'raft': '11', 'kubernetes': '15'}


### PR DESCRIPTION
When running the github tests, versions of postgres are taken from the `version` dictionary in `mapping.py`.

The version for DCS `etcd` is to use postgres 9.6. Sadly, this version is out of support and not available in some distribution repositories (we'd need to use archived repositories to get older versions of postgres).

As stated above, 9.6, and also 10, are not supported anymore so it's much better to test on supported software.

The commit pushes the version to be used in tests wity etcd to postgres 11, and closes #2510.

Signed-off-by: Martín Marqués <martin.marques@enterprisedb.com>