### PR TITLE
Compatibility with pyinstaller

### DIFF
--- a/mkbinary.sh
+++ b/mkbinary.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 
-pip install --ignore-installed setuptools==19.2 pyinstaller
-pyinstaller --clean --onefile patroni.spec
+pip install --ignore-installed pyinstaller
+pyinstaller --clean patroni.spec

--- a/patroni.spec
+++ b/patroni.spec
@@ -8,7 +8,7 @@ def hiddenimports():
     sys.path.insert(0, '.')
     try:
         import patroni.dcs
-        return patroni.dcs.dcs_modules()
+        return patroni.dcs.dcs_modules() + ['http.server']
     finally:
         sys.path.pop(0)
 

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -3,7 +3,7 @@ import os
 import signal
 import time
 
-from .daemon import AbstractPatroniDaemon, abstract_main
+from patroni.daemon import AbstractPatroniDaemon, abstract_main
 
 logger = logging.getLogger(__name__)
 
@@ -11,13 +11,13 @@ logger = logging.getLogger(__name__)
 class Patroni(AbstractPatroniDaemon):
 
     def __init__(self, config):
-        from .api import RestApiServer
-        from .dcs import get_dcs
-        from .ha import Ha
-        from .postgresql import Postgresql
-        from .request import PatroniRequest
-        from .version import __version__
-        from .watchdog import Watchdog
+        from patroni.api import RestApiServer
+        from patroni.dcs import get_dcs
+        from patroni.ha import Ha
+        from patroni.postgresql import Postgresql
+        from patroni.request import PatroniRequest
+        from patroni.version import __version__
+        from patroni.watchdog import Watchdog
 
         super(Patroni, self).__init__(config)
 
@@ -138,7 +138,7 @@ def patroni_main():
 
 def main():
     if os.getpid() != 1:
-        from . import check_psycopg
+        from patroni import check_psycopg
 
         check_psycopg()
         return patroni_main()


### PR DESCRIPTION
it doesn't like relative imports and not recognise `http.server` imported with `six`.
The last one is explicitly added to the list of `hiddenimports()` and will break compatibility with python 2.7, which support will be dropped in the next Patroni release anyway.

Close https://github.com/zalando/patroni/issues/2535