### PR TITLE
More use of CaseInsensitiveSet

### DIFF
--- a/patroni/collections.py
+++ b/patroni/collections.py
@@ -35,7 +35,7 @@ class CaseInsensitiveSet(MutableSet):
     def discard(self, value: str) -> None:
         self._values.pop(value.lower(), None)
 
-    def issubset(self, other: 'CaseInsensitiveSet'):
+    def issubset(self, other: 'CaseInsensitiveSet') -> bool:
         return self <= other
 
 

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -108,9 +108,14 @@ class GlobalConfig(object):
         return default if ret is None else ret
 
     @property
+    def min_synchronous_nodes(self) -> int:
+        """:returns: the minimal number of synchronous nodes based on whether strict mode is requested or not."""
+        return 1 if self.is_synchronous_mode_strict else 0
+
+    @property
     def synchronous_node_count(self) -> int:
         """:returns: currently configured value from the global configuration or 1 if it is not set or invalid."""
-        return self.get_int('synchronous_node_count', 0)
+        return max(self.get_int('synchronous_node_count', 1), self.min_synchronous_nodes)
 
     @property
     def maximum_lag_on_failover(self) -> int:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Union
 
 from . import psycopg
 from .async_executor import AsyncExecutor, CriticalTask
+from .collections import CaseInsensitiveSet
 from .exceptions import DCSError, PostgresConnectionException, PatroniFatalException
 from .postgresql.callback_executor import CallbackAction
 from .postgresql.misc import postgres_version_to_int
@@ -568,7 +569,7 @@ class Ha(object):
         """:returns: `True` if failsafe_mode is enabled in global configuration."""
         return self.global_config.check_mode('failsafe_mode')
 
-    def process_sync_replication(self):
+    def process_sync_replication(self) -> None:
         """Process synchronous standby beahvior.
 
         Synchronous standbys are registered in two places postgresql.conf and DCS. The order of updating them must
@@ -578,36 +579,34 @@ class Ha(object):
         promoting standbys that were guaranteed to be replicating synchronously.
         """
         if self.is_synchronous_mode():
-            sync_node_count = self.global_config.synchronous_node_count
-            sync_node_maxlag = self.global_config.maximum_lag_on_syncnode
-            current = [] if self.cluster.sync.is_empty else self.cluster.sync.members
-            picked, allow_promote = self.state_handler.sync_handler.current_state(self.cluster, sync_node_count,
-                                                                                  sync_node_maxlag)
-            if set(picked) != set(current):
+            current = CaseInsensitiveSet([] if self.cluster.sync.is_empty else self.cluster.sync.members)
+            picked, allow_promote = self.state_handler.sync_handler.current_state(self.cluster)
+
+            if picked != current:
                 # update synchronous standby list in dcs temporarily to point to common nodes in current and picked
