### PR TITLE
Update .gitignore to include common venv/data patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ docs/source/_templates/
 .vscode/
 
 # Virtual environment
-venv*
+venv*/
 
 # Default test data directory
-data
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ docs/source/_templates/
 
 #VSCode IDE
 .vscode/
+
+# Virtual environment
+venv*
+
+# Default test data directory
+data


### PR DESCRIPTION
Addresses #2731 by adding `venv*` and `data` patterns to the `.gitignore` to make development slightly easier for common setups.