### PR TITLE
Fix typo in set_state: initializing new cluster

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -59,7 +59,7 @@ class Bootstrap(object):
         return user_options
 
     def _initdb(self, config):
-        self._postgresql.set_state('initalizing new cluster')
+        self._postgresql.set_state('initializing new cluster')
         not_allowed_options = ('pgdata', 'nosync', 'pwfile', 'sync-only', 'version')
 
         def error_handler(e):


### PR DESCRIPTION
I noticed this typo while browsing the code.