### PR TITLE
Fix a minor error building a docker image for citus

### DIFF
--- a/Dockerfile.citus
+++ b/Dockerfile.citus
@@ -40,7 +40,7 @@ RUN set -ex \
         echo "deb [signed-by=/etc/apt/trusted.gpg.d/citusdata_community.gpg] https://packagecloud.io/citusdata/community/debian/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/citusdata_community.list \
         && curl -sL https://packagecloud.io/citusdata/community/gpgkey | gpg --dearmor > /etc/apt/trusted.gpg.d/citusdata_community.gpg \
         && apt-get update -y \
-        && apt-get -y install postgresql-$PG_MAJOR-citus-11.3 \
+        && apt-get -y install postgresql-$PG_MAJOR-citus-11.3; \
     fi \
     && pip3 install dumb-init \
 \


### PR DESCRIPTION
This handles the following syntax error.

```
$ docker build -t patroni-citus -f Dockerfile.citus . 
(snip)
  => ERROR [builder 2/3] RUN set -ex     && export DEBIAN_FRONTEND=noninteractive     && echo  0.5s -
(snip)
  #5 0.456 /bin/sh: 1: Syntax error: end of file unexpected (expecting "fi")
```