### PR TITLE
Compatibility with flake8>=5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ class Flake8(_Command):
         from flake8.main.cli import main
 
         logging.getLogger().setLevel(logging.ERROR)
-        main(self.targets())
+        raise SystemExit(main(self.targets()))
 
 
 class PyTest(_Command):


### PR DESCRIPTION
The main() function now returns exit code instead of exiting on it's own