### PR TITLE
Remove watchdog from __DEFAULT_CONFIG

### DIFF
--- a/patroni/config.py
+++ b/patroni/config.py
@@ -196,9 +196,6 @@ class Config(object):
             'use_slots': True,
             'parameters': CaseInsensitiveDict({p: v[0] for p, v in ConfigHandler.CMDLINE_OPTIONS.items()
                                                if p not in ('wal_keep_segments', 'wal_keep_size')})
-        },
-        'watchdog': {
-            'mode': 'automatic',
         }
     }
 

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -335,16 +335,16 @@ class Config(object):
 
         for name, value in dynamic_configuration.items():
             if name == 'postgresql':
-                for p, v in (value or {}).items():
-                    if p == 'parameters':
-                        config['postgresql'][p].update(self._process_postgresql_parameters(v))
-                    elif p not in ('connect_address', 'proxy_address', 'listen',
-                                   'config_dir', 'data_dir', 'pgpass', 'authentication'):
-                        config['postgresql'][p] = deepcopy(v)
-            elif name in ('standby_cluster', 'watchdog'):
-                for p, v in (value or {}).items():
-                    if p in self.__DEFAULT_CONFIG[name]:
-                        config[name][p] = deepcopy(v)
+                for name, value in (value or {}).items():
+                    if name == 'parameters':
+                        config['postgresql'][name].update(self._process_postgresql_parameters(value))
+                    elif name not in ('connect_address', 'proxy_address', 'listen',
+                                      'config_dir', 'data_dir', 'pgpass', 'authentication'):
+                        config['postgresql'][name] = deepcopy(value)
+            elif name == 'standby_cluster':
+                for name, value in (value or {}).items():
+                    if name in self.__DEFAULT_CONFIG['standby_cluster']:
+                        config['standby_cluster'][name] = deepcopy(value)
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overridden from DCS
                 config[name] = int(value)
         return config

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -335,16 +335,16 @@ class Config(object):
 
         for name, value in dynamic_configuration.items():
             if name == 'postgresql':
-                for name, value in (value or {}).items():
-                    if name == 'parameters':
-                        config['postgresql'][name].update(self._process_postgresql_parameters(value))
-                    elif name not in ('connect_address', 'proxy_address', 'listen',
-                                      'config_dir', 'data_dir', 'pgpass', 'authentication'):
-                        config['postgresql'][name] = deepcopy(value)
-            elif name == 'standby_cluster':
-                for name, value in (value or {}).items():
-                    if name in self.__DEFAULT_CONFIG['standby_cluster']:
-                        config['standby_cluster'][name] = deepcopy(value)
+                for p, v in (value or {}).items():
+                    if p == 'parameters':
+                        config['postgresql'][p].update(self._process_postgresql_parameters(v))
+                    elif p not in ('connect_address', 'proxy_address', 'listen',
+                                   'config_dir', 'data_dir', 'pgpass', 'authentication'):
+                        config['postgresql'][p] = deepcopy(v)
+            elif name in ('standby_cluster', 'watchdog'):
+                for p, v in (value or {}).items():
+                    if p in self.__DEFAULT_CONFIG[name]:
+                        config[name][p] = deepcopy(v)
             elif name in config:  # only variables present in __DEFAULT_CONFIG allowed to be overridden from DCS
                 config[name] = int(value)
         return config

--- a/patroni/watchdog/base.py
+++ b/patroni/watchdog/base.py
@@ -39,12 +39,14 @@ def synchronized(func):
 class WatchdogConfig(object):
     """Helper to contain a snapshot of configuration"""
     def __init__(self, config):
-        self.mode = parse_mode(config['watchdog'].get('mode', 'automatic'))
+        watchdog_config = config.get("watchdog") or {'mode': 'automatic'}
+
+        self.mode = parse_mode(watchdog_config.get('mode', 'automatic'))
         self.ttl = config['ttl']
         self.loop_wait = config['loop_wait']
-        self.safety_margin = config['watchdog'].get('safety_margin', 5)
-        self.driver = config['watchdog'].get('driver', 'default')
-        self.driver_config = dict((k, v) for k, v in config['watchdog'].items()
+        self.safety_margin = watchdog_config.get('safety_margin', 5)
+        self.driver = watchdog_config.get('driver', 'default')
+        self.driver_config = dict((k, v) for k, v in watchdog_config.items()
                                   if k not in ['mode', 'safety_margin', 'driver'])
 
     def __eq__(self, other):


### PR DESCRIPTION
Watchdog is assumed to be configurable via the dynamic config, however when one tries to add this section using `patronictl edit-config`, it fails to apply changes on the `_safe_copy_dynamic_configuration` stage:

```
2023-04-28 12:37:07,516 ERROR: Exception when setting dynamic_configuration                                                                    
Traceback (most recent call last):                                                                                                             
  File "/patroni/config.py", line 305, in set_dynamic_configuration                                                                            
    self.__effective_configuration = self._build_effective_configuration(configuration,                                                        
  File "/patroni/config.py", line 510, in _build_effective_configuration                                                                       
    config = self._safe_copy_dynamic_configuration(dynamic_configuration)                                                                      
  File "/patroni/config.py", line 349, in _safe_copy_dynamic_configuration
    config[name] = int(value)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'dict'
```

Upd: it is not actually assumed to be configurable, so remove it from __DEFAULT_CONFIG to avoid any further confusion 