### PR TITLE
Refactor write_sync_state()

### DIFF
--- a/patroni/dcs/etcd.py
+++ b/patroni/dcs/etcd.py
@@ -625,7 +625,7 @@ class AbstractEtcd(AbstractDCS):
 def catch_etcd_errors(func: Callable[..., Any]) -> Any:
     def wrapper(self: AbstractEtcd, *args: Any, **kwargs: Any) -> Any:
         try:
-            retval = func(self, *args, **kwargs) is not None
+            retval = func(self, *args, **kwargs)
             self._has_failed = False
             return retval
         except (RetryFailedError, etcd.EtcdException) as e:
@@ -817,8 +817,8 @@ class Etcd(AbstractEtcd):
         return bool(self._client.write(self.history_path, value))
 
     @catch_etcd_errors
-    def set_sync_state_value(self, value: str, index: Optional[int] = None) -> bool:
-        return bool(self.retry(self._client.write, self.sync_path, value, prevIndex=index or 0))
+    def set_sync_state_value(self, value: str, index: Optional[int] = None) -> Union[int, bool]:
+        return self.retry(self._client.write, self.sync_path, value, prevIndex=index or 0).modifiedIndex
 
     @catch_etcd_errors
     def delete_sync_state(self, index: Optional[int] = None) -> bool:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -910,7 +910,8 @@ class Etcd3(AbstractEtcd):
 
     @catch_etcd_errors
     def set_sync_state_value(self, value: str, index: Optional[str] = None) -> Union[str, bool]:
-        return self.retry(self._client.put, self.sync_path, value, mod_revision=index).get('header', {}).get('revision')
+        return self.retry(self._client.put, self.sync_path, value, mod_revision=index)\
+            .get('header', {}).get('revision', False)
 
     @catch_etcd_errors
     def delete_sync_state(self, index: Optional[str] = None) -> bool:

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -340,7 +340,8 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
         return self.call_rpc('/lease/keepalive', {'ID': ID}, retry).get('result', {}).get('TTL')
 
     def txn(self, compare: Dict[str, Any], success: Dict[str, Any], retry: Optional[Retry] = None) -> Dict[str, Any]:
-        return self.call_rpc('/kv/txn', {'compare': [compare], 'success': [success]}, retry).get('succeeded', {})
+        ret = self.call_rpc('/kv/txn', {'compare': [compare], 'success': [success]}, retry)
+        return ret if ret.get('succeeded') else {}
 
     @_handle_auth_errors
     def put(self, key: str, value: str, lease: Optional[str] = None, create_revision: Optional[str] = None,
@@ -908,8 +909,8 @@ class Etcd3(AbstractEtcd):
         return bool(self._client.put(self.history_path, value))
 
     @catch_etcd_errors
-    def set_sync_state_value(self, value: str, index: Optional[str] = None) -> bool:
-        return self.retry(self._client.put, self.sync_path, value, mod_revision=index)
+    def set_sync_state_value(self, value: str, index: Optional[str] = None) -> Union[str, bool]:
+        return self.retry(self._client.put, self.sync_path, value, mod_revision=index).get('header', {}).get('revision')
 
     @catch_etcd_errors
     def delete_sync_state(self, index: Optional[str] = None) -> bool:

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -15,6 +15,8 @@ def kv_get(self, key, **kwargs):
         return None, None
     if key == 'service/good/leader':
         return '1', None
+    if key == 'service/good/sync':
+        return '1', {'ModifyIndex': 1, 'Value': b'{}'}
     good_cls = ('6429',
                 [{'CreateIndex': 1334, 'Flags': 0, 'Key': key + 'failover', 'LockIndex': 0,
                   'ModifyIndex': 1334, 'Value': b''},
@@ -224,7 +226,11 @@ class TestConsul(unittest.TestCase):
     @patch.object(consul.Consul.KV, 'delete', Mock(return_value=True))
     @patch.object(consul.Consul.KV, 'put', Mock(return_value=True))
     def test_sync_state(self):
-        self.assertTrue(self.c.set_sync_state_value('{}'))
+        self.assertEqual(self.c.set_sync_state_value('{}'), 1)
+        with patch('time.time', Mock(side_effect=[1, 100, 1000])):
+            self.assertFalse(self.c.set_sync_state_value('{}'))
+        with patch.object(consul.Consul.KV, 'put', Mock(return_value=False)):
+            self.assertFalse(self.c.set_sync_state_value('{}'))
         self.assertTrue(self.c.delete_sync_state())
 
     @patch.object(consul.Consul.KV, 'put', Mock(return_value=True))

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -338,7 +338,7 @@ class TestEtcd(unittest.TestCase):
         self.assertTrue(self.etcd.watch(None, 1))
 
     def test_sync_state(self):
-        self.assertFalse(self.etcd.write_sync_state('leader', None))
+        self.assertIsNone(self.etcd.write_sync_state('leader', None))
         self.assertFalse(self.etcd.delete_sync_state())
 
     def test_set_history_value(self):

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -370,11 +370,15 @@ class TestKubernetesEndpoints(BaseTestKubernetes):
         mock_read.side_effect = Exception
         self.assertFalse(self.k.update_leader('123'))
 
-    @patch.object(k8s_client.CoreV1Api, 'create_namespaced_endpoints',
+    @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_endpoints',
                   Mock(side_effect=[k8s_client.rest.ApiException(500, ''),
                                     k8s_client.rest.ApiException(502, '')]), create=True)
     def test_delete_sync_state(self):
-        self.assertFalse(self.k.delete_sync_state())
+        self.assertFalse(self.k.delete_sync_state(1))
+
+    @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_endpoints', mock_namespaced_kind, create=True)
+    def test_write_sync_state(self):
+        self.assertIsNotNone(self.k.write_sync_state('a', ['b'], 1))
 
     @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_pod', mock_namespaced_kind, create=True)
     @patch.object(k8s_client.CoreV1Api, 'create_namespaced_endpoints', mock_namespaced_kind, create=True)

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -138,6 +138,7 @@ class TestRaft(unittest.TestCase):
         self.assertTrue(raft.cancel_initialization())
         self.assertTrue(raft.set_config_value('{}'))
         self.assertTrue(raft.write_sync_state('foo', 'bar'))
+        self.assertFalse(raft.write_sync_state('foo', 'bar', 1))
         raft._citus_group = '1'
         self.assertTrue(raft.manual_failover('foo', 'bar'))
         raft._citus_group = '0'


### PR DESCRIPTION
Make it return the new `SyncState` object in order to avoid reading the new cluster state in the Ha.process_sync_replication().

Now it is a small optimization, but it will become very handy in the quorum commit feature.