-                sync_common = list(set(current).intersection(set(allow_promote)))
-                if set(sync_common) != set(current):
-                    logger.info("Updating synchronous privilege temporarily from %s to %s", current, sync_common)
-                    if not self.dcs.write_sync_state(self.state_handler.name,
-                                                     sync_common or None,
+                sync_common = current & allow_promote
+                if sync_common != current:
+                    logger.info("Updating synchronous privilege temporarily from %s to %s",
+                                list(current), list(sync_common))
+                    if not self.dcs.write_sync_state(self.state_handler.name, sync_common,
                                                      index=self.cluster.sync.index):
                         logger.info('Synchronous replication key updated by someone else.')
                         return
 
-                # Update  db param and wait for x secs
+                # When strict mode and no suitable replication connections put "*" to synchronous_standby_names
                 if self.global_config.is_synchronous_mode_strict and not picked:
-                    picked = ['*']
+                    picked = CaseInsensitiveSet('*')
                     logger.warning("No standbys available!")
 
+                # Update postgresql.conf and wait 2 secs for changes to become active
                 logger.info("Assigning synchronous standby status to %s", picked)
                 self.state_handler.sync_handler.set_synchronous_standby_names(picked)
 
-                if picked and picked[0] != '*' and set(allow_promote) != set(picked) and not allow_promote:
+                if picked and picked != CaseInsensitiveSet('*') and allow_promote != picked and not allow_promote:
                     # Wait for PostgreSQL to enable synchronous mode and see if we can immediately set sync_standby
                     time.sleep(2)
-                    _, allow_promote = self.state_handler.sync_handler.current_state(self.cluster, sync_node_count,
-                                                                                     sync_node_maxlag)
-                if allow_promote and set(allow_promote) != set(sync_common):
+                    _, allow_promote = self.state_handler.sync_handler.current_state(self.cluster)
+                if allow_promote and allow_promote != sync_common:
                     try:
                         cluster = self.dcs.get_cluster()
                     except DCSError:
@@ -618,7 +617,7 @@ class Ha(object):
                     if not self.dcs.write_sync_state(self.state_handler.name, allow_promote, index=cluster.sync.index):
                         logger.info("Synchronous replication key updated by someone else")
                         return
-                    logger.info("Synchronous standby status assigned to %s", allow_promote)
+                    logger.info("Synchronous standby status assigned to %s", list(allow_promote))
         else:
             if not self.cluster.sync.is_empty and self.dcs.delete_sync_state(index=self.cluster.sync.index):
                 logger.info("Disabled synchronous replication")

--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -3,9 +3,13 @@ import re
 import time
 
 from copy import deepcopy
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING
 
 from ..collections import CaseInsensitiveDict, CaseInsensitiveSet
+from ..dcs import Cluster
 from ..psycopg import quote_ident as _quote_ident
+if TYPE_CHECKING:  # pragma: no cover
+    from ..postgresql import Postgresql
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +30,12 @@ SYNC_REP_PARSER_RE = re.compile(r"""
 _EMPTY_SSN = {'type': 'off', 'num': 0, 'members': CaseInsensitiveSet()}
 
 
-def quote_ident(value):
-    """Very simplified version of quote_ident"""
+def quote_ident(value: str) -> str:
+    """Very simplified version of `psycopg` :func:`quote_ident` function."""
     return value if SYNC_STANDBY_NAME_RE.match(value) else _quote_ident(value)
 
 
-def parse_sync_standby_names(value):
+def parse_sync_standby_names(value: str) -> Dict[str, Any]:
     """Parse postgresql synchronous_standby_names to constituent parts.
     Returns dict with the following keys:
     * type: 'quorum'|'priority'
@@ -137,7 +141,7 @@ class SyncHandler(object):
     and the `current_state()` method will count newly added names as "sync" only when
     they reached memorized LSN and also reported as "sync" by `pg_stat_replication`"""
 
-    def __init__(self, postgresql):
+    def __init__(self, postgresql: 'Postgresql') -> None:
         self._postgresql = postgresql
         self._synchronous_standby_names = ''  # last known value of synchronous_standby_names
         self._ssn_data = deepcopy(_EMPTY_SSN)
@@ -169,18 +173,21 @@ class SyncHandler(object):
         self._postgresql.query('SELECT pg_catalog.txid_current()')  # Ensure some WAL traffic to move replication
         self._postgresql.reset_cluster_info_state(None)  # Reset internal cache to query fresh values
 
-    def current_state(self, cluster, sync_node_count=1, sync_node_maxlag=-1):
+    def current_state(self, cluster: Cluster) -> Tuple[CaseInsensitiveSet, CaseInsensitiveSet]:
         """Finds best candidates to be the synchronous standbys.
 
         Current synchronous standby is always preferred, unless it has disconnected or does not want to be a
         synchronous standby any longer.
-        Parameter sync_node_maxlag(maximum_lag_on_syncnode) would help swapping unhealthy sync replica in case
-        if it stops responding (or hung). Please set the value high enough so it won't unncessarily swap sync
-        standbys during high loads. Any less or equal of 0 value keep the behavior backward compatible and
-        will not swap. Please note that it will not also swap sync standbys in case where all replicas are hung.
 
-        :returns: tuple of candidates list and synchronous standby list."""
+        Standbys are selected based on values from the global configuration:
+        - `maximum_lag_on_syncnode`: would help swapping unhealthy sync replica in case if it stops
+          responding (or hung). Please set the value high enough so it won't unncessarily swap sync
+          standbys during high loads. Any value less or equal of 0 keeps the behavior backward compatible.
+          Please note that it will not also swap sync standbys in case where all replicas are hung.
+        - `synchronous_node_count`: controlls how many nodes should be set as synchronous.
 
+        :returns: tuple of candidates :class:`CaseInsensitiveSet` and synchronous standbys :class:`CaseInsensitiveSet`.
+        """
         self._handle_synchronous_standby_names_change()
 
         # Pick candidates based on who has higher replay/remote_write/flush lsn.
@@ -209,11 +216,13 @@ class SyncHandler(object):
         max_lsn = max(replica_list, key=lambda x: x[3])[3]\
             if len(replica_list) > 1 else self._postgresql.last_operation()
 
-        if self._postgresql.major_version < 90600:
-            sync_node_count = 1
+        assert self._postgresql._global_config is not None
+        sync_node_count = self._postgresql._global_config.synchronous_node_count\
+            if self._postgresql.supports_multiple_sync else 1
+        sync_node_maxlag = self._postgresql._global_config.maximum_lag_on_syncnode
 
-        candidates = []
-        sync_nodes = []
+        candidates = CaseInsensitiveSet()
+        sync_nodes = CaseInsensitiveSet()
         # Prefer members without nofailover tag. We are relying on the fact that sorts are guaranteed to be stable.
         for pid, app_name, sync_state, replica_lsn, _ in sorted(replica_list, key=lambda x: x[4]):
             # if standby name is listed in the /sync key we can count it as synchronous, otherwice
@@ -223,16 +232,16 @@ class SyncHandler(object):
                 self._ready_replicas[app_name] = pid
 
             if sync_node_maxlag <= 0 or max_lsn - replica_lsn <= sync_node_maxlag:
-                candidates.append(app_name)
+                candidates.add(app_name)
                 if sync_state == 'sync' and app_name in self._ready_replicas:
-                    sync_nodes.append(app_name)
+                    sync_nodes.add(app_name)
             if len(candidates) >= sync_node_count:
                 break
 
         return candidates, sync_nodes
 
-    def set_synchronous_standby_names(self, value):
-        """Constructs and sets `synchronous_standby_names` value.
+    def set_synchronous_standby_names(self, value: List[str]) -> None:
+        """Constructs and sets "synchronous_standby_names" GUC value.
 
         :param value: list[str] - the list of wanted sync members"""
         if value and value != ['*']:

--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -3,13 +3,13 @@ import re
 import time
 
 from copy import deepcopy
-from typing import Any, Dict, Tuple, TYPE_CHECKING
+from typing import Any, Collection, Dict, Tuple, TYPE_CHECKING
 
 from ..collections import CaseInsensitiveDict, CaseInsensitiveSet
 from ..dcs import Cluster
 from ..psycopg import quote_ident as _quote_ident
 if TYPE_CHECKING:  # pragma: no cover
-    from ..postgresql import Postgresql
+    from . import Postgresql
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +240,7 @@ class SyncHandler(object):
 
         return candidates, sync_nodes
 
-    def set_synchronous_standby_names(self, sync: CaseInsensitiveSet) -> None:
+    def set_synchronous_standby_names(self, sync: Collection[str]) -> None:
         """Constructs and sets "synchronous_standby_names" GUC value.
 
         :param sync: set of nodes to sync to

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -796,7 +796,7 @@ class TestHa(PostgresInit):
         # manual failover when the `other` node isn't available but our name is in the /sync key
         self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'other', None),
                                                                  sync=('leader1', 'postgresql0'))
