### PR TITLE
Fix behave tests on GH actions MacOS

### DIFF
--- a/.github/workflows/install_deps.py
+++ b/.github/workflows/install_deps.py
@@ -96,7 +96,7 @@ def unpack(archive, name):
 
 
 def install_etcd():
-    version = os.environ.get('ETCDVERSION', '3.3.13')
+    version = os.environ.get('ETCDVERSION', '3.4.23')
     platform = {'linux2': 'linux', 'win32': 'windows', 'cygwin': 'windows'}.get(sys.platform, sys.platform)
     dirname = 'etcd-v{0}-{1}-amd64'.format(version, platform)
     ext = 'tar.gz' if platform == 'linux' else 'zip'
@@ -108,16 +108,17 @@ def install_etcd():
 
 
 def install_postgres():
-    version = os.environ.get('PGVERSION', '14.1-1')
+    version = os.environ.get('PGVERSION', '15.1-1')
     platform = {'darwin': 'osx', 'win32': 'windows-x64', 'cygwin': 'windows-x64'}[sys.platform]
+    if platform == 'osx':
+        return subprocess.call(['brew', 'install', 'expect', 'postgresql@{0}'.format(version.split('.')[0])])
     name = 'postgresql-{0}-{1}-binaries.zip'.format(version, platform)
     get_file('http://get.enterprisedb.com/postgresql/' + name, name)
     unzip_all(name)
     bin_dir = os.path.join('pgsql', 'bin')
     for f in os.listdir(bin_dir):
         chmod_755(os.path.join(bin_dir, f))
-    subprocess.call(['pgsql/bin/postgres', '-V'])
-    return 0
+    return subprocess.call(['pgsql/bin/postgres', '-V'])
 
 
 def main():

--- a/.github/workflows/run_tests.py
+++ b/.github/workflows/run_tests.py
@@ -29,10 +29,13 @@ def main():
         path = '/usr/lib/postgresql/{0}/bin:.'.format(version)
         unbuffer = ['timeout', '900', 'unbuffer']
     else:
-        path = os.path.abspath(os.path.join('pgsql', 'bin'))
         if sys.platform == 'darwin':
-            path += ':.'
-        unbuffer = []
+            version = os.environ.get('PGVERSION', '15.1-1')
+            path = '/usr/local/opt/postgresql@{0}/bin:.'.format(version.split('.')[0])
+            unbuffer = ['unbuffer']
+        else:
+            path = os.path.abspath(os.path.join('pgsql', 'bin'))
+            unbuffer = []
     env['PATH'] = path + os.pathsep + env['PATH']
     env['DCS'] = what
     if what == 'kubernetes':
@@ -43,6 +46,7 @@ def main():
     if ret != 0:
         if subprocess.call('grep . features/output/*_failed/*postgres?.*', shell=True) != 0:
             subprocess.call('grep . features/output/*/*postgres?.*', shell=True)
+            subprocess.call('grep . features/output/*', shell=True)
         return 1
     return 0
 

--- a/.github/workflows/run_tests.py
+++ b/.github/workflows/run_tests.py
@@ -41,14 +41,7 @@ def main():
     if what == 'kubernetes':
         env['PATRONI_KUBERNETES_CONTEXT'] = 'k3d-k3s-default'
 
-    ret = subprocess.call(unbuffer + [sys.executable, '-m', 'behave'], env=env)
-
-    if ret != 0:
-        if subprocess.call('grep . features/output/*_failed/*postgres?.*', shell=True) != 0:
-            subprocess.call('grep . features/output/*/*postgres?.*', shell=True)
-            subprocess.call('grep . features/output/*', shell=True)
-        return 1
-    return 0
+    return subprocess.call(unbuffer + [sys.executable, '-m', 'behave'], env=env)
 
 
 if __name__ == '__main__':

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,8 +92,8 @@ jobs:
     runs-on: ${{ fromJson('{"ubuntu":"ubuntu-20.04","windows":"windows-latest","macos":"macos-latest"}')[matrix.os] }}
     env:
       DCS: ${{ matrix.dcs }}
-      ETCDVERSION: 3.3.13
-      PGVERSION: 12.1-1  # for windows and macos
+      ETCDVERSION: 3.4.23
+      PGVERSION: 15.1-1  # for windows and macos
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -133,6 +133,17 @@ jobs:
       run: python .github/workflows/install_deps.py
     - name: Run behave tests
       run: python .github/workflows/run_tests.py
+    - name: Upload logs if behave failed
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}-logs
+        path: |
+          features/output/*_failed/*postgres?.*
+          features/output/*/*postgres?.*
+          features/output/*
+        if-no-files-found: error
+        retention-days: 5
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -140,7 +140,6 @@ jobs:
         name: behave-${{ matrix.os }}-${{ matrix.dcs }}-${{ matrix.python-version }}-logs
         path: |
           features/output/*_failed/*postgres?.*
-          features/output/*/*postgres?.*
           features/output/*
         if-no-files-found: error
         retention-days: 5


### PR DESCRIPTION
- the new MacOS doesn't play well with old go binaries (bump etcd)
- use brew to install Postgres and expect (unbuffer, to make behave output colorful) and use the latest version
- upload failed logs instead of grepping them to stdout