### PR TITLE
Quote strings as values for initdb configuration

### DIFF
--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -233,6 +233,17 @@ class Postgresql(object):
         pg_ctl = [self.pgcommand('pg_ctl'), cmd]
         return subprocess.call(pg_ctl + ['-D', self._data_dir] + list(args), **kwargs) == 0
 
+    def initdb(self, *args: str, **kwargs: Any) -> bool:
+        """Builds and executes the initdb command.
+
+        :param args: List of arguments to be joined into the initdb command.
+        :param kwargs: Keyword arguments to pass to ``subprocess.call``.
+
+        :returns: ``True`` if the result of ``subprocess.call`, the exit code, is ``0``.
+        """
+        initdb = [self.pgcommand('initdb')] + list(args) + [self.data_dir]
+        return subprocess.call(initdb, **kwargs) == 0
+
     def pg_isready(self):
         """Runs pg_isready to see if PostgreSQL is accepting connections.
 

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -55,7 +55,7 @@ class Bootstrap(object):
             >>> Bootstrap.process_user_options('foo', ['yes', {'foo': 'bar'}], (), print)
             ['--yes', '--foo=bar']
 
-            Options that contain spaces will passed as is to ``subprocess.call``
+            Options that contain spaces are passed as is to ``subprocess.call``
             >>> Bootstrap.process_user_options('foo', [{'foo': 'bar baz'}], (), print)
             ['--foo=bar baz']
 
@@ -72,7 +72,7 @@ class Bootstrap(object):
             * If the options list is not in the required structure.
 
         :param tool: The name of the tool used in error reports to *error_handler*
-        :param options: Options to parse as a list of key, values or single values or a dictionary
+        :param options: Options to parse as a list of key, values or single values, or a dictionary
         :param not_allowed_options: List of keys that cannot be used in the list of key, value formatted options
         :param error_handler: A function which will be called when an error condition is encountered
         :returns: List of long form arguments to pass to the named tool
@@ -86,9 +86,9 @@ class Bootstrap(object):
             return ret
 
         if isinstance(options, dict):
-            for k, v in options.items():
-                if k and v:
-                    user_options.append('--{0}={1}'.format(k, v))
+            for key, val in options.items():
+                if key and val:
+                    user_options.append('--{0}={1}'.format(key, unquote(val)))
         elif isinstance(options, list):
             for opt in options:
                 if isinstance(opt, str) and option_is_allowed(opt):

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -33,6 +33,11 @@ class Bootstrap(object):
                              error_handler: Callable[[str], None]) -> List:
         """Format *options* in a list or dictionary format into command line long form arguments.
 
+        .. note::
+            The format of the output of this method is to prepare arguments for use in the ``pg_ctl``
+            method of `self._postgres`, which will join all options together into a single space delimited
+           string passed to the argument ``-o``.
+
         :Example:
 
             The *options* can be defined as a dictionary of key, values to be converted into arguments:
@@ -50,6 +55,14 @@ class Bootstrap(object):
             Or a combination of single and key, values
             >>> Bootstrap.process_user_options('foo', ['yes', {'foo': 'bar'}], (), print)
             ['--yes', '--foo=bar']
+
+            Options that contain spaces will be quoted
+            >>> Bootstrap.process_user_options('foo', [{'foo': 'bar baz'}], (), print)
+            ["--foo='bar baz'"]
+
+            Options that are already quoted will remain so
+            >>> Bootstrap.process_user_options('foo', [{'foo': '"bar baz"'}], (), print)
+            ['--foo="bar baz"']
 
         .. note::
             The *error_handler* is called when any of these conditions are met:

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -6,7 +6,7 @@ import time
 
 from ..dcs import RemoteMember
 from ..psycopg import quote_ident, quote_literal
-from ..utils import deep_compare
+from ..utils import deep_compare, shell_quote
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class Bootstrap(object):
                     if len(keys) != 1 or not isinstance(opt[keys[0]], str) or not option_is_allowed(keys[0]):
                         error_handler('Error when parsing {0} key-value option {1}: only one key-value is allowed'
                                       ' and value should be a string'.format(tool, opt[keys[0]]))
