### PR TITLE
Don't allow on_reload callback kill other callbacks

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -15,7 +15,8 @@ from psutil import TimeoutExpired
 from threading import current_thread, Lock
 
 from .bootstrap import Bootstrap
-from .callback_executor import CallbackExecutor
+from .callback_executor import ACTION_NOOP, ACTION_ON_START, ACTION_ON_STOP,\
+    ACTION_ON_RESTART, ACTION_ON_RELOAD, ACTION_ON_ROLE_CHANGE, CallbackExecutor
 from .cancellable import CancellableSubprocess
 from .config import ConfigHandler, mtime
 from .connection import Connection, get_connection_cursor
@@ -30,13 +31,6 @@ from ..utils import Retry, RetryFailedError, polling_loop, data_directory_is_emp
 
 
 logger = logging.getLogger(__name__)
-
-ACTION_ON_START = "on_start"
-ACTION_ON_STOP = "on_stop"
-ACTION_ON_RESTART = "on_restart"
-ACTION_ON_RELOAD = "on_reload"
-ACTION_ON_ROLE_CHANGE = "on_role_change"
-ACTION_NOOP = "noop"
 
 STATE_RUNNING = 'running'
 STATE_REJECT = 'rejecting connections'

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -497,14 +497,14 @@ class Postgresql(object):
                        CallbackAction.ON_RESTART, CallbackAction.ON_ROLE_CHANGE):
             self.__cb_called = True
 
-        if self.callback and cb_type.value in self.callback:
-            cmd = self.callback[cb_type.value]
+        if self.callback and cb_type in self.callback:
+            cmd = self.callback[cb_type]
             role = 'master' if self.role == 'promoted' else self.role
             try:
-                cmd = shlex.split(self.callback[cb_type.value]) + [cb_type.value, role, self.scope]
+                cmd = shlex.split(self.callback[cb_type]) + [cb_type, role, self.scope]
                 self._callback_executor.call(cmd)
             except Exception:
-                logger.exception('callback %s %s %s %s failed', cmd, cb_type.value, role, self.scope)
+                logger.exception('callback %s %r %s %s failed', cmd, cb_type, role, self.scope)
 
     @property
     def role(self):

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -1,9 +1,28 @@
 import logging
 
-from patroni.postgresql.cancellable import CancellableExecutor
+from patroni.postgresql.cancellable import CancellableExecutor, CancellableSubprocess
 from threading import Condition, Thread
+from typing import List
 
 logger = logging.getLogger(__name__)
+
+ACTION_NOOP = "noop"
+ACTION_ON_START = "on_start"
+ACTION_ON_STOP = "on_stop"
+ACTION_ON_RESTART = "on_restart"
+ACTION_ON_RELOAD = "on_reload"
+ACTION_ON_ROLE_CHANGE = "on_role_change"
+
+
+class OnReloadExecutor(CancellableSubprocess):
+
+    def call_nowait(self, cmd: List[str]) -> None:
+        """Run one `on_reload` callback at most.
+
+        To achive it we always kill already running command including child processes."""
+        self.cancel(kill=True)
+        self._kill_children()
+        self._start_process(cmd, close_fds=True)
 
 
 class CallbackExecutor(CancellableExecutor, Thread):
@@ -12,11 +31,22 @@ class CallbackExecutor(CancellableExecutor, Thread):
         CancellableExecutor.__init__(self)
         Thread.__init__(self)
         self.daemon = True
+        self._on_reload_executor = OnReloadExecutor()
         self._cmd = None
         self._condition = Condition()
         self.start()
 
-    def call(self, cmd):
+    def call(self, cmd: List[str]) -> None:
+        """Executes one callback at a time.
+
+        Already running command is killed (including child processes).
+        If it couldn't be killed we wait until it finishes.
+
+        :param cmd: command to be executed"""
+
+        if cmd[-3] == ACTION_ON_RELOAD:
+            return self._on_reload_executor.call_nowait(cmd)
+
         self._kill_process()
         with self._condition:
             self._cmd = cmd

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -17,6 +17,9 @@ class CallbackAction(str, Enum):
     ON_RELOAD = "on_reload"
     ON_ROLE_CHANGE = "on_role_change"
 
+    def __repr__(self):
+        return self.value
+
 
 class OnReloadExecutor(CancellableSubprocess):
 

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -52,7 +52,7 @@ class CallbackExecutor(CancellableExecutor, Thread):
 
         :param cmd: command to be executed"""
 
-        if cmd[-3] == CallbackAction.ON_RELOAD.value:
+        if cmd[-3] == CallbackAction.ON_RELOAD:
             return self._on_reload_executor.call_nowait(cmd)
 
         self._kill_process()

--- a/patroni/postgresql/callback_executor.py
+++ b/patroni/postgresql/callback_executor.py
@@ -26,7 +26,7 @@ class OnReloadExecutor(CancellableSubprocess):
     def call_nowait(self, cmd: List[str]) -> None:
         """Run one `on_reload` callback at most.
 
-        To achive it we always kill already running command including child processes."""
+        To achieve it we always kill already running command including child processes."""
         self.cancel(kill=True)
         self._kill_children()
         with self._lock:

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -12,25 +12,28 @@ class TestCallbackExecutor(unittest.TestCase):
         mock_popen.return_value.children.return_value = []
         mock_popen.return_value.is_running.return_value = True
 
