### PR TITLE
Add support for custom Postgres binary names

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -135,7 +135,7 @@ PostgreSQL
 -  **PATRONI\_POSTGRESQL\_PROXY\_ADDRESS**: IP address + port through which a connection pool (e.g. pgbouncer) running next to Postgres is accessible. The value is written to the member key in DCS as ``proxy_url`` and could be used/useful for service discovery.
 -  **PATRONI\_POSTGRESQL\_DATA\_DIR**: The location of the Postgres data directory, either existing or to be initialized by Patroni.
 -  **PATRONI\_POSTGRESQL\_CONFIG\_DIR**: The location of the Postgres configuration directory, defaults to the data directory. Must be writable by Patroni.
--  **PATRONI\_POSTGRESQL\_BIN_DIR**: Path to PostgreSQL binaries. (pg_ctl, pg_rewind, pg_basebackup, postgres) The  default value is an empty string meaning that PATH environment variable will be used to find the executables.
+-  **PATRONI\_POSTGRESQL\_BIN_DIR**: Path to PostgreSQL binaries. (pg_ctl, initdb, pg_controldata, pg_basebackup, postgres, pg_isready, pg_rewind) The  default value is an empty string meaning that PATH environment variable will be used to find the executables.
 -  **PATRONI\_POSTGRESQL\_PGPASS**: path to the `.pgpass <https://www.postgresql.org/docs/current/static/libpq-pgpass.html>`__ password file. Patroni creates this file before executing pg\_basebackup and under some other circumstances. The location must be writable by Patroni.
 -  **PATRONI\_REPLICATION\_USERNAME**: replication username; the user will be created during initialization. Replicas will use this user to access the replication source via streaming replication
 -  **PATRONI\_REPLICATION\_PASSWORD**: replication password; the user will be created during initialization.

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -258,7 +258,16 @@ PostgreSQL
       own config item. See :ref:`custom replica creation methods documentation <custom_replica_creation>` for further explanation.
    -  **data\_dir**: The location of the Postgres data directory, either :ref:`existing <existing_data>` or to be initialized by Patroni.
    -  **config\_dir**: The location of the Postgres configuration directory, defaults to the data directory. Must be writable by Patroni.
-   -  **bin\_dir**: (optional) Path to PostgreSQL binaries (pg_ctl, pg_rewind, pg_basebackup, postgres). If not provided or is an empty string, PATH environment variable will be used to find the executables.
+   -  **bin\_dir**: (optional) Path to PostgreSQL binaries (pg_ctl, initdb, pg_controldata, pg_basebackup, postgres, pg_isready, pg_rewind). If not provided or is an empty string, PATH environment variable will be used to find the executables.
+   -  **bin\_name**: (optional) Make it possible to override Postgres binary names, if you are using a custom Postgres distribution:
+
+      - **pg\_ctl**: (optional) Custom name for ``pg_ctl`` binary.
+      - **initdb**: (optional) Custom name for ``initdb`` binary.
+      - **pg\controldata**: (optional) Custom name for ``pg_controldata`` binary.
+      - **pg\_basebackup**: (optional) Custom name for ``pg_basebackup`` binary.
+      - **postgres**: (optional) Custom name for ``postgres`` binary.
+      - **pg\_isready**: (optional) Custom name for ``pg_isready`` binary.
+      - **pg\_rewind**: (optional) Custom name for ``pg_rewind`` binary.
    -  **listen**: IP address + port that Postgres listens to; must be accessible from other nodes in the cluster, if you're using streaming replication. Multiple comma-separated addresses are permitted, as long as the port component is appended after to the last one with a colon, i.e. ``listen: 127.0.0.1,127.0.0.2:5432``. Patroni will use the first address from this list to establish local connections to the PostgreSQL node.
    -  **use\_unix\_socket**: specifies that Patroni should prefer to use unix sockets to connect to the cluster. Default value is ``false``. If ``unix_socket_directories`` is defined, Patroni will use the first suitable value from it to connect to the cluster and fallback to tcp if nothing is suitable. If ``unix_socket_directories`` is not specified in ``postgresql.parameters``, Patroni will assume that the default value should be used and omit ``host`` from the connection parameters.
    -  **use\_unix\_socket\_repl**: specifies that Patroni should prefer to use unix sockets for replication user cluster connection. Default value is ``false``. If ``unix_socket_directories`` is defined, Patroni will use the first suitable value from it to connect to the cluster and fallback to tcp if nothing is suitable. If ``unix_socket_directories`` is not specified in ``postgresql.parameters``, Patroni will assume that the default value should be used and omit ``host`` from the connection parameters.

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -227,8 +227,17 @@ class Postgresql(object):
         return 0
 
     def pgcommand(self, cmd: str) -> str:
-        """Returns path to the specified PostgreSQL command"""
-        return os.path.join(self._bin_dir, cmd)
+        """Return path to the specified PostgreSQL command.
+
+        .. note::
+            If ``postgresql.bin_name.*cmd*`` was configured by the user then that binary name is used, otherwise the
+            default binary name *cmd* is used.
+
+        :param cmd: the Postgres binary name to get path to.
+
+        :returns: path to Postgres binary named *cmd*.
+        """
+        return os.path.join(self._bin_dir, (self.config.get('bin_name', {}) or {}).get(cmd, cmd))
 
     def pg_ctl(self, cmd: str, *args: str, **kwargs: Any) -> bool:
         """Builds and executes pg_ctl command

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -457,7 +457,9 @@ class BinDirectory(Directory):
     :cvar BINARIES: list of executable files that should exist directly under a given Postgres binary directory.
     """
 
-    BINARIES = ["pg_ctl", "initdb", "pg_controldata", "pg_basebackup", "postgres", "pg_isready", "pg_rewind"]
+    # ``pg_rewind`` is not in the list because its usage by Patroni is optional. Also, it is not available by default on
+    # Postgres 9.3 and 9.4, versions which Patroni supports.
+    BINARIES = ["pg_ctl", "initdb", "pg_controldata", "pg_basebackup", "postgres", "pg_isready"]
 
     def validate(self, name: str) -> Iterator[Result]:
         """Check if the expected executables can be found under *name* binary directory.

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -457,7 +457,7 @@ class BinDirectory(Directory):
     :cvar BINARIES: list of executable files that should exist directly under a given Postgres binary directory.
     """
 
-    BINARIES = ["pg_ctl", "initdb", "pg_controldata", "pg_basebackup", "postgres", "pg_isready"]
+    BINARIES = ["pg_ctl", "initdb", "pg_controldata", "pg_basebackup", "postgres", "pg_isready", "pg_rewind"]
 
     def validate(self, name: str) -> Iterator[Result]:
         """Check if the expected executables can be found under *name* binary directory.
@@ -904,6 +904,7 @@ schema = Schema({
             Optional("pg_basebackup"): validate_binary_name,
             Optional("postgres"): validate_binary_name,
             Optional("pg_isready"): validate_binary_name,
+            Optional("pg_rewind"): validate_binary_name,
         },
         Optional("bin_dir", ""): BinDirectory(),
         Optional("parameters"): {

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -280,7 +280,7 @@ def validate_binary_name(bin_name: str) -> bool:
         raise ConfigParseError("is an empty string")
     bin_dir = schema.data.get('postgresql', {}).get('bin_dir', None)
     if not shutil.which(bin_name, path=bin_dir):
-        raise ConfigParseError(f"does not contain '{bin_name}' in '{bin_dir}'")
+        raise ConfigParseError(f"does not contain '{bin_name}' in '{bin_dir or '$PATH'}'")
     return True
 
 

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -557,7 +557,6 @@ class Schema(object):
             instance.
         """
         self.validator = validator
-        # self.data: Any = None
 
     def __call__(self, data: Any) -> List[str]:
         """Perform validation of data using the rules defined in this schema.

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -183,7 +183,7 @@ def get_bin_name(bin_name: str) -> str:
 
     :returns: value of ``postgresql.bin_name[*bin_name*]``, if present, otherwise *bin_name*.
     """
-    return schema.data.get('postgresql', {}).get('bin_name', {}).get(bin_name, bin_name)
+    return (schema.data.get('postgresql', {}).get('bin_name', {}) or {}).get(bin_name, bin_name)
 
 
 def get_major_version(bin_dir: OptionalType[str] = None) -> str:

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -467,9 +467,7 @@ class BinDirectory(Directory):
 
         :yields: objects with the error message related to the failure, if any check fails.
         """
-        self.contains_executable: List[str] = []
-        for binary in self.BINARIES:
-            self.contains_executable.append(get_bin_name(binary))
+        self.contains_executable: List[str] = [get_bin_name(binary) for binary in self.BINARIES]
         yield from super().validate(name)
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -99,7 +99,7 @@ schema2 = Schema({
     "some_dir": Directory(contains=["very_interesting_subdir", "another_interesting_subdir"])
 })
 
-required_binaries = ["pg_ctl", "initdb", "pg_controldata", "pg_basebackup", "postgres", "pg_isready", "pg_rewind"]
+required_binaries = ["pg_ctl", "initdb", "pg_controldata", "pg_basebackup", "postgres", "pg_isready"]
 
 directories = []
 files = []


### PR DESCRIPTION
When using a custom Postgres distribution it may be the case that the Postgres binaries are compiled with different names other than the ones used by the community Postgres distribution.

With that in mind we implemented a new set of settings for Patroni, so the user is able to override the default binary names with custom binary names through the new section postgresql.bin_name in the local configuration.

References: PAT-17.