### PR TITLE
Add "request_queue_size" option to REST API server

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -187,7 +187,8 @@ REST API
 -  **PATRONI\_RESTAPI\_ALLOWLIST\_INCLUDE\_MEMBERS**: (optional): If set to ``true`` it allows accessing unsafe REST API endpoints from other cluster members registered in DCS (IP address or hostname is taken from the members ``api_url``). Be careful, it might happen that OS will use a different IP for outgoing connections.
 -  **PATRONI\_RESTAPI\_HTTP\_EXTRA\_HEADERS**: (optional) HTTP headers let the REST API server pass additional information with an HTTP response.
 -  **PATRONI\_RESTAPI\_HTTPS\_EXTRA\_HEADERS**: (optional) HTTPS headers let the REST API server pass additional information with an HTTP response when TLS is enabled. This will also pass additional information set in ``http_extra_headers``.
--  **PATRONI\_RESTAPI\_REQUEST\_QUEUE\_SIZE**: (optional): Sets request queue size for TCP socket used by patroni REST API server.
+-  **PATRONI\_RESTAPI\_REQUEST\_QUEUE\_SIZE**: (optional): Sets request queue size for TCP socket used by Patroni REST API.  Once the queue is full, further requests get a "Connection denied" error. The default value is 5.
+- ```
 
 CTL
 ---

--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -187,6 +187,7 @@ REST API
 -  **PATRONI\_RESTAPI\_ALLOWLIST\_INCLUDE\_MEMBERS**: (optional): If set to ``true`` it allows accessing unsafe REST API endpoints from other cluster members registered in DCS (IP address or hostname is taken from the members ``api_url``). Be careful, it might happen that OS will use a different IP for outgoing connections.
 -  **PATRONI\_RESTAPI\_HTTP\_EXTRA\_HEADERS**: (optional) HTTP headers let the REST API server pass additional information with an HTTP response.
 -  **PATRONI\_RESTAPI\_HTTPS\_EXTRA\_HEADERS**: (optional) HTTPS headers let the REST API server pass additional information with an HTTP response when TLS is enabled. This will also pass additional information set in ``http_extra_headers``.
+-  **PATRONI\_RESTAPI\_REQUEST\_QUEUE\_SIZE**: (optional): Sets request queue size for TCP socket used by patroni REST API server.
 
 CTL
 ---

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -352,6 +352,7 @@ REST API
         -  **allowlist\_include\_members**: (optional): If set to ``true`` it allows accessing unsafe REST API endpoints from other cluster members registered in DCS (IP address or hostname is taken from the members ``api_url``). Be careful, it might happen that OS will use a different IP for outgoing connections.
         -  **http\_extra\_headers**: (optional): HTTP headers let the REST API server pass additional information with an HTTP response.
         -  **https\_extra\_headers**: (optional): HTTPS headers let the REST API server pass additional information with an HTTP response when TLS is enabled. This will also pass additional information set in ``http_extra_headers``.
+        -  **request_queue_size**: (optional): Sets request queue size for TCP socket used by patroni REST API server. Default value is 5.
 
 Here is an example of both **http_extra_headers** and **https_extra_headers**:
 

--- a/docs/SETTINGS.rst
+++ b/docs/SETTINGS.rst
@@ -352,7 +352,7 @@ REST API
         -  **allowlist\_include\_members**: (optional): If set to ``true`` it allows accessing unsafe REST API endpoints from other cluster members registered in DCS (IP address or hostname is taken from the members ``api_url``). Be careful, it might happen that OS will use a different IP for outgoing connections.
         -  **http\_extra\_headers**: (optional): HTTP headers let the REST API server pass additional information with an HTTP response.
         -  **https\_extra\_headers**: (optional): HTTPS headers let the REST API server pass additional information with an HTTP response when TLS is enabled. This will also pass additional information set in ``http_extra_headers``.
-        -  **request_queue_size**: (optional): Sets request queue size for TCP socket used by patroni REST API server. Default value is 5.
+        -  **request_queue_size**: (optional): Sets request queue size for TCP socket used by Patroni REST API.  Once the queue is full, further requests get a "Connection denied" error. The default value is 5.
 
 Here is an example of both **http_extra_headers** and **https_extra_headers**:
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -765,6 +765,10 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
         self.reload_config(config)
         self.daemon = True
 
+    def server_activate(self):
+        # Called by constructor to activate the server.
+        self.socket.listen(self.request_queue_size)
+
     def query(self, sql, *params):
         cursor = None
         try:
@@ -965,6 +969,8 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
 
         if isinstance(config.get('verify_client'), str):
             ssl_options['verify_client'] = config['verify_client'].lower()
+
+        self.request_queue_size = config.get('request_queue_size', 5)
 
         if self.__listen != config['listen'] or self.__ssl_options != ssl_options or self._received_new_cert:
             self.__initialize(config['listen'], ssl_options)

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -759,15 +759,12 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
     def __init__(self, patroni, config):
         self.patroni = patroni
         self.__listen = None
+        self.request_queue_size = config.get('request_queue_size', 5)
         self.__ssl_options = None
         self.__ssl_serial_number = None
         self._received_new_cert = False
         self.reload_config(config)
         self.daemon = True
-
-    def server_activate(self):
-        # Called by constructor to activate the server.
-        self.socket.listen(self.request_queue_size)
 
     def query(self, sql, *params):
         cursor = None
@@ -969,8 +966,6 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
 
         if isinstance(config.get('verify_client'), str):
             ssl_options['verify_client'] = config['verify_client'].lower()
-
-        self.request_queue_size = config.get('request_queue_size', 5)
 
         if self.__listen != config['listen'] or self.__ssl_options != ssl_options or self._received_new_cert:
             self.__initialize(config['listen'], ssl_options)

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -759,7 +759,7 @@ class RestApiServer(ThreadingMixIn, HTTPServer, Thread):
     def __init__(self, patroni, config):
         self.patroni = patroni
         self.__listen = None
-        self.request_queue_size = config.get('request_queue_size', 5)
+        self.request_queue_size = int(config.get('request_queue_size', 5))
         self.__ssl_options = None
         self.__ssl_serial_number = None
         self._received_new_cert = False

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -378,7 +378,8 @@ class Config(object):
 
         _set_section_values('restapi', ['listen', 'connect_address', 'certfile', 'keyfile', 'keyfile_password',
                                         'cafile', 'ciphers', 'verify_client', 'http_extra_headers',
-                                        'https_extra_headers', 'allowlist', 'allowlist_include_members'])
+                                        'https_extra_headers', 'allowlist', 'allowlist_include_members',
+                                        'request_queue_size'])
         _set_section_values('ctl', ['insecure', 'cacert', 'certfile', 'keyfile', 'keyfile_password'])
         _set_section_values('postgresql', ['listen', 'connect_address', 'proxy_address',
                                            'config_dir', 'data_dir', 'pgpass', 'bin_dir'])
@@ -393,12 +394,13 @@ class Config(object):
                 if value is not None:
                     ret[first][second] = value
 
-        for first, second in (('rest_api', ('request_queue_size',)), ('log', ('max_queue_size', 'file_size', 'file_num'))):
-            value = ret.get(first, {}).pop(second, None)
-            if value:
-                value = parse_int(value)
-                if value is not None:
-                    ret[first][second] = value
+        for first, params in (('restapi', ('request_queue_size',)), ('log', ('max_queue_size', 'file_size', 'file_num'))):
+            for second in params:
+                value = ret.get(first, {}).pop(second, None)
+                if value:
+                    value = parse_int(value)
+                    if value is not None:
+                        ret[first][second] = value
 
         def _parse_list(value):
             if not (value.strip().startswith('-') or '[' in value):

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -394,7 +394,8 @@ class Config(object):
                 if value is not None:
                     ret[first][second] = value
 
-        for first, params in (('restapi', ('request_queue_size',)), ('log', ('max_queue_size', 'file_size', 'file_num'))):
+        for first, params in (('restapi', ('request_queue_size',)),
+                              ('log', ('max_queue_size', 'file_size', 'file_num'))):
             for second in params:
                 value = ret.get(first, {}).pop(second, None)
                 if value:

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -393,12 +393,12 @@ class Config(object):
                 if value is not None:
                     ret[first][second] = value
 
-        for second in ('max_queue_size', 'file_size', 'file_num'):
-            value = ret.get('log', {}).pop(second, None)
+        for first, second in (('rest_api', ('request_queue_size',)), ('log', ('max_queue_size', 'file_size', 'file_num'))):
+            value = ret.get(first, {}).pop(second, None)
             if value:
                 value = parse_int(value)
                 if value is not None:
-                    ret['log'][second] = value
+                    ret[first][second] = value
 
         def _parse_list(value):
             if not (value.strip().startswith('-') or '[' in value):

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -703,7 +703,8 @@ schema = Schema({
     "scope": str,
     "restapi": {
         "listen": validate_host_port_listen,
-        "connect_address": validate_connect_address
+        "connect_address": validate_connect_address,
+        Optional("request_queue_size"): lambda i: assert_(0 <= int(i) <= 4096)
     },
     Optional("bootstrap"): {
         "dcs": {


### PR DESCRIPTION
Currently patroni has very small tcp accept queue size (which is 5, default value is set in Python's [socketserver](https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer.request_queue_size) module). This may cause denial of service under a huge load (haproxy cannot reach patroni REST API and considers a cluster member down).
```bash
pghost:~# ss -lptn | grep -E 'State|8008'
                    vvvvvv
