### PR TITLE
add "GET /metrics" rest_api.rst

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -115,6 +115,7 @@ The ``GET /patroni`` is used by Patroni during the leader race. It also could be
 Retrieve the Patroni metrics in Prometheus format through the ``GET /metrics`` endpoint.
 
 .. code-block:: bash
+
 	$ curl http://localhost:8008/metrics
 	
 	# HELP patroni_version Patroni semver without periods. \

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -112,7 +112,7 @@ The ``GET /patroni`` is used by Patroni during the leader race. It also could be
     }
 
 
-Retrieve the Patroni metrics Prometheus format through the ``GET /metrics`` endpoint.
+Retrieve the Patroni metrics in Prometheus format through the ``GET /metrics`` endpoint.
 
 .. code-block:: bash
 	$ curl http://localhost:8008/metrics

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -111,6 +111,65 @@ The ``GET /patroni`` is used by Patroni during the leader race. It also could be
       }
     }
 
+
+Retrieve the patroni information in metric form through the ``GET /metrics`` endpoint.
+
+.. code-block:: bash
+	$ curl http://localhost:8008/metrics
+	
+	# HELP patroni_version Patroni semver without periods. \
+	# TYPE patroni_version gauge
+	patroni_version{scope="batman"} 020103
+	# HELP patroni_postgres_running Value is 1 if Postgres is running, 0 otherwise.
+	# TYPE patroni_postgres_running gauge
+	patroni_postgres_running{scope="batman"} 1
+	# HELP patroni_postmaster_start_time Epoch seconds since Postgres started.
+	# TYPE patroni_postmaster_start_time gauge
+	patroni_postmaster_start_time{scope="batman"} 1657656955.179243
+	# HELP patroni_master Value is 1 if this node is the leader, 0 otherwise.
+	# TYPE patroni_master gauge
+	patroni_master{scope="batman"} 1
+	# HELP patroni_xlog_location Current location of the Postgres transaction log, 0 if this node is not the leader.
+	# TYPE patroni_xlog_location counter
+	patroni_xlog_location{scope="batman"} 22320573386952
+	# HELP patroni_standby_leader Value is 1 if this node is the standby_leader, 0 otherwise.
+	# TYPE patroni_standby_leader gauge
+	patroni_standby_leader{scope="batman"} 0
+	# HELP patroni_replica Value is 1 if this node is a replica, 0 otherwise.
+	# TYPE patroni_replica gauge
+	patroni_replica{scope="batman"} 0
+	# HELP patroni_xlog_received_location Current location of the received Postgres transaction log, 0 if this node is not a replica.
+	# TYPE patroni_xlog_received_location counter
+	patroni_xlog_received_location{scope="batman"} 0
+	# HELP patroni_xlog_replayed_location Current location of the replayed Postgres transaction log, 0 if this node is not a replica.
+	# TYPE patroni_xlog_replayed_location counter
+	patroni_xlog_replayed_location{scope="batman"} 0
+	# HELP patroni_xlog_replayed_timestamp Current timestamp of the replayed Postgres transaction log, 0 if null.
+	# TYPE patroni_xlog_replayed_timestamp gauge
+	patroni_xlog_replayed_timestamp{scope="batman"} 0
+	# HELP patroni_xlog_paused Value is 1 if the Postgres xlog is paused, 0 otherwise.
+	# TYPE patroni_xlog_paused gauge
+	patroni_xlog_paused{scope="batman"} 0
+	# HELP patroni_postgres_server_version Version of Postgres (if running), 0 otherwise.
+	# TYPE patroni_postgres_server_version gauge
+	patroni_postgres_server_version {scope="batman"} 140004
+	# HELP patroni_cluster_unlocked Value is 1 if the cluster is unlocked, 0 if locked.
+	# TYPE patroni_cluster_unlocked gauge
+	patroni_cluster_unlocked{scope="batman"} 0
+	# HELP patroni_postgres_timeline Postgres timeline of this node (if running), 0 otherwise.
+	# TYPE patroni_postgres_timeline counter
+	patroni_postgres_timeline{scope="batman"} 24
+	# HELP patroni_dcs_last_seen Epoch timestamp when DCS was last contacted successfully by Patroni.
+	# TYPE patroni_dcs_last_seen gauge
+	patroni_dcs_last_seen{scope="batman"} 1677658321
+	# HELP patroni_pending_restart Value is 1 if the node needs a restart, 0 otherwise.
+	# TYPE patroni_pending_restart gauge
+	patroni_pending_restart{scope="batman"} 1
+	# HELP patroni_is_paused Value is 1 if auto failover is disabled, 0 otherwise.
+	# TYPE patroni_is_paused gauge
+	patroni_is_paused{scope="batman"} 1
+
+
 Cluster status endpoints
 ------------------------
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -112,7 +112,7 @@ The ``GET /patroni`` is used by Patroni during the leader race. It also could be
     }
 
 
-Retrieve the patroni information in metric form through the ``GET /metrics`` endpoint.
+Retrieve the Patroni metrics Prometheus format through the ``GET /metrics`` endpoint.
 
 .. code-block:: bash
 	$ curl http://localhost:8008/metrics


### PR DESCRIPTION
When I tried to monitor the Patroni through Prometheus, I couldn't see the GET /metrics endpoint on the Rest API page (https://patroni.readthedocs.io/en/latest/rest_api.html#). As far as I can see, it is mentioned only in the release notes page (https://patroni.readthedocs.io/en/latest/releases.html#version-2-1-0) that it was added with Version 2.1.0. However, the /metrics endpoint exists and when I run it, I get the output.