### PR TITLE
Compatibility with python 3.6

### DIFF
--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -16,7 +16,7 @@ class TestCitus(BaseTestPostgresql):
         self.cluster = get_cluster_initialized_with_leader()
         self.cluster.workers[1] = self.cluster
 
-    @patch('time.time', Mock(side_effect=[100, 130, 160, 190, 220, 250, 280]))
+    @patch('time.time', Mock(side_effect=[100, 130, 160, 190, 220, 250, 280, 310]))
     @patch('patroni.postgresql.citus.logger.exception', Mock(side_effect=SleepException))
     @patch('patroni.postgresql.citus.logger.warning')
     @patch('patroni.postgresql.citus.PgDistNode.wait', Mock())

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -1,10 +1,11 @@
 import etcd
+import mock
 import os
 import unittest
 
 from click.testing import CliRunner
 from datetime import datetime, timedelta
-from mock import patch, Mock, call
+from mock import patch, Mock
 from patroni.ctl import ctl, load_config, output_members, get_dcs, parse_dcs, \
     get_all_members, get_any_member, get_cursor, query_member, PatroniCtlException, apply_config_changes, \
     format_config_for_editing, show_diff, invoke_editor, format_pg_version, CONFIG_FILE_PATH, PatronictlPrettyTable
@@ -576,8 +577,8 @@ class TestCtl(unittest.TestCase):
         )
         mock_env_get.assert_called_once_with('PAGER')
         mock_which.assert_has_calls([
-            call('less'),
-            call('more'),
+            mock.call('less'),
+            mock.call('more'),
         ])
         mock_markup_to_pager.assert_not_called()
 
@@ -594,9 +595,9 @@ class TestCtl(unittest.TestCase):
         )
         mock_env_get.assert_called_once_with('PAGER')
         mock_which.assert_has_calls([
-            call('random'),
-            call('less'),
-            call('more'),
+            mock.call('random'),
+            mock.call('less'),
+            mock.call('more'),
         ])
         mock_markup_to_pager.assert_not_called()
 


### PR DESCRIPTION
despite being EOL the number of downloads from pypi for 3.6 is on the first place, hence we need to support it.

Fixed a couple of problems in tests:
1. pytest complains about `call` imported from mock, mock.call() is fine
2. one test of Citus intergration was broken