### PR TITLE
Set encoding on open call in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ You can find a version of this documentation that is searchable and also easier 
 
 There are many ways to run high availability with PostgreSQL; for a list, see the `PostgreSQL Documentation <https://wiki.postgresql.org/wiki/Replication,_Clustering,_and_Connection_Pooling>`__.
 
-Patroni is a template for high availability (HA) PostgreSQL solutions using Python. For maximum accessibility, Patroni supports a variety of distributed configuration stores like `ZooKeeper <https://zookeeper.apache.org/>`__, `etcd <https://github.com/coreos/etcd>`__, `Consul <https://github.com/hashicorp/consul>`__ or `Kubernetes <https://kubernetes.io>`__. Database engineers, DBAs, DevOps engineers, and SREs who are looking to quickly deploy HA PostgreSQL in datacenters — or anywhere else — will hopefully find it useful.
+Patroni is a template for high availability (HA) PostgreSQL solutions using Python. For maximum accessibility, Patroni supports a variety of distributed configuration stores like `ZooKeeper <https://zookeeper.apache.org/>`__, `etcd <https://github.com/coreos/etcd>`__, `Consul <https://github.com/hashicorp/consul>`__ or `Kubernetes <https://kubernetes.io>`__. Database engineers, DBAs, DevOps engineers, and SREs who are looking to quickly deploy HA PostgreSQL in datacenters - or anywhere else - will hopefully find it useful.
 
 We call Patroni a "template" because it is far from being a one-size-fits-all or plug-and-play replication system. It will have its own caveats. Use wisely.
 

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ class PyTest(_Command):
 
 
 def read(fname):
-    with open(os.path.join(__location__, fname)) as fd:
+    with open(os.path.join(__location__, fname), encoding='utf-8') as fd:
         return fd.read()
 
 


### PR DESCRIPTION
If a host OS does not have a UTF-8 locale set the read() call is unable to read the utf-8 encoded README.rst file.

e.g. on centos:7

```
[root@d9de6028b39f src]# python3 setup.py build
Traceback (most recent call last):
  File "setup.py", line 182, in <module>
    setup_package(__version__)
  File "setup.py", line 157, in setup_package
    long_description=read('README.rst'),
  File "setup.py", line 120, in read
    return fd.read()
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1004: ordinal not in range(128)
```

I think perhaps the encoding of the README.rst changed in the last release?

note: can work around this by setting LC_ALL, e.g.
```
export LC_ALL=en_US.UTF-8
```