+        callback = ['test.sh', 'on_start', 'replica', 'foo']
         ce = CallbackExecutor()
         ce._kill_children = Mock(side_effect=Exception)
         ce._invoke_excepthook = Mock()
-        self.assertIsNone(ce.call([]))
+        self.assertIsNone(ce.call(callback))
         ce.join()
 
-        self.assertIsNone(ce.call([]))
+        self.assertIsNone(ce.call(callback))
 
         mock_popen.return_value.kill.side_effect = psutil.AccessDenied()
-        self.assertIsNone(ce.call([]))
+        self.assertIsNone(ce.call(callback))
 
         ce._process_children = []
         mock_popen.return_value.children.side_effect = psutil.Error()
         mock_popen.return_value.kill.side_effect = psutil.NoSuchProcess(123)
-        self.assertIsNone(ce.call([]))
+        self.assertIsNone(ce.call(callback))
 
         mock_popen.side_effect = Exception
         ce = CallbackExecutor()
         ce._condition.wait = Mock(side_effect=[None, Exception])
         ce._invoke_excepthook = Mock()
-        self.assertIsNone(ce.call([]))
+        self.assertIsNone(ce.call(callback))
+
+        self.assertIsNone(ce.call(['test.sh', 'on_reload', 'replica', 'foo']))
         ce.join()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -14,6 +14,7 @@ from patroni.dcs import RemoteMember
 from patroni.exceptions import PostgresConnectionException, PatroniException
 from patroni.postgresql import Postgresql, STATE_REJECT, STATE_NO_RESPONSE
 from patroni.postgresql.bootstrap import Bootstrap
+from patroni.postgresql.callback_executor import CallbackAction
 from patroni.postgresql.postmaster import PostmasterProcess
 from patroni.utils import RetryFailedError
 from six.moves import builtins
@@ -242,7 +243,7 @@ class TestPostgresql(BaseTestPostgresql):
     @patch('patroni.postgresql.config.mtime', mock_mtime)
     @patch('patroni.postgresql.config.ConfigHandler._get_pg_settings')
     def test_check_recovery_conf(self, mock_get_pg_settings):
-        self.p.call_nowait('on_start')
+        self.p.call_nowait(CallbackAction.ON_START)
         mock_get_pg_settings.return_value = {
             'primary_conninfo': ['primary_conninfo', 'foo=', None, 'string', 'postmaster', self.p.config._auto_conf],
             'recovery_min_apply_delay': ['recovery_min_apply_delay', '0', 'ms', 'integer', 'sighup', 'foo']
@@ -278,7 +279,7 @@ class TestPostgresql(BaseTestPostgresql):
     @patch.object(MockPostmaster, 'create_time', Mock(return_value=1234567), create=True)
     @patch('patroni.postgresql.config.ConfigHandler._get_pg_settings')
     def test__read_recovery_params(self, mock_get_pg_settings):
-        self.p.call_nowait('on_start')
+        self.p.call_nowait(CallbackAction.ON_START)
         mock_get_pg_settings.return_value = {'primary_conninfo': ['primary_conninfo', '', None, 'string',
                                                                   'postmaster', self.p.config._postgresql_conf]}
         self.p.config.write_recovery_conf({'standby_mode': 'on', 'primary_conninfo': {'password': 'foo'}})
@@ -320,7 +321,7 @@ class TestPostgresql(BaseTestPostgresql):
     @patch.object(Postgresql, 'is_running', Mock(return_value=False))
     @patch.object(Postgresql, 'start', Mock())
     def test_follow(self):
-        self.p.call_nowait('on_start')
+        self.p.call_nowait(CallbackAction.ON_START)
         m = RemoteMember('1', {'restore_command': '2', 'primary_slot_name': 'foo', 'conn_kwargs': {'host': 'bar'}})
         self.p.follow(m)
 
@@ -425,12 +426,9 @@ class TestPostgresql(BaseTestPostgresql):
     @patch('shlex.split', Mock(side_effect=OSError))
     def test_call_nowait(self):
         self.p.set_role('replica')
-        self.assertIsNone(self.p.call_nowait('on_start'))
+        self.assertIsNone(self.p.call_nowait(CallbackAction.ON_START))
         self.p.bootstrapping = True
-        self.assertIsNone(self.p.call_nowait('on_start'))
-
-    def test_non_existing_callback(self):
-        self.assertFalse(self.p.call_nowait('foobar'))
+        self.assertIsNone(self.p.call_nowait(CallbackAction.ON_START))
 
     @patch.object(Postgresql, 'is_running', Mock(return_value=MockPostmaster()))
     def test_is_leader_exception(self):


### PR DESCRIPTION
Since a long time Patroni enforcing only one callback script running at a time. If the new callback is executed while the old one is still running, the old one is killed (including all child processes).

Such behavior is fine for all callbacks but on_reload, because the last one may accidentally cancel important ones, that for example updating DNS or assigning/removing Virtual IP.

To mitigate the problem we introduce a dedicated executor for on_reload callbacks, so that on_reload may only cancel another on_reload.

Ref: https://github.com/zalando/patroni/issues/2445