### PR TITLE
Remove `__str__` method from `PatroniException`.

### DIFF
--- a/patroni/exceptions.py
+++ b/patroni/exceptions.py
@@ -8,13 +8,6 @@ class PatroniException(Exception):
     def __init__(self, value: Any) -> None:
         self.value = value
 
-    def __str__(self) -> str:
-        """
-        >>> str(PatroniException('foo'))
-        "'foo'"
-        """
-        return repr(self.value)
-
 
 class PatroniFatalException(PatroniException):
     pass


### PR DESCRIPTION
The `__str__` method was calling `repr` over the exception message, which was causing `print` calls to render not so nicely, e.g.:

```
$ patronictl show-config
Error: 'Can not find suitable configuration of distributed configuration store\nAvailable implementations: consul, etcd, etcd3, exhibitor, kubernetes, raft, zookeeper'
```

By removing the `__str__` method we get a better rendering, e.g.:

```
$ patronictl show-config
Error: Can not find suitable configuration of distributed configuration store
Available implementations: consul, etcd, etcd3, exhibitor, kubernetes, raft, zookeeper
```

References: PAT-107.