-        self.p.sync_handler.current_state = Mock(return_value=([], []))
+        self.p.sync_handler.current_state = Mock(return_value=(CaseInsensitiveSet(), CaseInsensitiveSet()))
         self.ha.dcs.write_sync_state = true
         self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
 
@@ -812,7 +812,8 @@ class TestHa(PostgresInit):
         self.ha.cluster = get_cluster_initialized_without_leader(failover=Failover(0, '', 'postgresql0', None),
                                                                  sync=('leader1', 'other'))
         self.p.set_role('replica')
-        self.p.sync_handler.current_state = Mock(return_value=(['leader1'], ['leader1']))
+        self.p.sync_handler.current_state = Mock(return_value=(CaseInsensitiveSet(['leader1']),
+                                                               CaseInsensitiveSet(['leader1'])))
         self.assertEqual(self.ha.run_cycle(), 'promoted self to leader by acquiring session lock')
 
     def test_manual_failover_process_no_leader_in_pause(self):
@@ -1113,7 +1114,7 @@ class TestHa(PostgresInit):
         with patch.object(self.ha.dcs, 'delete_sync_state') as mock_delete_sync:
             self.ha.run_cycle()
             mock_delete_sync.assert_called_once()
-            mock_set_sync.assert_called_once_with([])
+            mock_set_sync.assert_called_once_with(CaseInsensitiveSet())
 
         mock_set_sync.reset_mock()
         # Test sync key not touched when not there
