### PR TITLE
Release v3.0.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      If you have a question please post it on channel [#patroni](https://postgresteam.slack.com/archives/C9XPYG92A) in the [PostgreSQL Slack](https://postgresteam.slack.com).
+      If you have a question please post it on channel [#patroni](https://postgresteam.slack.com/archives/C9XPYG92A) in the [PostgreSQL Slack](https://join.slack.com/t/postgresteam/shared_invite/zt-1qj14i9sj-E9WqIFlvcOiHsEk2yFEMjA).
       Before reporting a bug please make sure to **reproduce it with the latest Patroni version**!
       Please fill the form below and provide as much information as possible.
       Not doing so may result in your bug not being addressed in a timely manner.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
 - name: Question
-  url: https://postgresteam.slack.com/archives/C9XPYG92A
-  about: Please ask question about Patroni on Slack
+  url: https://join.slack.com/t/postgresteam/shared_invite/zt-1qj14i9sj-E9WqIFlvcOiHsEk2yFEMjA
+  about: "Please ask questions on channel #patroni in the PostgreSQL Slack"

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ We report new releases information `here <https://github.com/zalando/patroni/rel
 Community
 =========
 
-There are two places to connect with the Patroni community: `on github <https://github.com/zalando/patroni>`__, via Issues and PRs, and on channel `#patroni <https://postgresteam.slack.com/archives/C9XPYG92A>`__ in the `PostgreSQL Slack <https://postgresteam.slack.com/>`__.  If you're using Patroni, or just interested, please join us.
+There are two places to connect with the Patroni community: `on github <https://github.com/zalando/patroni>`__, via Issues and PRs, and on channel `#patroni <https://postgresteam.slack.com/archives/C9XPYG92A>`__ in the `PostgreSQL Slack <https://join.slack.com/t/postgresteam/shared_invite/zt-1qj14i9sj-E9WqIFlvcOiHsEk2yFEMjA>`__.  If you're using Patroni, or just interested, please join us.
 
 ===================================
 Technical Requirements/Installation

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ Wanna contribute to Patroni? Yay - here is how!
 Chatting
 --------
 
-Just want to chat with other Patroni users?  Looking for interactive troubleshooting help? Join us on channel `#patroni <https://postgresteam.slack.com/archives/C9XPYG92A>`__ in the `PostgreSQL Slack <https://postgresteam.slack.com/>`__.
+Just want to chat with other Patroni users?  Looking for interactive troubleshooting help? Join us on channel `#patroni <https://postgresteam.slack.com/archives/C9XPYG92A>`__ in the `PostgreSQL Slack <https://join.slack.com/t/postgresteam/shared_invite/zt-1qj14i9sj-E9WqIFlvcOiHsEk2yFEMjA>`__.
 
 Running tests
 -------------

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -14,11 +14,11 @@ Version 3.0.2
 
 - Added sync standby replica status to ``/metrics`` endpoint (Thomas von Dein, Alexander Kukushkin)
 
-  Before were only reporing ``primary``/``standby_leader``/``replica``.
+  Before were only reporting ``primary``/``standby_leader``/``replica``.
 
-- User friendly handling of ``PAGER`` in ``patronictl`` (Israel Barth Rubio)
+- User-friendly handling of ``PAGER`` in ``patronictl`` (Israel Barth Rubio)
 
-  It makes pager configurable via ``PAGER`` environment variable, what overrides default ``less`` and ``more``.
+  It makes pager configurable via ``PAGER`` environment variable, which overrides default ``less`` and ``more``.
 
 
 **Improvements**
@@ -27,7 +27,7 @@ Version 3.0.2
 
   It was necessary to make ``recovery_target_action=pause`` work correctly.
 
-- Don't allow ``on_reload`` callback kill other callbacks (Alexander)
+- Don't allow ``on_reload`` callback to kill other callbacks (Alexander)
 
   ``on_start``/``on_stop``/``on_role_change`` are usually used to add/remove Virtual IP and ``on_reload`` should not interfere with them.
 
@@ -48,7 +48,7 @@ Version 3.0.2
 
 - Don't write to ``PGDATA`` if major version is not known (Alexander)
 
-  If right after start ``PGDATA`` was empty (maybe wasn't yet mounted), Patroni was making a false assumption about PostgreSQL version and falsely creating ``recovery.conf`` file even if the actual major version is v10+.
+  If right after the start ``PGDATA`` was empty (maybe wasn't yet mounted), Patroni was making a false assumption about PostgreSQL version and falsely creating ``recovery.conf`` file even if the actual major version is v10+.
 
 - Fixed bug with Citus metadata after coordinator failover (Alexander)
 
@@ -56,7 +56,7 @@ Version 3.0.2
 
 - Use etcd hosts listed in the config file as a fallback when all etcd nodes "failed" (Alexander)
 
-  The etcd cluster may change topology over time and Patroni tries to follow it. If at some point all nodes became unreachable Patroni will use a combination of nodes from the config plus last known topology when trying to reconnect.
+  The etcd cluster may change topology over time and Patroni tries to follow it. If at some point all nodes became unreachable Patroni will use a combination of nodes from the config plus the last known topology when trying to reconnect.
 
 
 Version 3.0.1

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -20,6 +20,10 @@ Version 3.0.2
 
   It makes pager configurable via ``PAGER`` environment variable, which overrides default ``less`` and ``more``.
 
+- Make K8s retriable HTTP status code configurable (Alexander)
+
+  On some managed platforms it is possible to get status code ``401 Unauthorized``, which sometimes gets resolved after a few retries.
+
 
 **Improvements**
 
@@ -30,10 +34,6 @@ Version 3.0.2
 - Don't allow ``on_reload`` callback to kill other callbacks (Alexander)
 
   ``on_start``/``on_stop``/``on_role_change`` are usually used to add/remove Virtual IP and ``on_reload`` should not interfere with them.
-
-- Make K8s retriable HTTP status code configurable (Alexander)
-
-  On some managed platforms it is possible to get status code ``401 Unauthorized``, which sometimes gets resolved after a few retries.
 
 - Switched to ``IMDSFetcher`` in aws callback example script (Polina Bungina)
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -3,6 +3,62 @@
 Release notes
 =============
 
+Version 3.0.2
+-------------
+
+.. warning::
+    Version 3.0.2 dropped support of Python older than 3.6.
+
+
+**New features**
+
+- Added sync standby replica status to ``/metrics`` endpoint (Thomas von Dein, Alexander Kukushkin)
+
+  Before were only reporing ``primary``/``standby_leader``/``replica``.
+
+- User friendly handling of ``PAGER`` in ``patronictl`` (Israel Barth Rubio)
+
+  It makes pager configurable via ``PAGER`` environment variable, what overrides default ``less`` and ``more``.
+
+
+**Improvements**
+
+- Set ``hot_standby`` to ``off`` during custom bootstrap only if ``recovery_target_action`` is set to ``promote`` (Alexander)
+
+  It was necessary to make ``recovery_target_action=pause`` work correctly.
+
+- Don't allow ``on_reload`` callback kill other callbacks (Alexander)
+
+  ``on_start``/``on_stop``/``on_role_change`` are usually used to add/remove Virtual IP and ``on_reload`` should not interfere with them.
+
+- Make K8s retriable HTTP status code configurable (Alexander)
+
+  On some managed platforms it is possible to get status code ``401 Unauthorized``, which sometimes gets resolved after a few retries.
+
+- Switched to ``IMDSFetcher`` in aws callback example script (Polina Bungina)
+
+  The ``IMDSv2`` requires a token to work with and the ``IMDSFetcher`` handles it transparently.
+
+
+**Bugfixes**
+
+- Fixed ``patronictl switchover`` on Citus cluster running on Kubernetes (Lukáš Lalinský)
+
+  It didn't work for namespaces different from ``default``.
+
+- Don't write to ``PGDATA`` if major version is not known (Alexander)
+
+  If right after start ``PGDATA`` was empty (maybe wasn't yet mounted), Patroni was making a false assumption about PostgreSQL version and falsely creating ``recovery.conf`` file even if the actual major version is v10+.
+
+- Fixed bug with Citus metadata after coordinator failover (Alexander)
+
+  The ``citus_set_coordinator_host()`` call doesn't cause metadata sync and the change was invisible on worker nodes. The issue is solved by switching to ``citus_update_node()``.
+
+- Use etcd hosts listed in the config file as a fallback when all etcd nodes "failed" (Alexander)
+
+  The etcd cluster may change topology over time and Patroni tries to follow it. If at some point all nodes became unreachable Patroni will use a combination of nodes from the config plus last known topology when trying to reconnect.
+
+
 Version 3.0.1
 -------------
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -142,8 +142,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         elif 'health' in path:
             status_code = 200 if response.get('state') == 'running' else 503
         elif cluster:  # dcs is available
-            is_synchronous = cluster.is_synchronous_mode() and cluster.sync \
-                    and patroni.postgresql.name in cluster.sync.members
+            is_synchronous = response.get('sync_standby')
             if path in ('/sync', '/synchronous') and is_synchronous:
                 status_code = replica_status_code
             elif path in ('/async', '/asynchronous') and not is_synchronous:

--- a/patroni/version.py
+++ b/patroni/version.py
@@ -2,4 +2,4 @@
 
 :var __version__: the current Patroni version.
 """
-__version__ = '3.0.1'
+__version__ = '3.0.2'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -197,8 +197,8 @@ class TestRestApiHandler(unittest.TestCase):
         with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'state': 'running'})):
             MockRestApiServer(RestApiHandler, 'GET /health')
         MockRestApiServer(RestApiHandler, 'GET /leader')
-        MockPatroni.dcs.cluster.is_synchronous_mode = Mock(return_value=True)
-        with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'role': 'replica'})):
+        with patch.object(RestApiHandler, 'get_postgresql_status',
+                          Mock(return_value={'role': 'replica', 'sync_standby': True})):
             MockRestApiServer(RestApiHandler, 'GET /synchronous')
             MockRestApiServer(RestApiHandler, 'GET /read-only-sync')
         with patch.object(RestApiHandler, 'get_postgresql_status', Mock(return_value={'role': 'replica'})):

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -601,11 +601,12 @@ class TestCtl(unittest.TestCase):
         mock_markup_to_pager.assert_not_called()
 
         # TTY with valid executable
-        mock_which.return_value = '/usr/bin/less'
+        mock_which.side_effect = [None, '/usr/bin/less', None]
         show_diff("foo:\n  bar: 1\n", "foo:\n  bar: 2\n")
         mock_markup_to_pager.assert_called_once()
 
         # Test that unicode handling doesn't fail with an exception
+        mock_which.side_effect = [None, '/usr/bin/less', None]
         show_diff(b"foo:\n  bar: \xc3\xb6\xc3\xb6\n".decode('utf-8'),
                   b"foo:\n  bar: \xc3\xbc\xc3\xbc\n".decode('utf-8'))
 


### PR DESCRIPTION
- bump version
- update release notes
- update links to Postgres Slack
- simplify /sync health-check endpoint code
- update unit-tests to cover missing lines