-                    user_options.append('--{0}={1}'.format(keys[0], opt[keys[0]]))
+                    user_options.append('--{0}={1}'.format(keys[0], shell_quote(opt[keys[0]])))
                 else:
                     error_handler('Error when parsing {0} option {1}: value should be string value'
                                   ' or a single key-value pair'.format(tool, opt))

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -86,10 +86,7 @@ class Bootstrap(object):
                     if len(keys) != 1 or not isinstance(opt[keys[0]], str) or not option_is_allowed(keys[0]):
                         error_handler('Error when parsing {0} key-value option {1}: only one key-value is allowed'
                                       ' and value should be a string'.format(tool, opt[keys[0]]))
-                    try:
-                        user_options.append('--{0}={1}'.format(keys[0], shell_quote(opt[keys[0]])))
-                    except ValueError as err:
-                        error_handler('Format of {0} options map invalid: {1}'.format(tool, ' '.join(err.args)))
+                    user_options.append('--{0}={1}'.format(keys[0], shell_quote(opt[keys[0]])))
                 else:
                     error_handler('Error when parsing {0} option {1}: value should be string value'
                                   ' or a single key-value pair'.format(tool, opt))

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -31,11 +31,11 @@ class Bootstrap(object):
                              options: Union[Dict[str, str], List[Union[str, Dict[str, str]]]],
                              not_allowed_options: Tuple[str, ...],
                              error_handler: Callable) -> List:
-        """Format ``options`` in a list or dictionary format into command line long form arguments.
+        """Format *options* in a list or dictionary format into command line long form arguments.
 
         :Example:
 
-            The ``options`` can be defined as a dictionary of key, values to be converted into arguments:
+            The *options* can be defined as a dictionary of key, values to be converted into arguments:
             >>> Bootstrap.process_user_options('foo', {'foo': 'bar'}, (), print)
             ['--foo=bar']
 
@@ -52,18 +52,18 @@ class Bootstrap(object):
             ['--yes', '--foo=bar']
 
         .. note::
-            The ``error_handler`` is called when any of these conditions are met:
+            The *error_handler* is called when any of these conditions are met:
 
             * Key, value dictionaries in the list form contains multiple keys.
-            * If a key is listed in ``not_allowed_options``.
+            * If a key is listed in *not_allowed_options*.
             * If there was a problem parsing the format of a value, e.g. unbalanced quoting.
             * If the options list is not in the required structure.
 
-        :param tool: The name of the tool used in error reports to ``error_handler``
+        :param tool: The name of the tool used in error reports to *error_handler*
         :param options: Options to parse as a list of key, values or single values or a dictionary
         :param not_allowed_options: List of keys that cannot be used in the list of key, value formatted options
         :param error_handler: A function which will be called when an error condition is encountered
-        :return: List of long form arguments to pass to the named tool
+        :returns: List of long form arguments to pass to the named tool
         """
         user_options = []
 

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -30,7 +30,7 @@ class Bootstrap(object):
     def process_user_options(tool: str,
                              options: Union[Dict[str, str], List[Union[str, Dict[str, str]]]],
                              not_allowed_options: Tuple[str, ...],
-                             error_handler: Callable) -> List:
+                             error_handler: Callable[[str], None]) -> List:
         """Format *options* in a list or dictionary format into command line long form arguments.
 
         :Example:

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -86,7 +86,10 @@ class Bootstrap(object):
                     if len(keys) != 1 or not isinstance(opt[keys[0]], str) or not option_is_allowed(keys[0]):
                         error_handler('Error when parsing {0} key-value option {1}: only one key-value is allowed'
                                       ' and value should be a string'.format(tool, opt[keys[0]]))
-                    user_options.append('--{0}={1}'.format(keys[0], shell_quote(opt[keys[0]])))
+                    try:
+                        user_options.append('--{0}={1}'.format(keys[0], shell_quote(opt[keys[0]])))
+                    except ValueError as err:
+                        error_handler('Format of {0} options map invalid: {1}'.format(tool, ' '.join(err.args)))
                 else:
                     error_handler('Error when parsing {0} option {1}: value should be string value'
                                   ' or a single key-value pair'.format(tool, opt))

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -19,6 +19,7 @@ import socket
 import sys
 import tempfile
 import time
