### PR TITLE
Submit coverage to codacy only if secret is available

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,10 @@ on:
     tags:
     - v.*
 
+env:
+  CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+
 jobs:
   unit:
     runs-on: ${{ fromJson('{"ubuntu":"ubuntu-20.04","windows":"windows-latest","macos":"macos-latest"}')[matrix.os] }}
@@ -147,9 +151,6 @@ jobs:
       run: python -m coverage xml -o cobertura.xml
     - name: Upload coverage to Codacy
       run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r cobertura.xml -l Python --partial
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
       if: ${{ env.SECRETS_AVAILABLE == 'true' }}
 
   coveralls-finish:
@@ -169,7 +170,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: bash <(curl -Ls https://coverage.codacy.com/get.sh) final
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
       if: ${{ env.SECRETS_AVAILABLE == 'true' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -149,6 +149,8 @@ jobs:
       run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r cobertura.xml -l Python --partial
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+      if: ${{ env.SECRETS_AVAILABLE == 'true' }}
 
   coveralls-finish:
     name: Finalize coveralls.io
@@ -169,3 +171,5 @@ jobs:
     - run: bash <(curl -Ls https://coverage.codacy.com/get.sh) final
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+      if: ${{ env.SECRETS_AVAILABLE == 'true' }}


### PR DESCRIPTION
If PR is open from the external GH repo secrets are not set due to security reasons. It makes codacy coverage report to fail.