@@ -1121,7 +1122,7 @@ class TestHa(PostgresInit):
         with patch.object(self.ha.dcs, 'delete_sync_state') as mock_delete_sync:
             self.ha.run_cycle()
             mock_delete_sync.assert_not_called()
-            mock_set_sync.assert_called_once_with([])
+            mock_set_sync.assert_called_once_with(CaseInsensitiveSet())
 
         mock_set_sync.reset_mock()
 
@@ -1202,7 +1203,7 @@ class TestHa(PostgresInit):
 
         # When we just became primary nobody is sync
         self.assertEqual(self.ha.enforce_primary_role('msg', 'promote msg'), 'promote msg')
-        mock_set_sync.assert_called_once_with([])
+        mock_set_sync.assert_called_once_with(CaseInsensitiveSet())
         mock_write_sync.assert_called_once_with('leader', None, index=0)
 
         mock_set_sync.reset_mock()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,8 @@ import os
 
 from mock import Mock, patch
 
+from patroni.collections import CaseInsensitiveSet
+from patroni.config import GlobalConfig
 from patroni.dcs import Cluster, SyncState
 from patroni.postgresql import Postgresql
 
@@ -20,6 +22,7 @@ class TestSync(BaseTestPostgresql):
     def setUp(self):
         super(TestSync, self).setUp()
         self.p.config.write_postgresql_conf()
+        self.p._global_config = GlobalConfig({'synchronous_mode': True})
         self.s = self.p.sync_handler
 
     @patch.object(Postgresql, 'last_operation', Mock(return_value=1))
@@ -35,32 +38,34 @@ class TestSync(BaseTestPostgresql):
         # sync node is a bit behind of async, but we prefer it anyway
         with patch.object(Postgresql, "_cluster_info_state_get", side_effect=[self.leadermem.name,
                                                                               'on', pg_stat_replication]):
-            self.assertEqual(self.s.current_state(cluster), ([self.leadermem.name], [self.leadermem.name]))
+            self.assertEqual(self.s.current_state(cluster), (CaseInsensitiveSet([self.leadermem.name]),
+                                                             CaseInsensitiveSet([self.leadermem.name])))
 
         # prefer node with sync_state='potential', even if it is slightly behind of async
         pg_stat_replication[0]['sync_state'] = 'potential'
         for r in pg_stat_replication:
             r['write_lsn'] = r.pop('flush_lsn')
         with patch.object(Postgresql, "_cluster_info_state_get", side_effect=['', 'remote_write', pg_stat_replication]):