+from shlex import quote, shlex
 
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING
 
@@ -923,7 +924,20 @@ def shell_quote(opt: str) -> str:
     :return: Quoted string
 
     """
-    if sys.platform != 'win32' and not re.match(r'^[\'"]', opt):
-        from shlex import quote
+    if sys.platform != 'win32' and not is_single_quoted_string(opt):
         return quote(opt)
     return opt
+
+
+def is_single_quoted_string(string: str) -> bool:
+    """Check if a string is a single fully quoted string and not multi-quoted using shlex.
+
+    :param string: The input string to check.
+    :return: True if the input string is a single fully quoted string, False otherwise.
+
+    """
+    lexer = shlex(string)
+    lexer.whitespace_split = False
+    lexer.whitespace = ''
+    tokens = list(lexer)
+    return len(tokens) == 1 and tokens[0][0] == tokens[0][-1] and tokens[0][0] in ('"', "'")

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -917,12 +917,11 @@ def enable_keepalive(sock: socket.socket, timeout: int, idle: int, cnt: Optional
 def shell_quote(opt: str) -> str:
     """Quote a string intended to be used as part of a shell command.
 
-    Applies quoting on POSIX compliant systems only, on `win32` platforms
+    Applies quoting on POSIX compliant systems only, on ``win32`` platforms
     will just return the original string unquoted.
 
     :param opt: String to be quoted
-    :return: Quoted string
-
+    :returns: Quoted string
     """
     if sys.platform != 'win32' and not is_single_quoted_string(opt):
         return quote(opt)
@@ -933,10 +932,10 @@ def is_single_quoted_string(string: str) -> bool:
     """Check if a string is a single fully quoted string and not multi-quoted using shlex.
 
     :param string: The input string to check.
-    :return: True if the input string is a single fully quoted string, False otherwise.
-
+    :returns: ``True`` if the input string is a single fully quoted string, ``False`` otherwise.
     """
     lexer = shlex(string)
+    # Next 2 assignments ensure shlex does not split the string on whitespace
     lexer.whitespace_split = False
     lexer.whitespace = ''
     tokens = list(lexer)

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -911,3 +911,19 @@ def enable_keepalive(sock: socket.socket, timeout: int, idle: int, cnt: Optional
 
     for opt in keepalive_socket_options(timeout, idle, cnt):
         sock.setsockopt(*opt)
+
+
+def shell_quote(opt: str) -> str:
+    """Quote a string intended to be used as part of a shell command.
+
+    Applies quoting on POSIX compliant systems only, on `win32` platforms
+    will just return the original string unquoted.
+
+    :param opt: String to be quoted
+    :return: Quoted string
+
+    """
+    if sys.platform != 'win32' and not re.match(r'^[\'"]', opt):
+        from shlex import quote
+        return quote(opt)
+    return opt

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -923,8 +923,8 @@ def shell_quote(opt: str) -> str:
     :param opt: String to be quoted
     :returns: Quoted string
     """
-    if sys.platform != 'win32' and requires_quoting(str(opt)):
-        return quote(str(opt))
+    if sys.platform != 'win32' and requires_quoting(opt):
+        return quote(opt)
     return opt
 
 

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -19,7 +19,7 @@ import socket
 import sys
 import tempfile
 import time
-from shlex import quote, split
+from shlex import split
 
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING
 
