### PR TITLE
Attempt to reduce behave flakiness on MacOS

### DIFF
--- a/features/ignored_slots.feature
+++ b/features/ignored_slots.feature
@@ -10,7 +10,7 @@ Feature: ignored slots
     When I shut down postgres1
     And I start postgres1
     Then postgres1 is a leader after 10 seconds
-    And "members/postgres1" key in DCS has role=master after 3 seconds
+    And "members/postgres1" key in DCS has role=master after 10 seconds
     # Make sure Patroni has finished telling Postgres it should be accepting writes.
     And postgres1 role is the primary after 20 seconds
     # 1. Create our test logical replication slot.
@@ -31,19 +31,19 @@ Feature: ignored slots
     And postgres1 has a logical replication slot named unmanaged_slot_3 with the test_decoding plugin
 
     When I start postgres0
-    Then "members/postgres0" key in DCS has role=replica after 3 seconds
+    Then "members/postgres0" key in DCS has role=replica after 10 seconds
     And postgres0 role is the secondary after 20 seconds
     # Verify that the replica has advanced beyond the point in the WAL
     # where we created the replication slot so that on the next failover
     # cycle we don't accidentally rewind to before the slot creation.
     And replication works from postgres1 to postgres0 after 20 seconds
     When I shut down postgres1
-    Then "members/postgres0" key in DCS has role=master after 3 seconds
+    Then "members/postgres0" key in DCS has role=master after 10 seconds
 
     # 2. After a failover the server (now a replica) still has the slot.
     When I start postgres1
     Then postgres1 role is the secondary after 20 seconds
-    And "members/postgres1" key in DCS has role=replica after 3 seconds
+    And "members/postgres1" key in DCS has role=replica after 10 seconds
     # give Patroni time to sync replication slots
     And I sleep for 2 seconds
     And postgres1 has a logical replication slot named unmanaged_slot_0 with the test_decoding plugin
@@ -54,7 +54,7 @@ Feature: ignored slots
 
     # 3. After a failover the server (now a primary) still has the slot.
     When I shut down postgres0
-    Then "members/postgres1" key in DCS has role=master after 3 seconds
+    Then "members/postgres1" key in DCS has role=master after 10 seconds
     And postgres1 has a logical replication slot named unmanaged_slot_0 with the test_decoding plugin
     And postgres1 has a logical replication slot named unmanaged_slot_1 with the test_decoding plugin
     And postgres1 has a logical replication slot named unmanaged_slot_2 with the test_decoding plugin

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -50,15 +50,15 @@ Scenario: check dynamic configuration change via DCS
 Scenario: check the scheduled restart
 	Given I issue a PATCH request to http://127.0.0.1:8008/config with {"postgresql": {"parameters": {"superuser_reserved_connections": "6"}}}
 	Then I receive a response code 200
-		And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 5 seconds
+	And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 5 seconds
 	Given I issue a scheduled restart at http://127.0.0.1:8008 in 5 seconds with {"role": "replica"}
 	Then I receive a response code 202
-		And I sleep for 8 seconds
-		And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 10 seconds
+	And I sleep for 8 seconds
+	And Response on GET http://127.0.0.1:8008/patroni contains pending_restart after 10 seconds
 	Given I issue a scheduled restart at http://127.0.0.1:8008 in 5 seconds with {"restart_pending": "True"}
 	Then I receive a response code 202
-		And Response on GET http://127.0.0.1:8008/patroni does not contain pending_restart after 10 seconds
-		And postgres0 role is the primary after 10 seconds
+	And Response on GET http://127.0.0.1:8008/patroni does not contain pending_restart after 10 seconds
+	And postgres0 role is the primary after 10 seconds
 
 Scenario: check API requests for the primary-replica pair in the pause mode
 	Given I start postgres1
@@ -79,7 +79,7 @@ Scenario: check API requests for the primary-replica pair in the pause mode
 	When I run patronictl.py reinit batman postgres1 --force
 	Then I receive a response returncode 0
 	And I receive a response output "Success: reinitialize for member postgres1"
-	And postgres1 role is the secondary after 15 seconds
+	And postgres1 role is the secondary after 30 seconds
 	And replication works from postgres0 to postgres1 after 20 seconds
 	When I run patronictl.py restart batman postgres0 --force
 	Then I receive a response returncode 0

--- a/features/patroni_api.feature
+++ b/features/patroni_api.feature
@@ -79,12 +79,12 @@ Scenario: check API requests for the primary-replica pair in the pause mode
 	When I run patronictl.py reinit batman postgres1 --force
 	Then I receive a response returncode 0
 	And I receive a response output "Success: reinitialize for member postgres1"
+	And postgres1 role is the secondary after 15 seconds
+	And replication works from postgres0 to postgres1 after 20 seconds
 	When I run patronictl.py restart batman postgres0 --force
 	Then I receive a response returncode 0
 	And I receive a response output "Success: restart on member postgres0"
 	And postgres0 role is the primary after 5 seconds
-	When I sleep for 10 seconds
-	Then postgres1 role is the secondary after 15 seconds
 
 Scenario: check the switchover via the API in the pause mode
 	Given I issue a POST request to http://127.0.0.1:8008/switchover with {"leader": "postgres0", "candidate": "postgres1"}


### PR DESCRIPTION
Sometimes MacOS workers are so slow that Postgres shutdown might take more than 30s-40s, what breaks a test with replica reinit in parallel with the primary restart, because basebackup() does only two attempts and in a pause the replica remains running with empty PGDATA.

In addition to that increase timeouts in ignore_slots test.
Close #2637