-            self.assertEqual(self.s.current_state(cluster), ([self.leadermem.name], []))
+            self.assertEqual(self.s.current_state(cluster), (CaseInsensitiveSet([self.leadermem.name]),
+                                                             CaseInsensitiveSet()))
 
         # when there are no sync or potential candidates we pick async with the minimal replication lag
         for i, r in enumerate(pg_stat_replication):
             r.update(replay_lsn=3 - i, application_name=r['application_name'].upper())
         missing = pg_stat_replication.pop(0)
         with patch.object(Postgresql, "_cluster_info_state_get", side_effect=['', 'remote_apply', pg_stat_replication]):
-            self.assertEqual(self.s.current_state(cluster), ([self.me.name], []))
+            self.assertEqual(self.s.current_state(cluster), (CaseInsensitiveSet([self.me.name]), CaseInsensitiveSet()))
 
         # unknown sync node is ignored
         missing.update(application_name='missing', sync_state='sync')
         pg_stat_replication.insert(0, missing)
         with patch.object(Postgresql, "_cluster_info_state_get", side_effect=['', 'remote_apply', pg_stat_replication]):
-            self.assertEqual(self.s.current_state(cluster), ([self.me.name], []))
+            self.assertEqual(self.s.current_state(cluster), (CaseInsensitiveSet([self.me.name]), CaseInsensitiveSet()))
 
         # invalid synchronous_standby_names and empty pg_stat_replication
         with patch.object(Postgresql, "_cluster_info_state_get", side_effect=['a b', 'remote_apply', None]):
             self.p._major_version = 90400
-            self.assertEqual(self.s.current_state(cluster), ([], []))
+            self.assertEqual(self.s.current_state(cluster), (CaseInsensitiveSet(), CaseInsensitiveSet()))
 
     def test_set_sync_standby(self):
         def value_in_conf():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -75,20 +75,26 @@ class TestSync(BaseTestPostgresql):
                         return line.strip()
 
         mock_reload = self.p.reload = Mock()
-        self.s.set_synchronous_standby_names(['n1'])
+        self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
         self.assertEqual(value_in_conf(), "synchronous_standby_names = 'n1'")
         mock_reload.assert_called()
 
         mock_reload.reset_mock()
-        self.s.set_synchronous_standby_names(['n1'])
+        self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1']))
         mock_reload.assert_not_called()
         self.assertEqual(value_in_conf(), "synchronous_standby_names = 'n1'")
 
-        self.s.set_synchronous_standby_names(['n1', 'n2'])
+        self.s.set_synchronous_standby_names(CaseInsensitiveSet(['n1', 'n2']))
         mock_reload.assert_called()
         self.assertEqual(value_in_conf(), "synchronous_standby_names = '2 (n1,n2)'")
 
         mock_reload.reset_mock()
-        self.s.set_synchronous_standby_names([])
+        self.s.set_synchronous_standby_names(CaseInsensitiveSet([]))
         mock_reload.assert_called()
         self.assertEqual(value_in_conf(), None)
+
+        mock_reload.reset_mock()
+        self.p._global_config = GlobalConfig({'synchronous_mode': True})
+        self.s.set_synchronous_standby_names(CaseInsensitiveSet('*'))
+        mock_reload.assert_called()
+        self.assertEqual(value_in_conf(), "synchronous_standby_names = '*'")


### PR DESCRIPTION
1. make `SyncHandler.current_state()` return `CaseInsensitiveSet` instead of `list` objects.
2. take `sync_node_count` and `sync_node_maxlag` from the `Postgresql._global_config` instead of passing them as arguments.
3. Make `AbstractDCS.write_sync_state()` accept any `Collection`-like objects.