@@ -914,33 +914,30 @@ def enable_keepalive(sock: socket.socket, timeout: int, idle: int, cnt: Optional
         sock.setsockopt(*opt)
 
 
-def shell_quote(opt: str) -> str:
-    """Quote a string intended to be used as part of a shell command.
+def unquote(string: str) -> str:
+    """Unquote a fully quoted *string*.
 
-    Applies quoting on POSIX compliant systems only, on ``win32`` platforms
-    will just return the original string unquoted.
+    :Examples:
 
-    :param opt: String to be quoted
-    :returns: Quoted string
-    """
-    if sys.platform != 'win32' and requires_quoting(opt):
-        return quote(opt)
-    return opt
+        A *string* with quotes will have those quotes removed
+        >>> unquote('"a quoted string"')
+        'a quoted string'
 
+        A *string* with multiple quotes will be returned as is
+        >>> unquote('"a multi" "quoted string"')
+        '"a multi" "quoted string"'
 
-def requires_quoting(string: str) -> bool:
-    """Check if string is unquoted.
+        So will a *string* with unbalanced quotes
+        >>> unquote('unbalanced "quoted string')
+        'unbalanced "quoted string'
 
-    .. note::
-        Checks if *string* can be unquoted and the result is a single string.
-        If the string cannot be unquoted or an attempt to do so results in an error being raised
-        from ``shlex.split`` then assume *string* requires quoting.
-
-    :param string: The input string to check.
-    :returns: ``True`` if the string is not a single fully quoted string, or cannot be unquoted,
-              ``False`` if already quoted or quoting is not required.
+    :param string: The string to be checked for quoting.
+    :returns: The string with quotes removed, if it is a fully quoted single string,
+              or the original string if quoting is not detected, or unquoting was not possible.
     """
     try:
-        return len(split(string)) > 1
+        ret = split(string)
+        ret = ret[0] if len(ret) == 1 else string
     except ValueError:
-        return True
+        ret = string
+    return ret

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -938,7 +938,7 @@ def requires_quoting(string: str) -> bool:
 
     :param string: The input string to check.
     :returns: ``True`` if the string is not a single fully quoted string, or cannot be unquoted,
-              ``False`` if already quoted.
+              ``False`` if already quoted or quoting is not required.
     """
     try:
         return len(split(string)) > 1

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -119,14 +119,14 @@ class TestBootstrap(BaseTestPostgresql):
                     [{'key': 'value with spaces'}],
                     (), error_handler
                 ),
-                ["--key='value with spaces'"])
+                ["--key=value with spaces"])
             self.assertEqual(
                 self.b.process_user_options(
                     'initdb',
                     [{'key': "'value with spaces'"}],
                     (), error_handler
                 ),
-                ["--key='value with spaces'"])
+                ["--key=value with spaces"])
 
     @patch.object(CancellableSubprocess, 'call', Mock())
     @patch.object(Postgresql, 'is_running', Mock(return_value=True))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from mock import Mock, PropertyMock, patch
 
@@ -98,6 +99,34 @@ class TestBootstrap(BaseTestPostgresql):
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': [{'foo': 'bar', 1: 2}]})
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': [1]})
         self.assertRaises(Exception, self.b.bootstrap, {'initdb': 1})
+
+    def test__process_user_options(self):
+        def error_handler(msg):
+            raise Exception(msg)
+
+        self.assertEqual(self.b.process_user_options('initdb', ['string'], (), error_handler), ['--string'])
+        self.assertEqual(
+            self.b.process_user_options(
+                'initdb',
+                [{'key': 'value'}],
+                (), error_handler
+            ),
+            ['--key=value'])
+        if sys.platform != 'win32':
+            self.assertEqual(
+                self.b.process_user_options(
+                    'initdb',
+                    [{'key': 'value with spaces'}],
+                    (), error_handler
+                ),
+                ["--key='value with spaces'"])
+            self.assertEqual(
+                self.b.process_user_options(
+                    'initdb',
+                    [{'key': "'value with spaces'"}],
+                    (), error_handler
+                ),
+                ["--key='value with spaces'"])
 
     @patch.object(CancellableSubprocess, 'call', Mock())
     @patch.object(Postgresql, 'is_running', Mock(return_value=True))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -127,6 +127,20 @@ class TestBootstrap(BaseTestPostgresql):
                     (), error_handler
                 ),
                 ["--key=value with spaces"])
