### PR TITLE
Fix `patronictl switchover` on Citus cluster running on Kubernetes

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -698,8 +698,9 @@ class Kubernetes(AbstractDCS):
         self._namespace = config.get('namespace') or 'default'
         self._role_label = config.get('role_label', 'role')
         self._ca_certs = os.environ.get('PATRONI_KUBERNETES_CACERT', config.get('cacert')) or SERVICE_CERT_FILENAME
-        config['namespace'] = ''
-        super(Kubernetes, self).__init__(config)
+        config_copy = deepcopy(config)
+        config_copy['namespace'] = ''
+        super(Kubernetes, self).__init__(config_copy)
         if self._citus_group:
             self._labels[self._CITUS_LABEL] = self._citus_group
 

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -698,9 +698,7 @@ class Kubernetes(AbstractDCS):
         self._namespace = config.get('namespace') or 'default'
         self._role_label = config.get('role_label', 'role')
         self._ca_certs = os.environ.get('PATRONI_KUBERNETES_CACERT', config.get('cacert')) or SERVICE_CERT_FILENAME
-        config_copy = deepcopy(config)
-        config_copy['namespace'] = ''
-        super(Kubernetes, self).__init__(config_copy)
+        super(Kubernetes, self).__init__({**config, 'namespace': ''})
         if self._citus_group:
             self._labels[self._CITUS_LABEL] = self._citus_group
 


### PR DESCRIPTION
The code tries to initialize DCS twice, first for the current group and the second time for the selected group. However, there is a line in kubernetes.py that overwrites the namespace config.

So the second DCS is trying to find objects in the default namespace and that fails, because it does not have access to that.

ObjectCache.run hides the actual error, but after allowing it to show the traceback, I got this error:

```
2023-02-17 09:23:46,545 - ERROR - ObjectCache.run ApiException()
Traceback (most recent call last):
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 681, in run
    self._build_cache()
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 644, in _build_cache
    objects = self._list()
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 557, in _list
    return self._func(_retry=self._retry.copy())
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 516, in wrapper
    return getattr(self._core_v1_api, func)(*args, **kwargs)
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 452, in wrapper
    return self._api_client.call_api(method, path, headers, body, **kwargs)
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 421, in call_api
    return self._handle_server_response(response, _preload_content)
  File "/opt/patroni/lib/python3.9/site-packages/patroni/dcs/kubernetes.py", line 251, in _handle_server_response
    raise k8s_client.rest.ApiException(http_resp=response)
patroni.dcs.kubernetes.K8sClient.rest.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '3a48c3eb-ff1a-43c9-8872-33d39b1f21e7', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': '11c45271-7843-4c7c-b1d4-4d854da739ca', 'X-Kubernetes-Pf-Prioritylevel-Uid': 'a64f159e-1797-41df-8a15-d315d95b013c', 'Date': 'Fri, 17 Feb 2023 09:23:45 GMT', 'Content-Length': '316'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"configmaps is forbidden: User \\"system:serviceaccount:acoustid:postgresql-fingerprint\\" cannot list resource \\"configmaps\\" in API group \\"\\" in the namespace \\"default\\"","reason":"Forbidden","details":{"kind":"configmaps"},"code":403}\n'
```

Making a copy of the config and making the namespace field for AbstractDCS seems to work, but maybe there is a better way to do it.