### PR TITLE
Set hot_standby=off only if recovery_target_action=promote

### DIFF
--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -675,14 +675,16 @@ class TestPostgresql(BaseTestPostgresql):
 
     @patch.object(Postgresql, 'get_postgres_role_from_data_directory', Mock(return_value='replica'))
     @patch.object(Bootstrap, 'running_custom_bootstrap', PropertyMock(return_value=True))
-    @patch.object(Bootstrap, 'keep_existing_recovery_conf', PropertyMock(return_value=True))
+    @patch.object(Postgresql, 'controldata', Mock(return_value={'max_connections setting': '200',
+                                                                'max_worker_processes setting': '20',
+                                                                'max_locks_per_xact setting': '100',
+                                                                'max_wal_senders setting': 10}))
     def test__build_effective_configuration(self):
-        with patch.object(Postgresql, 'controldata',
-                          Mock(return_value={'max_connections setting': '200',
-                                             'max_worker_processes setting': '20',
-                                             'max_locks_per_xact setting': '100',
-                                             'max_wal_senders setting': 10})):
-            self.p.cancellable.cancel()
+        self.p.cancellable.cancel()
+        self.p.config.write_recovery_conf({'pause_at_recovery_target': 'false'})
+        self.assertFalse(self.p.start())
+        self.assertTrue(self.p.pending_restart)
+        with patch.object(Bootstrap, 'keep_existing_recovery_conf', PropertyMock(return_value=True)):
             self.assertFalse(self.p.start())
             self.assertTrue(self.p.pending_restart)
 


### PR DESCRIPTION
During custom bootstrap the `hot_standby` is set to off to protect postgres from panicking and shutting down when some parameters like `max_connections` are increased on the primary.

According to the [documentation](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-RECOVERY-TARGET-ACTION), `hot_standby` set to `off` affects behavior of the `recovery_target_action`, and `pause` starts acting as the `shutdown`:
> If [hot_standby](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-HOT-STANDBY) is not enabled, a setting of pause will act the same as shutdown

 This is not what users expect/need, because normally they resolve pause state on their own.

To solve the problem we will set `hot_standby` to `off` during custom bootstrap only if `recovery_target_action` is set to 'promote'.

Close https://github.com/zalando/patroni/issues/2569