### PR TITLE
Fixes and improvements in failsafe

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,10 @@ on:
     tags:
     - v.*
 
+env:
+  CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  SECRETS_AVAILABLE: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+
 jobs:
   unit:
     runs-on: ${{ fromJson('{"ubuntu":"ubuntu-20.04","windows":"windows-latest","macos":"macos-latest"}')[matrix.os] }}
@@ -147,8 +151,7 @@ jobs:
       run: python -m coverage xml -o cobertura.xml
     - name: Upload coverage to Codacy
       run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r cobertura.xml -l Python --partial
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      if: ${{ env.SECRETS_AVAILABLE == 'true' }}
 
   coveralls-finish:
     name: Finalize coveralls.io
@@ -167,5 +170,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: bash <(curl -Ls https://coverage.codacy.com/get.sh) final
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      if: ${{ env.SECRETS_AVAILABLE == 'true' }}

--- a/features/dcs_failsafe_mode.feature
+++ b/features/dcs_failsafe_mode.feature
@@ -77,6 +77,7 @@ Feature: dcs failsafe mode
     Then "members/postgres0" key in DCS has state=running after 10 seconds
     And "members/postgres2" key in DCS has state=running after 10 seconds
     And Response on GET http://127.0.0.1:8008/failsafe contains postgres2 after 10 seconds
+    And replication works from postgres1 to postgres0 after 10 seconds
     Given DCS is down
     Then Response on GET http://127.0.0.1:8008/primary contains failsafe_mode_is_active after 12 seconds
     Then postgres1 role is the primary after 10 seconds

--- a/features/dcs_failsafe_mode.feature
+++ b/features/dcs_failsafe_mode.feature
@@ -24,9 +24,9 @@ Feature: dcs failsafe mode
 
   @dcs-failsafe
   Scenario: check new replica isn't promoted when leader is down and DCS is up
+    Given DCS is up
     When I do a backup of postgres0
     And I shut down postgres0
-    And DCS is up
     When I start postgres1 in a cluster batman from backup with no_master
     And I sleep for 2 seconds
     Then postgres1 role is the replica after 12 seconds
@@ -47,31 +47,28 @@ Feature: dcs failsafe mode
   Scenario: check leader and replica are functioning while DCS is down
     Given logical slot dcs_slot_0 is in sync between postgres0 and postgres1 after 10 seconds
     And DCS is down
-    And I sleep for 12 seconds
+    Then Response on GET http://127.0.0.1:8008/primary contains failsafe_mode_is_active after 12 seconds
     Then postgres0 role is the primary after 10 seconds
     And postgres1 role is the replica after 2 seconds
     And replication works from postgres0 to postgres1 after 10 seconds
     And I get all changes from logical slot dcs_slot_0 on postgres0
-    And logical slot dcs_slot_0 is in sync between postgres0 and postgres1 after 10 seconds
+    And logical slot dcs_slot_0 is in sync between postgres0 and postgres1 after 20 seconds
 
   @dcs-failsafe
   Scenario: check master is demoted when one replica is shut down and DCS is down
     Given DCS is down
-    And I shut down postgres1
+    And I kill postgres1
+    And I kill postmaster on postgres1
     And I sleep for 2 seconds
     Then postgres0 role is the replica after 12 seconds
 
   @dcs-failsafe
   Scenario: check known replica is promoted when leader is down and DCS is up
-    Given DCS is up
-    Then postgres0 role is the primary after 22 seconds
+    Given I shut down postgres0
+    And DCS is up
     When I start postgres1
     Then "members/postgres1" key in DCS has state=running after 10 seconds
-    And Response on GET http://127.0.0.1:8009/failsafe contains postgres1 after 10 seconds
-    Given DCS is down
-    And I shut down postgres0
-    And DCS is up
-    Then postgres1 role is the primary after 22 seconds
+    And postgres1 role is the primary after 25 seconds
 
   @dcs-failsafe
   Scenario: check three-node cluster is functioning while DCS is down
@@ -81,7 +78,7 @@ Feature: dcs failsafe mode
     And "members/postgres2" key in DCS has state=running after 10 seconds
     And Response on GET http://127.0.0.1:8008/failsafe contains postgres2 after 10 seconds
     Given DCS is down
-    And I sleep for 12 seconds
+    Then Response on GET http://127.0.0.1:8008/primary contains failsafe_mode_is_active after 12 seconds
     Then postgres1 role is the primary after 10 seconds
     And postgres0 role is the replica after 2 seconds
     And postgres2 role is the replica after 2 seconds

--- a/features/environment.py
+++ b/features/environment.py
@@ -184,6 +184,8 @@ class PatroniController(AbstractController):
             config.pop('etcd', None)
 
         raft_port = os.environ.get('RAFT_PORT')
+        # If patroni_raft_controller is suspended two Patroni members is enough to get a quorum,
+        # therefore we don't want Patroni to join as a voting member when testing dcs_failsafe_mode.
         if raft_port and not self._output_dir.endswith('dcs_failsafe_mode'):
             os.environ['RAFT_PORT'] = str(int(raft_port) + 1)
             config['raft'] = {'data_dir': self._output_dir, 'self_addr': 'localhost:' + os.environ['RAFT_PORT']}

--- a/features/environment.py
+++ b/features/environment.py
@@ -184,7 +184,7 @@ class PatroniController(AbstractController):
             config.pop('etcd', None)
 
         raft_port = os.environ.get('RAFT_PORT')
-        if raft_port:
+        if raft_port and not self._output_dir.endswith('dcs_failsafe_mode'):
             os.environ['RAFT_PORT'] = str(int(raft_port) + 1)
             config['raft'] = {'data_dir': self._output_dir, 'self_addr': 'localhost:' + os.environ['RAFT_PORT']}
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1699,9 +1699,11 @@ class Ha(object):
         :param dcs_failed: bool, indicates that communication with DCS failed (get_cluster() or update_leader())
         :returns: list[str], replication slots names that should be copied from the primary"""
 
+        slots = []
+
         # If dcs_failed we don't want to touch replication slots on a leader or replicas if failsafe_mode isn't enabled.
         if not self.cluster or dcs_failed and (self.is_leader() or not self.is_failsafe_mode()):
-            return
+            return slots
 
         # It could be that DCS is read-only, or only the leader can't access it.
         # Only the second one could be handled by `load_cluster_from_dcs()`.
@@ -1714,8 +1716,8 @@ class Ha(object):
                                                                             self.patroni.nofailover,
                                                                             self.patroni.replicatefrom,
                                                                             self.is_paused())
-            # Don't copy replication slots if failsafe_mode is active
-            return [] if self.failsafe_is_active() else slots
+        # Don't copy replication slots if failsafe_mode is active
+        return [] if self.failsafe_is_active() else slots
 
     def run_cycle(self):
         with self._async_executor:

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -506,6 +506,14 @@ class TestHa(PostgresInit):
         self.p.is_leader = false
         self.assertEqual(self.ha.run_cycle(), 'DCS is not accessible')
 
+    def test_no_dcs_connection_replica_failsafe_not_enabled_but_active(self):
+        self.ha.load_cluster_from_dcs = Mock(side_effect=DCSError('Etcd is not responding properly'))
+        self.ha.cluster = get_cluster_initialized_with_leader()
+        self.ha.update_failsafe({'name': 'leader', 'api_url': 'http://127.0.0.1:8008/patroni',
+                                 'conn_url': 'postgres://127.0.0.1:5432/postgres', 'slots': {'foo': 1000}})
+        self.p.is_leader = false
+        self.assertEqual(self.ha.run_cycle(), 'DCS is not accessible')
+
     def test_update_failsafe(self):
         self.assertRaises(Exception, self.ha.update_failsafe, {})
         self.p.set_role('master')

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -498,6 +498,14 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.run_cycle(),
                          'continue to run as a leader because failsafe mode is enabled and all members are accessible')
 
+    def test_readonly_dcs_primary_failsafe(self):
+        self.ha.cluster = get_cluster_initialized_with_leader_and_failsafe()
+        self.ha.dcs.update_leader = Mock(side_effect=DCSError('Etcd is not responding properly'))
+        self.ha.dcs._last_failsafe = self.ha.cluster.failsafe
+        self.ha.state_handler.name = self.ha.cluster.leader.name
+        self.assertEqual(self.ha.run_cycle(),
+                         'continue to run as a leader because failsafe mode is enabled and all members are accessible')
+
     def test_no_dcs_connection_replica_failsafe(self):
         self.ha.load_cluster_from_dcs = Mock(side_effect=DCSError('Etcd is not responding properly'))
         self.ha.cluster = get_cluster_initialized_with_leader_and_failsafe()


### PR DESCRIPTION
1. Fix problem with logical slots not advancing when only the primary lost access to DCS
2. Don't let Patroni to join as a raft voting member when running failsafe behave tests. It allows to test exactly the same conditions as for other DCS
3. Speed up dcs_failsafe_mode behave tests by getting rid from long sleeps, slight reshuffling of places when we start/stop outage, and by killing Patroni/Postgres to avoid long shutdown due to the leader key removal attempts.