State     Recv-Q    Send-Q       Local Address:Port        Peer Address:Port    Process
LISTEN    0         5                  0.0.0.0:8008             0.0.0.0:*        users:(("patroni",pid=36218,fd=5))
pghost:~# netstat -s | grep overflow
    295971810 times the listen queue of a socket overflowed

clienthost:~# ./tcpretrans.bt | grep SYN_SENT
09:17:03 0         10.32.143.249:53762    10.50.168.51:8008   SYN_SENT
09:17:03 0         10.32.143.249:39862    10.50.144.54:8008   SYN_SENT
09:17:03 0         10.32.143.249:37168    10.50.156.36:8008   SYN_SENT
09:17:03 600       10.32.143.249:35528    10.34.196.18:8008   SYN_SENT
```

There were two related issues but nobody fixed the issue so far: https://github.com/zalando/patroni/issues/2618, https://github.com/zalando/patroni/issues/2620

This fix adds **request_queue_size** option to patroni config "restapi" section. The default value is 5 so that shouldn't break anything. The result is:
```bash
# ss -tlpn | grep -E 'State|8008'
State     Recv-Q    Send-Q       Local Address:Port        Peer Address:Port    Process                                                                         
LISTEN    0         128                0.0.0.0:8008             0.0.0.0:*        users:(("patroni",pid=29319,fd=5))  
```