+            self.assertEqual(
+                self.b.process_user_options(
+                    'initdb',
+                    {'key': 'value with spaces'},
+                    (), error_handler
+                ),
+                ["--key=value with spaces"])
+            self.assertEqual(
+                self.b.process_user_options(
+                    'initdb',
+                    {'key': "'value with spaces'"},
+                    (), error_handler
+                ),
+                ["--key=value with spaces"])
 
     @patch.object(CancellableSubprocess, 'call', Mock())
     @patch.object(Postgresql, 'is_running', Mock(return_value=True))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 from mock import Mock, patch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,7 @@ import unittest
 from mock import Mock, patch
 
 from patroni.exceptions import PatroniException
-from patroni.utils import Retry, RetryFailedError, enable_keepalive, polling_loop, validate_directory, \
-    shell_quote
+from patroni.utils import Retry, RetryFailedError, enable_keepalive, polling_loop, validate_directory, unquote
 
 
 class TestUtils(unittest.TestCase):
@@ -44,39 +43,30 @@ class TestUtils(unittest.TestCase):
                 with patch('sys.platform', platform):
                     self.assertIsNone(enable_keepalive(Mock(), 10, 5))
 
-    @unittest.skipIf(os.name == 'nt', "POSIX compliant systems only")
-    def test_shell_quote(self):
-        self.assertEqual(shell_quote('value'), 'value')
-        self.assertEqual(shell_quote('value with spaces'), "'value with spaces'")
-
-        self.assertEqual(shell_quote(
-            'value "with" double quotes'),
-            '\'value "with" double quotes\'')
-        self.assertEqual(shell_quote(
-            '"value starting with" double quotes'),
-            '\'"value starting with" double quotes\'')
-        self.assertEqual(shell_quote(
-            'value with a \' single quote'),
-            '\'value with a \'"\'"\' single quote\''
-        )
-        self.assertEqual(shell_quote(
-            '\'value with a \'"\'"\' single quote\''),
-            '\'value with a \'"\'"\' single quote\''
-        )
-        self.assertEqual(shell_quote(
-            '\'value starting with\' single quotes'),
-            '\'\'"\'"\'value starting with\'"\'"\' single quotes\'')
-        self.assertEqual(shell_quote(
+    def test_unquote(self):
+        self.assertEqual(unquote('value'), 'value')
+        self.assertEqual(unquote('value with spaces'), "value with spaces")
+        self.assertEqual(unquote(
             '"double quoted value"'),
-            '"double quoted value"')
-        self.assertEqual(shell_quote(
+            'double quoted value')
+        self.assertEqual(unquote(
             '\'single quoted value\''),
-            '\'single quoted value\'')
-
-    @patch('sys.platform', 'win32')
-    def test_shell_quote_win(self):
-        self.assertEqual(shell_quote('value'), 'value')
-        self.assertEqual(shell_quote('value with spaces'), "value with spaces")
+            'single quoted value')
+        self.assertEqual(unquote(
+            'value "with" double quotes'),
+            'value "with" double quotes')
+        self.assertEqual(unquote(
+            '"value starting with" double quotes'),
+            '"value starting with" double quotes')
+        self.assertEqual(unquote(
+            '\'value starting with\' single quotes'),
+            '\'value starting with\' single quotes')
+        self.assertEqual(unquote(
+            'value with a \' single quote'),
+            'value with a \' single quote')
+        self.assertEqual(unquote(
+            '\'value with a \'"\'"\' single quote\''),
+            'value with a \' single quote')
 
 
 @patch('time.sleep', Mock())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from mock import Mock, patch
@@ -42,6 +43,7 @@ class TestUtils(unittest.TestCase):
                 with patch('sys.platform', platform):
                     self.assertIsNone(enable_keepalive(Mock(), 10, 5))
 
+    @unittest.skipIf(os.name == 'nt', "POSIX compliant systems only")
     def test_shell_quote(self):
         self.assertEqual(shell_quote('value'), 'value')
         self.assertEqual(shell_quote('value with spaces'), "'value with spaces'")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,6 @@ class TestRetrySleeper(unittest.TestCase):
             else:
                 scope['times'] += 1
                 raise PatroniException('Failed!')
-
         return inner
 
     def test_reset(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from mock import Mock, patch
+
 from patroni.exceptions import PatroniException
 from patroni.utils import Retry, RetryFailedError, enable_keepalive, polling_loop, validate_directory, \
     shell_quote
@@ -45,8 +46,26 @@ class TestUtils(unittest.TestCase):
 
     @unittest.skipIf(os.name == 'nt', "POSIX compliant systems only")
     def test_shell_quote(self):
+        self.assertRaises(ValueError, shell_quote, 'value with a \' single quote')
+
         self.assertEqual(shell_quote('value'), 'value')
         self.assertEqual(shell_quote('value with spaces'), "'value with spaces'")
+
+        self.assertEqual(shell_quote(
+            'value "with" double quotes'),
+            '\'value "with" double quotes\'')
+        self.assertEqual(shell_quote(
+            '"value starting with" double quotes'),
+            '\'"value starting with" double quotes\'')
+        self.assertEqual(shell_quote(
+            '\'value starting with\' single quotes'),
+            '\'\'"\'"\'value starting with\'"\'"\' single quotes\'')
+        self.assertEqual(shell_quote(
+            '"double quoted value"'),
+            '"double quoted value"')
+        self.assertEqual(shell_quote(
+            '\'single quoted value\''),
+            '\'single quoted value\'')
 
     @patch('sys.platform', 'win32')
     def test_shell_quote_win(self):
@@ -67,6 +86,7 @@ class TestRetrySleeper(unittest.TestCase):
             else:
                 scope['times'] += 1
                 raise PatroniException('Failed!')
+
         return inner
 
     def test_reset(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,8 @@ import unittest
 
 from mock import Mock, patch
 from patroni.exceptions import PatroniException
-from patroni.utils import Retry, RetryFailedError, enable_keepalive, polling_loop, validate_directory
+from patroni.utils import Retry, RetryFailedError, enable_keepalive, polling_loop, validate_directory, \
+    shell_quote
 
 
 class TestUtils(unittest.TestCase):
@@ -40,6 +41,15 @@ class TestUtils(unittest.TestCase):
             for platform in ('linux2', 'darwin', 'other'):
                 with patch('sys.platform', platform):
                     self.assertIsNone(enable_keepalive(Mock(), 10, 5))
+
+    def test_shell_quote(self):
+        self.assertEqual(shell_quote('value'), 'value')
+        self.assertEqual(shell_quote('value with spaces'), "'value with spaces'")
+
+    @patch('sys.platform', 'win32')
+    def test_shell_quote_win(self):
+        self.assertEqual(shell_quote('value'), 'value')
+        self.assertEqual(shell_quote('value with spaces'), "value with spaces")
 
 
 @patch('time.sleep', Mock())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,8 +46,6 @@ class TestUtils(unittest.TestCase):
 
     @unittest.skipIf(os.name == 'nt', "POSIX compliant systems only")
     def test_shell_quote(self):
-        self.assertRaises(ValueError, shell_quote, 'value with a \' single quote')
-
         self.assertEqual(shell_quote('value'), 'value')
         self.assertEqual(shell_quote('value with spaces'), "'value with spaces'")
 
@@ -57,6 +55,14 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(shell_quote(
             '"value starting with" double quotes'),
             '\'"value starting with" double quotes\'')
+        self.assertEqual(shell_quote(
+            'value with a \' single quote'),
+            '\'value with a \'"\'"\' single quote\''
+        )
+        self.assertEqual(shell_quote(
+            '\'value with a \'"\'"\' single quote\''),
+            '\'value with a \'"\'"\' single quote\''
+        )
         self.assertEqual(shell_quote(
             '\'value starting with\' single quotes'),
             '\'\'"\'"\'value starting with\'"\'"\' single quotes\'')


### PR DESCRIPTION
A user may be confused by the fact that a string value of a configuration dictionary needs to be double-quoted.

If a value is not already quoted, supporting backwards compatibility with existing config, then quote it. Applies to POSIX compliant OSes only.

References: PAT-86 #2632