### PR TITLE
Document and refactor dcs/__init__.py and postgres/slots.py

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1,3 +1,4 @@
+"""Abstract classes for Distributed Configuration Store."""
 import abc
 import dateutil.parser
 import datetime
@@ -32,30 +33,45 @@ logger = logging.getLogger(__name__)
 def slot_name_from_member_name(member_name: str) -> str:
     """Translate member name to valid PostgreSQL slot name.
 
-    PostgreSQL's replication slot names must be valid PostgreSQL names. This function maps the wider space of
-    member names to valid PostgreSQL names. Names are lowercase, dashes and periods common in hostnames
-    are replaced with underscores, other characters are encoded as their unicode codepoint. Name is truncated
-    to 64 characters. Multiple different member names may map to a single slot name."""
+    .. note::
+        PostgreSQL's replication slot names must be valid PostgreSQL names. This function maps the wider space of
+        member names to valid PostgreSQL names. Names have their case lowered, dashes and periods common in hostnames
+        are replaced with underscores, other characters are encoded as their unicode codepoint. Name is truncated
+        to 64 characters. Multiple different member names may map to a single slot name.
+
+    :param member_name: The string to convert to a slot name.
+
+    :return: The string converted using the rules described above.
+    """
 
     def replace_char(match: Any) -> str:
         c = match.group(0)
-        return '_' if c in '-.' else "u{:04d}".format(ord(c))
+        return '_' if c in '-.' else f"u{ord(c):04d}"
 
     slot_name = re.sub('[^a-z0-9_]', replace_char, member_name.lower())
     return slot_name[0:63]
 
 
 def parse_connection_string(value: str) -> Tuple[str, Union[str, None]]:
-    """Original Governor stores connection strings for each cluster members if a following format:
-        postgres://{username}:{password}@{connect_address}/postgres
-    Since each of our patroni instances provides own REST API endpoint it's good to store this information
-    in DCS among with postgresql connection string. In order to not introduce new keys and be compatible with
-    original Governor we decided to extend original connection string in a following way:
-        postgres://{username}:{password}@{connect_address}/postgres?application_name={api_url}
-    This way original Governor could use such connection string as it is, because of feature of `libpq` library.
+    """Split and rejoin a URL string into a connection URL and an API URL.
 
-    This method is able to split connection string stored in DCS into two parts, `conn_url` and `api_url`"""
+    .. note::
+        Original Governor stores connection strings for each cluster members if a following format:
 
+            postgres://{username}:{password}@{connect_address}/postgres
+
+        Since each of our patroni instances provides their own REST API endpoint, it's good to store this information
+        in DCS along with PostgreSQL connection string. In order to not introduce new keys and be compatible with
+        original Governor we decided to extend original connection string in a following way:
+
+            postgres://{username}:{password}@{connect_address}/postgres?application_name={api_url}
+
+        This way original Governor could use such connection string as it is, because of feature of `libpq` library.
+
+    :param value: The URL string to split.
+
+    :returns: the connection string stored in DCS split into two parts, `conn_url` and `api_url`.
+    """
     scheme, netloc, path, params, query, fragment = urlparse(value)
     conn_url = urlunparse((scheme, netloc, path, params, '', fragment))
     api_url = ([v for n, v in parse_qsl(query) if n == 'application_name'] or [None])[0]
@@ -63,11 +79,15 @@ def parse_connection_string(value: str) -> Tuple[str, Union[str, None]]:
 
 
 def dcs_modules() -> List[str]:
-    """Get names of DCS modules, depending on execution environment. If being packaged with PyInstaller,
-    modules aren't discoverable dynamically by scanning source directory because `FrozenImporter` doesn't
-    implement `iter_modules` method. But it is still possible to find all potential DCS modules by
-    iterating through `toc`, which contains list of all "frozen" resources."""
+    """Get names of DCS modules, depending on execution environment.
 
+    .. note::
+        If being packaged with PyInstaller, modules aren't discoverable dynamically by scanning source directory because
+        :class:`importlib.machinery.FrozenImporter` doesn't implement :meth:`iter_modules`. But it is still possible to
+        find all potential DCS modules by iterating through ``toc``, which contains list of all "frozen" resources.
+
+    :returns: list of known module names with absolute python module path namespace, e.g. ``patroni.dcs.etcd``.
+    """
     dcs_dirname = os.path.dirname(__file__)
     module_prefix = __package__ + '.'
 
@@ -81,11 +101,30 @@ def dcs_modules() -> List[str]:
             if hasattr(importer, 'toc'):
                 toc |= getattr(importer, 'toc')
         return [module for module in toc if module.startswith(module_prefix) and module.count('.') == 2]
-    else:
-        return [module_prefix + name for _, name, is_pkg in pkgutil.iter_modules([dcs_dirname]) if not is_pkg]
+
+    return [module_prefix + name for _, name, is_pkg in pkgutil.iter_modules([dcs_dirname]) if not is_pkg]
 
 
 def get_dcs(config: Union['Config', Dict[str, Any]]) -> 'AbstractDCS':
+    """Attempt to load a Distributed Configuration Store from known available implementations.
+
+    .. note::
+        Using the list of available DCS modules returned by :func:`dcs_modules` attempt to dynamically import and
+        instantiate the class that implements a DCS using the abstract class :class:`AbstractDCS`.
+
+        Basic top-level configuration parameters retrieved from *config* are propagated to the DCS specific config
+        before being passed to the module DCS class.
+
+        If a module successfully imports we can assume that all its requirements are installed.
+        If no module is loaded successfully then report and log an error. This will cause Patroni to exit.
+
+    :raises :exc:`PatroniFatalException`: if a load of all available DCS modules have been tried and none succeeded.
+
+    :param config: object or dictionary with Patroni configuration. This is normally a representation of the main
+                   Patroni
+
+    :return: The first successfully loaded DCS module which is an implementation of :class:`AbstractDCS`.
+    """
     modules = dcs_modules()
 
     for module_name in modules:
@@ -115,8 +154,9 @@ def get_dcs(config: Union['Config', Dict[str, Any]]) -> 'AbstractDCS':
                                              and inspect.isclass(item) and issubclass(item, AbstractDCS))
         except ImportError:
             logger.info('Failed to import %s', module_name)
-    raise PatroniFatalException("""Can not find suitable configuration of distributed configuration store
-Available implementations: """ + ', '.join(sorted(set(available_implementations))))
+    raise PatroniFatalException(
+        f"Can not find suitable configuration of distributed configuration store\n"
+        f"Available implementations: {', '.join(sorted(set(available_implementations)))}")
 
 
 _Version = Union[int, str]
@@ -125,16 +165,22 @@ _Session = Union[int, float, str, None]
 
 class Member(NamedTuple):
     """Immutable object (namedtuple) which represents single member of PostgreSQL cluster.
-    Consists of the following fields:
-    :param version: modification version of a given member key in a Configuration Store
-    :param name: name of PostgreSQL cluster member
-    :param session: either session id or just ttl in seconds
-    :param data: arbitrary data i.e. conn_url, api_url, xlog location, state, role, tags, etc...
 
-    There are two mandatory keys in a data:
-    conn_url: connection string containing host, user and password which could be used to access this member.
-    api_url: REST API url of patroni instance
+    .. note::
+        There are two mandatory keys in a data:
+
+        conn_url: connection string containing host, user and password which could be used to access this member.
+        api_url: REST API url of patroni instance
+
+    Consists of the following fields:
+
+    :ivar version: modification version of a given member key in a Configuration Store.
+    :ivar name: name of PostgreSQL cluster member.
+    :ivar session: either session id or just ttl in seconds.
+    :ivar data: dictionary containing arbitrary data i.e. ``conn_url``, ``api_url``, ``xlog_location``, ``state``,
+                ``role``, ``tags``, etc...
     """
+
     version: _Version
     name: str
     session: _Session
@@ -142,11 +188,22 @@ class Member(NamedTuple):
 
     @staticmethod
     def from_node(version: _Version, name: str, session: _Session, value: str) -> 'Member':
-        """
-        >>> Member.from_node(-1, '', '', '{"conn_url": "postgres://foo@bar/postgres"}') is not None
-        True
-        >>> Member.from_node(-1, '', '', '{')
-        Member(version=-1, name='', session='', data={})
+        """Factory method for instantiating :class:`Member` from a JSON serialised string or object.
+
+        :Example:
+
+            >>> Member.from_node(-1, '', '', '{"conn_url": "postgres://foo@bar/postgres"}') is not None
+            True
+            >>> Member.from_node(-1, '', '', '{')
+            Member(version=-1, name='', session='', data={})
+
+        :param version: modification version of a given member key in a Configuration Store.
+        :param name: name of PostgreSQL cluster member.
+        :param session: either session id or just ttl in seconds.
+        :param value: dictionary containing arbitrary data i.e. ``conn_url``, ``api_url``, ``xlog_location``, ``state``,
+                      ``role``, ``tags``, etc...
+
+        :return:
         """
         if value.startswith('postgres'):
             conn_url, api_url = parse_connection_string(value)
@@ -161,6 +218,7 @@ class Member(NamedTuple):
 
     @property
     def conn_url(self) -> Optional[str]:
+        """The ``conn_url`` value from :attr:`~Member.data` if defined or constructed from ``conn_kwargs``."""
         conn_url = self.data.get('conn_url')
         if conn_url:
             return conn_url
@@ -171,7 +229,21 @@ class Member(NamedTuple):
             self.data['conn_url'] = conn_url
             return conn_url
 
+        return None
+
     def conn_kwargs(self, auth: Union[Any, Dict[str, Any], None] = None) -> Dict[str, Any]:
+        """Give keyword arguments used for PostgreSQL connection settings.
+
+        :param auth: Authentication properties - can be defined as anything supported by the ``psycopg2`` or
+                     ``psycopg`` modules. See,
+                     Converts a key of ``username`` to ``user`` if supplied.
+
+        :returns: A dictionary containing a merge of default parameter keys ``host``, ``port`` and ``dbname``, with
+                 the contents of :attr:`~Member.data` ``conn_kwargs`` key. If those are not defined will
+                 parse and reform connection parameters from :attr:`~Member.conn_url`. One of these two attributes
+                 needs to have data defined to construct the output dictionary. Finally, *auth* parameters are merged
+                 with the dictionary before returned.
+        """
         defaults = {
             "host": None,
             "port": None,
@@ -202,127 +274,185 @@ class Member(NamedTuple):
 
     @property
     def api_url(self) -> Optional[str]:
+        """The ``api_url`` value from :attr:`~Member.data` if defined."""
         return self.data.get('api_url')
 
     @property
     def tags(self) -> Dict[str, Any]:
+        """The ``tags`` value from :attr:`~Member.data` if defined, otherwise an empty dictionary."""
         return self.data.get('tags', {})
 
     @property
     def nofailover(self) -> bool:
+        """The value for ``nofailover`` in :attr:`Member`.tags`` if defined, otherwise ``False``."""
         return self.tags.get('nofailover', False)
 
     @property
     def replicatefrom(self) -> Optional[str]:
+        """The value for ``replicatefrom`` in :attr:`Member`.tags`` if defined."""
         return self.tags.get('replicatefrom')
 
     @property
     def clonefrom(self) -> bool:
+        """``True`` if both a node to clone from and a connection URL is defined."""
         return self.tags.get('clonefrom', False) and bool(self.conn_url)
 
     @property
     def state(self) -> str:
+        """The ``state`` value of :attr:`~Member.data`."""
         return self.data.get('state', 'unknown')
 
     @property
     def is_running(self) -> bool:
+        """``True`` if the member :attr:`~Member.state` is ``running``."""
         return self.state == 'running'
 
     @property
     def patroni_version(self) -> Optional[Tuple[int, ...]]:
+        """The ``version`` string value from :attr:`~Member.data` converted to tuple.
+
+        :Example:
+
+            >>> Member.from_node(1, '', '', '{"version":"1.2.3"}').patroni_version
+            (1, 2, 3)
+
+        """
         version = self.data.get('version')
         if version:
             try:
                 return tuple(map(int, version.split('.')))
             except Exception:
                 logger.debug('Failed to parse Patroni version %s', version)
+        return None
 
 
 class RemoteMember(Member):
-    """Represents a remote member (typically a primary) for a standby cluster"""
+    """Represents a remote member (typically a primary) for a standby cluster."""
+
+    ALLOWED_KEYS: Tuple[str, ...] = (
+        'primary_slot_name',
+        'create_replica_methods',
+        'restore_command',
+        'archive_cleanup_command',
+        'recovery_min_apply_delay',
+        'no_replication_slot'
+    )
 
     @classmethod
     def from_name_and_data(cls, name: str, data: Dict[str, Any]) -> 'RemoteMember':
-        return super(RemoteMember, cls).__new__(cls, -1, name, None, data)
+        """Factory method to construct instance from given *name* and *data*.
 
-    @staticmethod
-    def allowed_keys() -> Tuple[str, ...]:
-        return ('primary_slot_name',
-                'create_replica_methods',
-                'restore_command',
-                'archive_cleanup_command',
-                'recovery_min_apply_delay',
-                'no_replication_slot')
+        :param name: name of the remote member.
+        :param data: dictionary of member information.
+
+        :returns: constructed instance using supplied parameters.
+        """
+        return super().__new__(cls, -1, name, None, data)
 
     def __getattr__(self, name: str) -> Any:
-        if name in RemoteMember.allowed_keys():
+        """Dictionary style key lookup.
+
+        :param name: key to lookup.
+
+        :returns: value of :attr:`~RemoteMember.data` if key name is in :const:`~RemoteMember.ALLOWED_KEYS`.
+        """
+        if name in RemoteMember.ALLOWED_KEYS:
             return self.data.get(name)
+        return None
 
 
 class Leader(NamedTuple):
     """Immutable object (namedtuple) which represents leader key.
 
     Consists of the following fields:
-    :param version: modification version of a leader key in a Configuration Store
-    :param session: either session id or just ttl in seconds
-    :param member: reference to a `Member` object which represents current leader (see `Cluster.members`)
+
+    :ivar version: modification version of a leader key in a Configuration Store
+    :ivar session: either session id or just ttl in seconds
+    :ivar member: reference to a `Member` object which represents current leader (see `Cluster.members`)
     """
+
     version: _Version
     session: _Session
     member: Member
 
     @property
     def name(self) -> str:
+        """The leader "member" name."""
         return self.member.name
 
     def conn_kwargs(self, auth: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        """Connection keyword arguments.
+
+        :param auth: an optional dictionary containing authentication information.
+
+        :return: the result of the called :meth:`Member.conn_kwargs` method.
+        """
         return self.member.conn_kwargs(auth)
 
     @property
     def conn_url(self) -> Optional[str]:
+        """Connection URL value of the :class:`Member` instance."""
         return self.member.conn_url
 
     @property
     def data(self) -> Dict[str, Any]:
+        """Data value of the :class:`Member` instance."""
         return self.member.data
 
     @property
     def timeline(self) -> Optional[int]:
+        """Timeline value of :attr:`~Leader.data`."""
         return self.data.get('timeline')
 
     @property
     def checkpoint_after_promote(self) -> Optional[bool]:
-        """
-        >>> Leader(1, '', Member.from_node(1, '', '', '{"version":"z"}')).checkpoint_after_promote
+        """Determine whether a checkpoint should be made for this leader after promotion.
 
+        :Example:
+
+            >>> Leader(1, '', Member.from_node(1, '', '', '{"version":"z"}')).checkpoint_after_promote
+
+        :return: ``True`` if the role is ``master`` or ``primary`` and ``checkpoint_after_promote`` is not set,
+                 ``False`` if not a ``master`` or ``primary`` or if the checkpoint has already been made.
+                 If the version of Patroni is older than 1.5.6, return ``None``.
         """
         version = self.member.patroni_version
         # 1.5.6 is the last version which doesn't expose checkpoint_after_promote: false
         if version and version > (1, 5, 6):
             return self.data.get('role') in ('master', 'primary') and 'checkpoint_after_promote' not in self.data
+        return None
 
 
 class Failover(NamedTuple):
+    """Immutable object (namedtuple) which represents configuration information required for failover capability.
 
+    :Example:
+        >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader"}'))
+        True
+        >>> 'Failover' in str(Failover.from_node(1, {"leader": "cluster_leader"}))
+        True
+        >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader", "member": "cluster_candidate"}'))
+        True
+        >>> Failover.from_node(1, 'null') is None
+        False
+        >>> n = '''{"leader": "cluster_leader", "member": "cluster_candidate",
+        ...         "scheduled_at": "2016-01-14T10:09:57.1394Z"}'''
+        >>> 'tzinfo=' in str(Failover.from_node(1, n))
+        True
+        >>> Failover.from_node(1, None) is None
+        False
+        >>> Failover.from_node(1, '{}') is None
+        False
+        >>> 'abc' in Failover.from_node(1, 'abc:def')
+        True
+
+    :ivar version: *version* of the object
+    :ivar leader: name of the leader
+    :ivar candidate: the name of the member node to be considered as a fail-over *candidate*.
+    :ivar scheduled_at: in the case of a switchover the :func:`~datetime.datetime` object to perfrom the scheduled
+                        switchover.
     """
-    >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader"}'))
-    True
-    >>> 'Failover' in str(Failover.from_node(1, {"leader": "cluster_leader"}))
-    True
-    >>> 'Failover' in str(Failover.from_node(1, '{"leader": "cluster_leader", "member": "cluster_candidate"}'))
-    True
-    >>> Failover.from_node(1, 'null') is None
-    False
-    >>> n = '{"leader": "cluster_leader", "member": "cluster_candidate", "scheduled_at": "2016-01-14T10:09:57.1394Z"}'
-    >>> 'tzinfo=' in str(Failover.from_node(1, n))
-    True
-    >>> Failover.from_node(1, None) is None
-    False
-    >>> Failover.from_node(1, '{}') is None
-    False
-    >>> 'abc' in Failover.from_node(1, 'abc:def')
-    True
-    """
+
     version: _Version
     leader: Optional[str]
     candidate: Optional[str]
@@ -330,6 +460,15 @@ class Failover(NamedTuple):
 
     @staticmethod
     def from_node(version: _Version, value: Union[str, Dict[str, str]]) -> 'Failover':
+        """Factory method to parse *value* as fail-over configuration.
+
+        :param version: *version* number for the object.
+        :param value: JSON serialized data or a dictionary of configuration.
+                      Can also be a colon ``:`` delimited list of leader, followed by candidate names.
+                      If ``scheduled_at`` key is defined the value will be parsed by :func:`dateutil.parser.parse`.
+
+        :return: constructed :class:`Failover` information object
+        """
         if isinstance(value, dict):
             data: Dict[str, Any] = value
         elif value:
@@ -352,21 +491,36 @@ class Failover(NamedTuple):
         return Failover(version, data.get('leader'), data.get('member'), data.get('scheduled_at'))
 
     def __len__(self) -> int:
+        """Implement ``len`` function capability."""
         return int(bool(self.leader)) + int(bool(self.candidate))
 
 
 class ClusterConfig(NamedTuple):
+    """Immutable object (namedtuple) which represents cluster configuration.
+
+    :ivar version: *version* number for the object.
+    :ivar data: dictionary of configuration information.
+    :ivar modify_version: modified version number.
+    """
+
     version: _Version
     data: Dict[str, Any]
     modify_version: _Version
 
     @staticmethod
     def from_node(version: _Version, value: str, modify_version: Optional[_Version] = None) -> 'ClusterConfig':
-        """
-        >>> ClusterConfig.from_node(1, '{') is None
-        False
-        """
+        """Factory method to parse *value* as configuration information.
 
+        :Example:
+            >>> ClusterConfig.from_node(1, '{') is None
+            False
+
+        :param version: version number for object.
+        :param value: raw JSON serialized data, if not parsable replaced with an empty dictionary.
+        :param modify_version: optional modify version number, use *version* if not provided.
+
+        :returns: constructed :class:`ClusterConfig` instance.
+        """
         try:
             data = json.loads(value)
             assert isinstance(data, dict)
@@ -377,44 +531,57 @@ class ClusterConfig(NamedTuple):
 
     @property
     def permanent_slots(self) -> Dict[str, Any]:
-        return self.data.get('permanent_replication_slots')\
-            or self.data.get('permanent_slots') or self.data.get('slots') or {}
+        """Dictionary of slot information looked up from :attr:`~ClusterConfig.data`."""
+        return (self.data.get('permanent_replication_slots')
+                or self.data.get('permanent_slots')
+                or self.data.get('slots')
+                or {})
 
     @property
     def ignore_slots_matchers(self) -> List[Dict[str, Any]]:
+        """The value for ``ignore_slots`` from :attr:`~ClusterConfig.data`."""
         return self.data.get('ignore_slots') or []
 
     @property
     def max_timelines_history(self) -> int:
+        """The value for ``max_timelines_history`` from :attr:`~ClusterConfig.data`."""
         return self.data.get('max_timelines_history', 0)
 
 
 class SyncState(NamedTuple):
-    """Immutable object (namedtuple) which represents last observed synhcronous replication state
+    """Immutable object (namedtuple) which represents last observed synchronous replication state.
 
-    :param version: modification version of a synchronization key in a Configuration Store
-    :param leader: reference to member that was leader
-    :param sync_standby: synchronous standby list (comma delimited) which are last synchronized to leader
+    :ivar version: modification version of a synchronization key in a Configuration Store.
+    :ivar leader: reference to member that was leader.
+    :ivar sync_standby: synchronous standby list (comma delimited) which are last synchronized to leader.
     """
+
     version: Optional[_Version]
     leader: Optional[str]
     sync_standby: Optional[str]
 
     @staticmethod
     def from_node(version: Optional[_Version], value: Union[str, Dict[str, Any], None]) -> 'SyncState':
-        """
-        >>> SyncState.from_node(1, None).leader is None
-        True
-        >>> SyncState.from_node(1, '{}').leader is None
-        True
-        >>> SyncState.from_node(1, '{').leader is None
-        True
-        >>> SyncState.from_node(1, '[]').leader is None
-        True
-        >>> SyncState.from_node(1, '{"leader": "leader"}').leader == "leader"
-        True
-        >>> SyncState.from_node(1, {"leader": "leader"}).leader == "leader"
-        True
+        """Factory method to parse *value* as synchronisation state information.
+
+        :Example:
+            >>> SyncState.from_node(1, None).leader is None
+            True
+            >>> SyncState.from_node(1, '{}').leader is None
+            True
+            >>> SyncState.from_node(1, '{').leader is None
+            True
+            >>> SyncState.from_node(1, '[]').leader is None
+            True
+            >>> SyncState.from_node(1, '{"leader": "leader"}').leader == "leader"
+            True
+            >>> SyncState.from_node(1, {"leader": "leader"}).leader == "leader"
+            True
+
+        :param version: optional *version* number for the object.
+        :param value: (optionally JSON serialised) sychronisation state information
+
+        :return: constructed :class:`SyncState` object.
         """
         try:
             if value and isinstance(value, str):
@@ -426,49 +593,62 @@ class SyncState(NamedTuple):
 
     @staticmethod
     def empty(version: Optional[_Version] = None) -> 'SyncState':
+        """Construct an empty :class:`SyncState` instance.
+
+        :param version: optional *version* number.
+
+        :return: empty synchronisation state object.
+        """
         return SyncState(version, None, None)
 
     @property
     def is_empty(self) -> bool:
-        """:returns: True if /sync key is not valid (doesn't have a leader)."""
+        """``True`` if ``/sync`` key is not valid (doesn't have a leader)."""
         return not self.leader
 
     @staticmethod
     def _str_to_list(value: str) -> List[str]:
         """Splits a string by comma and returns list of strings.
 
-        :param value: a comma separated string
-        :returns: list of non-empty strings after splitting an input value by comma
+        :param value: a comma separated string.
+
+        :returns: list of non-empty strings after splitting an input value by comma.
         """
         return list(filter(lambda a: a, [s.strip() for s in value.split(',')]))
 
     @property
     def members(self) -> List[str]:
-        """:returns: sync_standby as list."""
+        """:class:`~SyncState.sync_standby` as list or an empty list if undefined or object considered ``empty``."""
         return self._str_to_list(self.sync_standby) if not self.is_empty and self.sync_standby else []
 
     def matches(self, name: Optional[str], check_leader: bool = False) -> bool:
         """Checks if node is presented in the /sync state.
 
         Since PostgreSQL does case-insensitive checks for synchronous_standby_name we do it also.
-        :param name: name of the node
-        :param check_leader: by default the name is searched in members, check_leader=True will include leader to list
-        :returns: `True` if the /sync key not :func:`is_empty` and a given name is among presented in the sync state
-        >>> s = SyncState(1, 'foo', 'bar,zoo')
-        >>> s.matches('foo')
-        False
-        >>> s.matches('fOo', True)
-        True
-        >>> s.matches('Bar')
-        True
-        >>> s.matches('zoO')
-        True
-        >>> s.matches('baz')
-        False
-        >>> s.matches(None)
-        False
-        >>> SyncState.empty(1).matches('foo')
-        False
+
+        .. Examples::
+            >>> s = SyncState(1, 'foo', 'bar,zoo')
+            >>> s.matches('foo')
+            False
+            >>> s.matches('fOo', True)
+            True
+            >>> s.matches('Bar')
+            True
+            >>> s.matches('zoO')
+            True
+            >>> s.matches('baz')
+            False
+            >>> s.matches(None)
+            False
+            >>> SyncState.empty(1).matches('foo')
+            False
+
+        :param name: *name* of the node.
+        :param check_leader: by default the *name* is searched for only in members, a value of ``True`` will include the
+                             leader to list.
+
+        :returns: ``True`` if the ``/sync`` key not :func:`is_empty` and the given *name* is among those presented in
+                  the sync state.
         """
         ret = False
         if name and not self.is_empty:
@@ -477,7 +657,10 @@ class SyncState(NamedTuple):
         return ret
 
     def leader_matches(self, name: Optional[str]) -> bool:
-        """:returns: `True` if name is matching the `SyncState.leader` value."""
+        """Compare the given *name* to stored leader value.
+
+        :returns: ``True`` if name is matching the :attr:`~SyncState.leader` value.
+        """
         return bool(name and not self.is_empty and name.lower() == (self.leader or '').lower())
 
 
@@ -485,17 +668,32 @@ _HistoryTuple = Union[Tuple[int, int, str], Tuple[int, int, str, str], Tuple[int
 
 
 class TimelineHistory(NamedTuple):
-    """Object representing timeline history file"""
+    """Object representing timeline history file.
+
+    :ivar version: version number of the file.
+    :ivar value: raw JSON serialised data.
+    :ivar lines: parsed lines from the history file.
+    """
+
     version: _Version
     value: Any
     lines: List[_HistoryTuple]
 
     @staticmethod
     def from_node(version: _Version, value: str) -> 'TimelineHistory':
-        """
-        >>> h = TimelineHistory.from_node(1, 2)
-        >>> h.lines
-        []
+        """Parse the given JSON serialized string as a list of timeline history lines.
+
+        :Example:
+            If the passed *value* argument is not parsed an empty list of lines is returned:
+
+            >>> h = TimelineHistory.from_node(1, 2)
+            >>> h.lines
+            []
+
+        :param version: *version* number
+        :param value: JSON serialized string.
+
+        :return: composed timeline history object using parsed lines.
         """
         try:
             lines = json.loads(value)
@@ -507,12 +705,14 @@ class TimelineHistory(NamedTuple):
 
 class Cluster(NamedTuple):
     """Immutable object (namedtuple) which represents PostgreSQL cluster.
+
     Consists of the following fields:
+
     :param initialize: shows whether this cluster has initialization key stored in DC or not.
     :param config: global dynamic configuration, reference to `ClusterConfig` object
     :param leader: `Leader` object which represents current leader of the cluster
     :param last_lsn: int or long object containing position of last known leader LSN.
-        This value is stored in the `/status` key or `/optime/leader` (legacy) key
+                     This value is stored in the `/status` key or `/optime/leader` (legacy) key
     :param members: list of Member object, all PostgreSQL cluster members including leader
     :param failover: reference to `Failover` object
     :param sync: reference to `SyncState` object, last observed synchronous replication state.
@@ -521,6 +721,7 @@ class Cluster(NamedTuple):
     :param failsafe: failsafe topology. Node is allowed to become the leader only if its name is found in this list.
     :param workers: workers of the Citus cluster, optional. Format: {int(group): Cluster()}
     """
+
     initialize: Optional[str]
     config: Optional[ClusterConfig]
     leader: Optional[Leader]
@@ -535,50 +736,87 @@ class Cluster(NamedTuple):
 
     @staticmethod
     def empty() -> 'Cluster':
+        """Produce an empty :class:`Cluster` instance."""
         return Cluster(None, None, None, 0, [], None, SyncState.empty(), None, None, None)
 
     def is_empty(self):
-        return self.initialize is None and self.config is None and self.leader is None and self.last_lsn == 0\
-            and self.members == [] and self.failover is None and self.sync.version is None\
-            and self.history is None and self.slots is None and self.failsafe is None and self.workers == {}
+        """Validate definition of all attributes of this :class:`Cluster` instance.
+
+        :returns: ``True`` if the current :class:`Cluster` has unpopulated attributes.
+        """
+        return all((self.initialize is None, self.config is None, self.leader is None, self.last_lsn == 0,
+                    self.members == [], self.failover is None, self.sync.version is None,
+                    self.history is None, self.slots is None, self.failsafe is None, not self.workers))
 
     def __len__(self) -> int:
+        """Implement ``len`` function capability."""
         return int(not self.is_empty())
 
     @property
     def leader_name(self) -> Optional[str]:
+        """The name of the leader if defined otherwise ``None``."""
         return self.leader and self.leader.name
 
     def is_unlocked(self) -> bool:
+        """Check if the cluster does not have the leader lock.
+
+        :return: ``True`` if a leader name is defined.
+        """
         return not self.leader_name
 
     def has_member(self, member_name: str) -> bool:
+        """Check if the given member name is present in the cluster.
+
+        :param member_name: name to look up in the :attr:`~Cluster.members`.
+
+        :return: ``True`` if the member name is found.
+        """
         return any(m for m in self.members if m.name == member_name)
 
     def get_member(self, member_name: str, fallback_to_leader: bool = True) -> Union[Member, Leader, None]:
-        return ([m for m in self.members if m.name == member_name] or [self.leader if fallback_to_leader else None])[0]
+        """Get :class:`Member` object by name or the :class:`Leader`.
+
+        :param member_name: name of the member to retrieve.
+        :param fallback_to_leader: if ``True`` return the :class:`Leader` instead if the member cannot be found.
+
+        :return: the :class:`Member` if found or :class:`Leader` object.
+        """
+        return next((m for m in self.members if m.name == member_name),
+                    self.leader if fallback_to_leader else None)
 
     def get_clone_member(self, exclude_name: str) -> Union[Member, Leader, None]:
+        """Get member or leader object to use as clone source.
+
+        :param exclude_name: name of a member name to exclude.
+
+        :return: a randomly selected candidate member from available running members that are configured to as viable
+                 sources for cloning (has tag ``clonefrom`` in configuration). If no member is appropriate the current
+                 leader is used.
+        """
         exclude = [exclude_name] + ([self.leader.name] if self.leader else [])
         candidates = [m for m in self.members if m.clonefrom and m.is_running and m.name not in exclude]
         return candidates[randint(0, len(candidates) - 1)] if candidates else self.leader
 
     @property
     def __permanent_slots(self) -> Dict[str, Union[Dict[str, Any], Any]]:
+        """Dictionary of permanent replication slots."""
         return self.config and self.config.permanent_slots or {}
 
     @property
     def __permanent_physical_slots(self) -> Dict[str, Any]:
+        """Dictionary of permanent ``physical`` replication slots."""
         return {name: value for name, value in self.__permanent_slots.items()
                 if not value or isinstance(value, dict) and value.get('type', 'physical') == 'physical'}
 
     @property
     def __permanent_logical_slots(self) -> Dict[str, Any]:
+        """Dictionary of permanent ``logical`` replication slots."""
         return {name: value for name, value in self.__permanent_slots.items() if isinstance(value, dict)
                 and value.get('type', 'logical') == 'logical' and value.get('database') and value.get('plugin')}
 
     @property
     def use_slots(self) -> bool:
+        """``True`` if cluster is configured to use replication slots."""
         return bool(self.config and (self.config.data.get('postgresql') or {}).get('use_slots', True))
 
     def get_replication_slots(self, my_name: str, role: str, nofailover: bool,
@@ -609,7 +847,7 @@ class Cluster(NamedTuple):
             for name in slot_members:
                 slot_conflicts[slot_name_from_member_name(name)].append(name)
             logger.error("Following cluster members share a replication slot name: %s",
-                         "; ".join("{} map to {}".format(", ".join(v), k)
+                         "; ".join(f"{', '.join(v)} map to {k}"
                                    for k, v in slot_conflicts.items() if len(v) > 1))
 
         disabled_permanent_logical_slots: list[str] = self._merge_permanent_slots(
@@ -657,7 +895,8 @@ class Cluster(NamedTuple):
                     if name != slot_name_from_member_name(my_name):
                         slots[name] = value
                     continue
-                elif value['type'] == 'logical' and value.get('database') and value.get('plugin'):
+
+                if value['type'] == 'logical' and value.get('database') and value.get('plugin'):
                     if major_version < 110000:
                         disabled_permanent_logical_slots.append(name)
                     elif name in slots:
@@ -725,17 +964,32 @@ class Cluster(NamedTuple):
         return slot_members
 
     def has_permanent_logical_slots(self, my_name: str, nofailover: bool, major_version: int = 110000) -> bool:
+        """Check if the given member node has permanent ``logical`` replication slots configured.
+
+        :param my_name: name of the member node to check.
+        :param nofailover: whether this node can be considered a fail-over candidated.
+        :param major_version: the PostgreSQL major version number.
+
+        :return: ``False`` if PostgreSQL is < 11, ``True`` if any detected replications slots are ``logical``.
+        """
         if major_version < 110000:
             return False
         slots = self.get_replication_slots(my_name, 'replica', nofailover, major_version).values()
         return any(v for v in slots if v.get("type") == "logical")
 
     def should_enforce_hot_standby_feedback(self, my_name: str, nofailover: bool, major_version: int) -> bool:
-        """
-        The hot_standby_feedback must be enabled if the current replica has logical slots
-        or it is working as a cascading replica for the other node that has logical slots.
-        """
+        """Determine whether ``hot_standby_feedback`` should be enabled for the given member.
 
+        The ``hot_standby_feedback`` must be enabled if the current replica has ``logical`` slots,
+        or it is working as a cascading replica for the other node that has ``logical`` slots.
+
+        :param my_name: name of the member node to check.
+        :param nofailover: if this node should be considered a fail-over candidate.
+        :param major_version: PostgreSQL major version number.
+
+        :return: ``True`` if this node or any member replicating from this node has permanent logical slots.
+                 ``False`` if PostgreSQL major version is < 11.
+        """
         if major_version < 110000:
             return False
 
@@ -748,25 +1002,48 @@ class Cluster(NamedTuple):
         return False
 
     def get_my_slot_name_on_primary(self, my_name: str, replicatefrom: Optional[str]) -> str:
-        """
-        P <-- I <-- L
-        In case of cascading replication we have to check not our physical slot,
-        but slot of the replica that connects us to the primary.
-        """
+        """Canonical slot name for physical replication.
 
+        .. note::
+            P <-- I <-- L
+
+            In case of cascading replication we have to check not our physical slot, but slot of the replica that
+            connects us to the primary.
+
+        :param my_name: the member node name that is replicating.
+        :param replicatefrom: the Intermediate member name that is configured to replicate for cascading replication.
+
+        :returns: The slot name that is in use for physical replication on this no`de.
+        """
         m = self.get_member(replicatefrom, False) if replicatefrom else None
         return self.get_my_slot_name_on_primary(m.name, m.replicatefrom)\
             if isinstance(m, Member) else slot_name_from_member_name(my_name)
 
     @property
     def timeline(self) -> int:
-        """
-        >>> Cluster(0, 0, 0, 0, 0, 0, 0, 0, 0, None).timeline
-        0
-        >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[]'), 0, None).timeline
-        1
-        >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[["a"]]'), 0, None).timeline
-        0
+        """Get the cluster history index from the :attr:`~Cluster.history`.
+
+        :Example:
+
+            No history provided:
+            >>> Cluster(0, 0, 0, 0, 0, 0, 0, 0, 0, None).timeline
+            0
+
+            Empty history assume timeline is ``1``:
+            >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[]'), 0, None).timeline
+            1
+
+            Invalid history format, a string of ``a``, returns ``0``:
+            >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[["a"]]'), 0, None).timeline
+            0
+
+            History as a list of strings:
+            >>> Cluster(0, 0, 0, 0, 0, 0, 0, TimelineHistory.from_node(1, '[["3", "2", "1"]]'), 0, None).timeline
+            4
+
+        :returns: If the recorded history is empty assume timeline is ``1``, if it is not defined or the stored history
+                  is not formatted as expected ``0`` is returned and an error will be logged.
+                  Otherwise, the first number stored (indexed starting at 1) is returned.
         """
         if self.history:
             if self.history.lines:
@@ -780,14 +1057,21 @@ class Cluster(NamedTuple):
 
     @property
     def min_version(self) -> Optional[Tuple[int, ...]]:
+        """Lowest Patroni software version found in known members of the cluster."""
         return next(iter(sorted(m.patroni_version for m in self.members if m.patroni_version)), None)
 
 
 class ReturnFalseException(Exception):
-    pass
+    """Exception to be caught by the :func:`catch_return_false_exception` decorator."""
 
 
 def catch_return_false_exception(func: Callable[..., Any]) -> Any:
+    """Decorator function for catching functions raising :exc:`ReturnFalseException`.
+
+    :param func: function to be wrapped.
+
+    :return: wrapped function.
+    """
     def wrapper(*args: Any, **kwargs: Any):
         try:
             return func(*args, **kwargs)
@@ -798,6 +1082,7 @@ def catch_return_false_exception(func: Callable[..., Any]) -> Any:
 
 
 class AbstractDCS(abc.ABC):
+    """Abstract representation of DCS for preparing and loading :class:`Cluster` objects."""
 
     _INITIALIZE = 'initialize'
     _CONFIG = 'config'
@@ -812,9 +1097,10 @@ class AbstractDCS(abc.ABC):
     _FAILSAFE = 'failsafe'
 
     def __init__(self, config: Dict[str, Any]) -> None:
-        """
-        :param config: dict, reference to config section of selected DCS.
-            i.e.: `zookeeper` for zookeeper, `etcd` for etcd, etc...
+        """Prepare DCS paths, Citus group ID, initial values for state information and processing dependencies.
+
+        :ivar config: dict, reference to config section of selected DCS.
+                      i.e.: `zookeeper` for zookeeper, `etcd` for etcd, etc...
         """
         self._name = config['name']
         self._base_path = re.sub('/+', '/', '/'.join(['', config.get('namespace', 'service'), config['scope']]))
@@ -832,6 +1118,12 @@ class AbstractDCS(abc.ABC):
         self.event = Event()
 
     def client_path(self, path: str) -> str:
+        """Construct the client path from appropriate parts for the DCS type.
+
+        :param path: Additional string path to append, leftmost ``/`` will be removed.
+
+        :return: ``/`` delimited path joined to a single string.
+        """
         components = [self._base_path]
         if self._citus_group:
             components.append(self._citus_group)
@@ -840,112 +1132,146 @@ class AbstractDCS(abc.ABC):
 
     @property
     def initialize_path(self) -> str:
+        """Get the client path for ``initialize``."""
         return self.client_path(self._INITIALIZE)
 
     @property
     def config_path(self) -> str:
+        """Get the client path for ``config``."""
         return self.client_path(self._CONFIG)
 
     @property
     def members_path(self) -> str:
+        """Get the client path for ``members``."""
         return self.client_path(self._MEMBERS)
 
     @property
     def member_path(self) -> str:
+        """Get the client path for ``member``."""
         return self.client_path(self._MEMBERS + self._name)
 
     @property
     def leader_path(self) -> str:
+        """Get the client path for ``leader``."""
         return self.client_path(self._LEADER)
 
     @property
     def failover_path(self) -> str:
+        """Get the client path for ``failover``."""
         return self.client_path(self._FAILOVER)
 
     @property
     def history_path(self) -> str:
+        """Get the client path for ``history``."""
         return self.client_path(self._HISTORY)
 
     @property
     def status_path(self) -> str:
+        """Get the client path for ``status``."""
         return self.client_path(self._STATUS)
 
     @property
     def leader_optime_path(self) -> str:
+        """Get the client path for ``optime``."""
         return self.client_path(self._LEADER_OPTIME)
 
     @property
     def sync_path(self) -> str:
+        """Get the client path for ``sync``."""
         return self.client_path(self._SYNC)
 
     @property
     def failsafe_path(self) -> str:
+        """Get the client path for ``failsafe``."""
         return self.client_path(self._FAILSAFE)
 
     @abc.abstractmethod
     def set_ttl(self, ttl: int) -> Optional[bool]:
-        """Set the new ttl value for leader key"""
+        """Set the new ttl value for leader key."""
 
     @property
     @abc.abstractmethod
     def ttl(self) -> int:
-        """Get new ttl value"""
+        """Get new ttl value."""
 
     @abc.abstractmethod
     def set_retry_timeout(self, retry_timeout: int) -> None:
-        """Set the new value for retry_timeout"""
+        """Set the new value for retry_timeout."""
 
     def _set_loop_wait(self, loop_wait: int) -> None:
+        """Set new *loop_wait* value.
+
+        :param loop_wait: value to set.
+        """
         self._loop_wait = loop_wait
 
     def reload_config(self, config: Union['Config', Dict[str, Any]]) -> None:
+        """Load and set relevant values from configuration.
+
+        Sets `loop_wait`, `ttl` and `retry_timeout` properties.
+
+        :param config: Loaded configuration information object or dictionary of key value pairs.
+        """
         self._set_loop_wait(config['loop_wait'])
         self.set_ttl(config['ttl'])
         self.set_retry_timeout(config['retry_timeout'])
 
     @property
     def loop_wait(self) -> int:
+        """The recorded value for cluster HA loop wait time in seconds."""
         return self._loop_wait
 
     @property
     def last_seen(self) -> int:
+        """The time recorded when the cluster was last loaded from DCS."""
         return self._last_seen
 
     @abc.abstractmethod
     def _cluster_loader(self, path: Any) -> Cluster:
-        """Load and build the `Cluster` object from DCS, which
-        represents a single Patroni cluster.
+        """Load and build the :class:`Cluster` object from DCS, which represents a single Patroni cluster.
 
         :param path: the path in DCS where to load Cluster(s) from.
-        :returns: `Cluster`"""
+
+        :returns: :class:`Cluster` instance.
+        """
 
     @abc.abstractmethod
     def _citus_cluster_loader(self, path: Any) -> Union[Cluster, Dict[int, Cluster]]:
-        """Load and build `Cluster` onjects from DCS that represent all
-        Patroni clusters from a single Citus cluster.
+        """Load and build all Patroni clusters from a single Citus cluster.
 
         :param path: the path in DCS where to load Cluster(s) from.
-        :returns: all Citus groups as `dict`, with group ids as keys"""
+
+        :returns: all Citus groups as `dict`, with group IDs as keys and :class:`Cluster` objects as values.
+        """
 
     @abc.abstractmethod
     def _load_cluster(
             self, path: str, loader: Callable[[Any], Union[Cluster, Dict[int, Cluster]]]
     ) -> Union[Cluster, Dict[int, Cluster]]:
-        """Internally this method should call the `loader` method that
-        will build `Cluster` object which represents current state and
-        topology of the cluster in DCS. This method supposed to be
-        called only by `get_cluster` method.
+        """Main abstract method that implements the loading of :class:`Cluster` instance.
+
+        .. note::
+            Internally this method should call the ``loader`` method that will build :class:`Cluster` object which
+            represents current state and topology of the cluster in DCS. This method supposed to be called only by
+            the :meth:`~AbstractDCS.get_cluster` method.
 
         :param path: the path in DCS where to load Cluster(s) from.
-        :param loader: one of `_cluster_loader` or `_citus_cluster_loader`
-        :raise: `~DCSError` in case of communication problems with DCS.
-        If the current node was running as a primary and exception
-        raised, instance would be demoted."""
+        :param loader: one of :meth:`~AbstractDCS._cluster_loader` or :meth:`~AbstractDCS._citus_cluster_loader`.
+
+        :raise: :exc:`~DCSError` in case of communication problems with DCS. If the current node was running as a
+                primary and exception raised, instance would be demoted.
+        """
 
     def _bypass_caches(self) -> None:
-        """Used only in zookeeper"""
+        """Used only in Zookeeper."""
 
     def __get_patroni_cluster(self, path: Optional[str] = None) -> Cluster:
+        """Low level method to load a :class:`Cluster` object from DCS.
+
+        :param path: optional client path in DCS backend to load from.
+
+        :return: a loaded :class:`Cluster` instance.
+        """
         if path is None:
             path = self.client_path('')
         cluster = self._load_cluster(path, self._cluster_loader)
@@ -954,15 +1280,28 @@ class AbstractDCS(abc.ABC):
         return cluster
 
     def is_citus_coordinator(self) -> bool:
+        """:class:`Cluster` instance has a Citus Coordinator group ID.
+
+        :returns: ``True`` if this object's Citus group ID matches the default Citus Coordinator group ID.
+        """
         return self._citus_group == str(CITUS_COORDINATOR_GROUP_ID)
 
     def get_citus_coordinator(self) -> Optional[Cluster]:
+        """Load the cluster for the Citus Coordinator node.
+
+        :return: Select :class:`Cluster` instance associated with the Citus Coordinator group ID.
+        """
         try:
-            return self.__get_patroni_cluster('{0}/{1}/'.format(self._base_path, CITUS_COORDINATOR_GROUP_ID))
+            return self.__get_patroni_cluster(f'{self._base_path}/{CITUS_COORDINATOR_GROUP_ID}/')
         except Exception as e:
             logger.error('Failed to load Citus coordinator cluster from %s: %r', self.__class__.__name__, e)
+        return None
 
     def _get_citus_cluster(self) -> Cluster:
+        """Load Citus cluster from DCS.
+
+        :returns: A Citus :class:`Cluster` instance from Zookeeper cache or select matching coordinator group ID.
+        """
         groups = self._load_cluster(self._base_path + '/', self._citus_cluster_loader)
         if isinstance(groups, Cluster):  # Zookeeper could return a cached version
             cluster = groups
@@ -972,6 +1311,17 @@ class AbstractDCS(abc.ABC):
         return cluster
 
     def get_cluster(self, force: bool = False) -> Cluster:
+        """Retrieve an appropriate cached or fresh view of DCS.
+
+        .. note::
+            Stores copy of time, status and failsafe values for comparison in DCS update decisions.
+
+            Returns either a Citus or Patroni implementation of :class:`Cluster` depending on availability.
+
+        :param force: a value of ``True`` will override Zookeeper caching features.
+
+        :return:
+        """
         if force:
             self._bypass_caches()
         try:
@@ -991,32 +1341,51 @@ class AbstractDCS(abc.ABC):
 
     @property
     def cluster(self) -> Optional[Cluster]:
+        """Cached DCS cluster information that has not yet expired."""
         with self._cluster_thread_lock:
             return self._cluster if self._cluster_valid_till > time.time() else None
 
     def reset_cluster(self) -> None:
+        """Clear cached state of DCS."""
         with self._cluster_thread_lock:
             self._cluster = None
             self._cluster_valid_till = 0
 
     @abc.abstractmethod
     def _write_leader_optime(self, last_lsn: str) -> bool:
-        """write current WAL LSN into `/optime/leader` key in DCS
+        """Write current WAL LSN into `/optime/leader` key in DCS.
 
-        :param last_lsn: absolute WAL LSN in bytes
-        :returns: `!True` on success."""
+        :param last_lsn: absolute WAL LSN in bytes.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     def write_leader_optime(self, last_lsn: int) -> None:
+        """Write value for WAL LSN to ``optime/leader`` key in DCS.
+
+        :param last_lsn: absolute WAL LSN in bytes.
+        """
         self.write_status({self._OPTIME: last_lsn})
 
     @abc.abstractmethod
     def _write_status(self, value: str) -> bool:
-        """write current WAL LSN and confirmed_flush_lsn of permanent slots into the `/status` key in DCS
+        """Write current WAL LSN and confirmed_flush_lsn of permanent slots into the `/status` key in DCS.
 
-        :param value: status serialized in JSON forman
-        :returns: `!True` on success."""
+        :param value: status serialized in JSON format.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     def write_status(self, value: Dict[str, Any]) -> None:
+        """Write cluster status to DCS if changed.
+
+        .. note::
+            The DCS key ``/status`` was introduced in Patroni version 2.1.0. Previous to this the position of last known
+            leader LSN was stored in ``optime/leader``. This method has detection for backwards compatibility of members
+            with a version older than this.
+
+        :param value: JSON serializable dictionary with current WAL LSN and ``confirmed_flush_lsn`` of permanent slots.
+        """
         if not deep_compare(self._last_status, value) and self._write_status(json.dumps(value, separators=(',', ':'))):
             self._last_status = value
         cluster = self.cluster
@@ -1029,38 +1398,55 @@ class AbstractDCS(abc.ABC):
     def _write_failsafe(self, value: str) -> bool:
         """Write current cluster topology to DCS that will be used by failsafe mechanism (if enabled).
 
-        :param value: failsafe topology serialized in JSON format
-        :returns: `!True` on success."""
+        :param value: failsafe topology serialized in JSON format.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     def write_failsafe(self, value: Dict[str, str]) -> None:
+        """Write the ``/failsafe`` key in DCS.
+
+        :param value: dictionary value to set.
+        """
         if not (isinstance(self._last_failsafe, dict) and deep_compare(self._last_failsafe, value))\
                 and self._write_failsafe(json.dumps(value, separators=(',', ':'))):
             self._last_failsafe = value
 
     @property
     def failsafe(self) -> Optional[Dict[str, str]]:
+        """Stored value of :attr:`~AbstractDCS._last_failsafe`."""
         return self._last_failsafe
 
     @abc.abstractmethod
     def _update_leader(self, leader: Leader) -> bool:
-        """Update leader key (or session) ttl
+        """Update *leader* key (or session) ttl.
 
-        :param leader: a reference to a current leader key object
-        :returns: `!True` if leader key (or session) has been updated successfully
+        .. note::
+            You have to use CAS (Compare And Swap) operation in order to update leader key, for example for etcd
+            `prevValue` parameter must be used.
 
-        You have to use CAS (Compare And Swap) operation in order to update leader key,
-        for example for etcd `prevValue` parameter must be used.
-        If update fails due to DCS not being accessible or because it is not able to
-        process requests (hopefuly temporary), the ~DCSError exception should be raised."""
+            If update fails due to DCS not being accessible or because it is not able to process requests (hopefully
+            temporary), the :exc:`DCSError` exception should be raised.
 
-    def update_leader(self, leader: Leader, last_lsn: Optional[int],
-                      slots: Optional[Dict[str, int]] = None, failsafe: Optional[Dict[str, str]] = None) -> bool:
-        """Update leader key (or session) ttl and optime/leader
+        :param leader: a reference to a current *leader* key object.
 
-        :param last_lsn: absolute WAL LSN in bytes
-        :param slots: dict with permanent slots confirmed_flush_lsn
-        :returns: `!True` if leader key (or session) has been updated successfully."""
+        :returns: ``True`` if *leader* key (or session) has been updated successfully.
+        """
 
+    def update_leader(self,
+                      leader: Leader,
+                      last_lsn: Optional[int],
+                      slots: Optional[Dict[str, int]] = None,
+                      failsafe: Optional[Dict[str, str]] = None) -> bool:
+        """Update *leader* key (or session) ttl and optime/leader.
+
+        :param leader: object with information on the *leader*.
+        :param last_lsn: absolute WAL LSN in bytes.
+        :param slots: dictionary with permanent slots ``confirmed_flush_lsn``.
+        :param failsafe: if defined dictionary passed to :meth:`~AbstractDCS.write_failsafe`.
+
+        :returns: ``True`` if *leader* key (or session) has been updated successfully.
+        """
         ret = self._update_leader(leader)
         if ret and last_lsn:
             status: Dict[str, Any] = {self._OPTIME: last_lsn}
@@ -1075,22 +1461,41 @@ class AbstractDCS(abc.ABC):
 
     @abc.abstractmethod
     def attempt_to_acquire_leader(self) -> bool:
-        """Attempt to acquire leader lock
-        This method should create `/leader` key with value=`~self._name`
-        :returns: `!True` if key has been created successfully.
+        """Attempt to acquire leader lock.
 
-        Key must be created atomically. In case if key already exists it should not be
-        overwritten and `!False` must be returned.
+        .. note::
+            This method should create `/leader` key with the value :attr:`~AbstractDCS._name`.
 
-        If key creation fails due to DCS not being accessible or because it is not able to
-        process requests (hopefuly temporary), the ~DCSError exception should be raised"""
+            The key must be created atomically. In case the key already exists it should not be
+            overwritten and ``False`` must be returned.
+
+            If key creation fails due to DCS not being accessible or because it is not able to
+            process requests (hopefully temporary), the :exc:`DCSError` exception should be raised.
+
+        :returns: ``True`` if key has been created successfully.
+        """
 
     @abc.abstractmethod
     def set_failover_value(self, value: str, version: Optional[Any] = None) -> bool:
-        """Create or update `/failover` key"""
+        """Create or update `/failover` key.
+
+        :param value: *value* to set.
+        :param version: for conditional update of the key/object.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     def manual_failover(self, leader: Optional[str], candidate: Optional[str],
                         scheduled_at: Optional[datetime.datetime] = None, version: Optional[Any] = None) -> bool:
+        """Prepare dictionary with given values and set ``/failover`` key in DCS.
+
+        :param leader: value to set for *leader*.
+        :param candidate: value to set for ``member``.
+        :param scheduled_at: value converted to ISO date format for ``scheduled_at``.
+        :param version: for conditional update of the key/object.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
         failover_value = {}
         if leader:
             failover_value['leader'] = leader
@@ -1104,106 +1509,158 @@ class AbstractDCS(abc.ABC):
 
     @abc.abstractmethod
     def set_config_value(self, value: str, version: Optional[Any] = None) -> bool:
-        """Create or update `/config` key"""
+        """Create or update ``/config`` key in DCS.
+
+        :param value: new *value* to set in the key.
+        :param version: for conditional update of the key/object.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     @abc.abstractmethod
     def touch_member(self, data: Dict[str, Any]) -> bool:
         """Update member key in DCS.
-        This method should create or update key with the name = '/members/' + `~self._name`
-        and value = data in a given DCS.
 
-        :param data: information about instance (including connection strings)
-        :param ttl: ttl for member key, optional parameter. If it is None `~self.member_ttl will be used`
-        :returns: `!True` on success otherwise `!False`
+        .. note::
+            This method should create or update key with the name with ``/members/`` + :attr:`~AbstractDCS._name`
+            and the value of *data* in a given DCS.
+
+        :param data: information about an instance (including connection strings).
+
+        :returns: ``True`` if successfully committed to DCS.
         """
 
     @abc.abstractmethod
     def take_leader(self) -> bool:
-        """This method should create leader key with value = `~self._name` and ttl=`~self.ttl`
-        Since it could be called only on initial cluster bootstrap it could create this key regardless,
-        overwriting the key if necessary."""
+        """Establish a new leader in DCS.
+
+        .. note::
+            This method should create leader key with value of :attr:`~AbstractDCS._name` and ``ttl`` of
+            :attr:`~AbstractDCS.ttl`.
+
+            Since it could be called only on initial cluster bootstrap it could create this key regardless,
+            overwriting the key if necessary.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     @abc.abstractmethod
     def initialize(self, create_new: bool = True, sysid: str = "") -> bool:
         """Race for cluster initialization.
 
-        :param create_new: False if the key should already exist (in the case we are setting the system_id)
-        :param sysid: PostgreSQL cluster system identifier, if specified, is written to the key
-        :returns: `!True` if key has been created successfully.
+        This method should atomically create ``initialize`` key and return ``True``,
+        otherwise it should return ``False``.
 
-        this method should create atomically initialize key and return `!True`
-        otherwise it should return `!False`"""
+        :param create_new: ``False`` if the key should already exist (in the case we are setting the system_id).
+        :param sysid: PostgreSQL cluster system identifier, if specified, is written to the key.
+
+        :returns: ``True`` if key has been created successfully.
+        """
 
     @abc.abstractmethod
     def _delete_leader(self) -> bool:
         """Remove leader key from DCS.
-        This method should remove leader key if current instance is the leader"""
+
+        This method should remove leader key if current instance is the leader.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     def delete_leader(self, last_lsn: Optional[int] = None) -> bool:
-        """Update optime/leader and voluntarily remove leader key from DCS.
-        This method should remove leader key if current instance is the leader.
-        :param last_lsn: latest checkpoint location in bytes"""
+        """Update ``optime/leader`` and voluntarily remove leader key from DCS.
 
+        This method should remove leader key if current instance is the leader.
+
+        :param last_lsn: latest checkpoint location in bytes.
+
+        :returns: boolean result of called abstract :meth:`~AbstractDCS._delete_leader`.
+        """
         if last_lsn:
             self.write_status({self._OPTIME: last_lsn})
         return self._delete_leader()
 
     @abc.abstractmethod
     def cancel_initialization(self) -> bool:
-        """ Removes the initialize key for a cluster """
+        """Removes the ``initialize`` key for a cluster.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     @abc.abstractmethod
     def delete_cluster(self) -> bool:
-        """Delete cluster from DCS"""
+        """Delete cluster from DCS.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     @staticmethod
     def sync_state(leader: Optional[str], sync_standby: Optional[Collection[str]]) -> Dict[str, Any]:
-        """Build sync_state dict.
-        The sync_standby key being kept for backward compatibility.
-        :param leader: name of the leader node that manages /sync key
-        :param sync_standby: collection of currently known synchronous standby node names
-        :returns: dictionary that later could be serialized to JSON or saved directly to DCS
+        """Build ``sync_state`` dictionary.
+
+        The *sync_standby* key is kept for backward compatibility.
+
+        :param leader: name of the *leader* node that manages ``/sync`` key.
+        :param sync_standby: collection of currently known synchronous standby node names.
+
+        :returns: dictionary that later could be serialized to JSON or saved directly to DCS.
         """
         return {'leader': leader, 'sync_standby': ','.join(sorted(sync_standby)) if sync_standby else None}
 
     def write_sync_state(self, leader: Optional[str], sync_standby: Optional[Collection[str]],
                          version: Optional[Any] = None) -> Optional[SyncState]:
         """Write the new synchronous state to DCS.
-        Calls :func:`sync_state` method to build a dict and than calls DCS specific :func:`set_sync_state_value` method.
-        :param leader: name of the leader node that manages /sync key
-        :param sync_standby: collection of currently known synchronous standby node names
-        :param version: for conditional update of the key/object
-        :returns: the new :class:`SyncState` object or None
+
+        Calls :meth:`~AbstractDCS.sync_state` to build a dictionary and then calls DCS specific
+        :meth:`~AbstractDCS.set_sync_state_value`.
+
+        :param leader: name of the *leader* node that manages ``/sync`` key.
+        :param sync_standby: collection of currently known synchronous standby node names.
+        :param version: for conditional update of the key/object.
+
+        :returns: the new :class:`SyncState` object or ``None``.
         """
         sync_value = self.sync_state(leader, sync_standby)
         ret = self.set_sync_state_value(json.dumps(sync_value, separators=(',', ':')), version)
         if not isinstance(ret, bool):
             return SyncState.from_node(ret, sync_value)
+        return None
 
     @abc.abstractmethod
     def set_history_value(self, value: str) -> bool:
-        """"""
+        """Set value for ``history`` in DCS.
+
+        :param value: new value of ``history`` key/object.
+
+        :returns: ``True`` if successfully committed to DCS.
+        """
 
     @abc.abstractmethod
     def set_sync_state_value(self, value: str, version: Optional[Any] = None) -> Union[Any, bool]:
-        """Set synchronous state in DCS, should be implemented in the child class.
+        """Set synchronous state in DCS.
 
-        :param value: the new value of /sync key
-        :param version: for conditional update of the key/object
-        :returns: version of the new object or `False` in case of error
+        :param value: the new value of /sync key.
+        :param version: for conditional update of the key/object.
+
+        :returns: *version* of the new object or ``False`` in case of error.
         """
 
     @abc.abstractmethod
     def delete_sync_state(self, version: Optional[Any] = None) -> bool:
-        """"""
+        """Delete the synchronous state from DCS.
+
+        :param version: for conditional deletion of the key/object.
+
+        :returns: ``True`` if delete successful.
+        """
 
     def watch(self, leader_version: Optional[Any], timeout: float) -> bool:
-        """If the current node is a leader it should just sleep.
-        Any other node should watch for changes of leader key with a given timeout
+        """Sleep if the current node is a leader, otherwise, watch for changes of leader key with a given *timeout*.
 
-        :param leader_version: version of a leader key
-        :param timeout: timeout in seconds
-        :returns: `!True` if you would like to reschedule the next run of ha cycle"""
+        :param leader_version: version of a leader key.
+        :param timeout: timeout in seconds.
 
+        :returns: if ``True`` this will reschedule the next run of the HA cycle.
+        """
+        _ = leader_version
         self.event.wait(timeout)
         return self.event.is_set()

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1862,7 +1862,7 @@ class Ha(object):
         cluster_params = self.global_config.get_standby_cluster_config()
 
         if cluster_params:
-            data.update({k: v for k, v in cluster_params.items() if k in RemoteMember.allowed_keys()})
+            data.update({k: v for k, v in cluster_params.items() if k in RemoteMember.ALLOWED_KEYS})
             data['no_replication_slot'] = 'primary_slot_name' not in cluster_params
             conn_kwargs = member.conn_kwargs() if member else \
                 {k: cluster_params[k] for k in ('host', 'port') if k in cluster_params}

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -126,6 +126,12 @@ class SlotsAdvanceThread(Thread):
 class SlotsHandler(object):
 
     def __init__(self, postgresql: 'Postgresql') -> None:
+        """Create an instance with storage attributes for replication slots and schedule the first synchronisation.
+
+        :param postgresql: Calling class instance providing interface to PostgreSQL.
+        """
+        self._force_readiness_check = False
+        self._schedule_load_slots = False
         self._postgresql = postgresql
         self._advance = None
         self._replication_slots: Dict[str, Dict[str, Any]] = {}  # already existing replication slots

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -364,9 +364,9 @@ class SlotsHandler:
                     self._schedule_load_slots = True
 
     def _ensure_physical_slots(self, slots: Dict[str, Any]) -> None:
-        """Create any missing physical replication slots.
+        """Create any missing physical replication *slots*.
 
-        Any failures are logged and do not interrupt creation of all slots.
+        Any failures are logged and do not interrupt creation of all *slots*.
 
         :param slots: A dictionary mapping slot name to slot attributes. This method only considers a slot
                       if the value is a dictionary with the key ``type`` and a value of ``physical``.
@@ -399,7 +399,7 @@ class SlotsHandler:
             yield cur
 
     def _ensure_logical_slots_primary(self, slots: Dict[str, Any]) -> None:
-        """Create any missing logical replication slots.
+        """Create any missing logical replication *slots*.
 
         If the logical slot already exists, copy state information into the replication slots structure stored in the
         class instance.
@@ -445,16 +445,16 @@ class SlotsHandler:
         return self._advance.schedule(slots)
 
     def _ensure_logical_slots_replica(self, cluster: Cluster, slots: Dict[str, Any]) -> List[str]:
-        """Update missing logical slots on replicas.
+        """Update missing logical *slots* on replicas.
 
         If the logical slot already exists, copy state information into the replication slots structure stored in the
-        class instance. Slots that exist are also advanced if their `confirmed_flush_lsn` is greater than the stored
+        class instance. Slots that exist are also advanced if their ``confirmed_flush_lsn`` is greater than the stored
         state of the slot.
 
         As logical slots can only be created when the primary is available, pass the list of slots that need to be
-        copied back to the caller. They will be created on replicas with :meth:``SlotsHandler.copy_logical_slots``.
+        copied back to the caller. They will be created on replicas with :meth:`SlotsHandler.copy_logical_slots`.
 
-        :param cluster: object containing stateful information for the cluster
+        :param cluster: object containing stateful information for the cluster.
         :param slots: A dictionary mapping slot name to slot attributes. This method only considers a slot
                       if the value is a dictionary with the key ``type`` and a value of ``logical``.
 
@@ -493,12 +493,12 @@ class SlotsHandler:
         Create any missing physical slots. If we are the leader then logical slots too, otherwise if logical slots
         are known and active create them on replica nodes.
 
-        :param cluster: object containing stateful information for the cluster
-        :param nofailover: ``True`` if this node has been tagged to not failover
-        :param replicatefrom: the tag containing the node to replicate from
-        :param paused: ``True`` if the cluster is configured as paused
+        :param cluster: object containing stateful information for the cluster.
+        :param nofailover: ``True`` if this node has been tagged to not failover.
+        :param replicatefrom: the tag containing the node to replicate from.
+        :param paused: ``True`` if the cluster is in maintenance mode.
 
-        :returns: list of logical replication slots names that should be copied from the primary
+        :returns: list of logical replication slots names that should be copied from the primary.
         """
         ret = []
         if self._postgresql.major_version >= 90400 and cluster.config:

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -20,8 +20,24 @@ logger = logging.getLogger(__name__)
 
 
 def compare_slots(s1: Dict[str, Any], s2: Dict[str, Any], dbid: str = 'database') -> bool:
-    return s1['type'] == s2['type'] and (s1['type'] == 'physical'
-                                         or s1.get(dbid) == s2.get(dbid) and s1['plugin'] == s2['plugin'])
+    """Compare 2 replication slot objects for equality.
+
+    ..note ::
+        If the first argument is a ``physical`` replication slot then only the `type` of the second slot is compared.
+        If the first argument is another ``type`` (e.g. ``logical``) then *dbid* and ``plugin`` are compared.
+
+    :param s1: First slot dictionary to be compared.
+    :param s2: Second slot dictionary to be compared.
+    :param dbid: Optional attribute to be compared when comparing ``physical`` replication slots.
+
+    :return: ``True`` if the slot ``type`` of *s1* and *s2* is matches, and the ``type`` of *s1* is ``physical``,
+             OR the ``types`` match AND the *dbid* and ``plugin`` attributes are equal.
+
+    """
+    return (s1['type'] == s2['type']
+            and (s1['type'] == 'physical'
+                 or s1.get(dbid) == s2.get(dbid)
+                 and s1['plugin'] == s2['plugin']))
 
 
 class SlotsAdvanceThread(Thread):

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -621,7 +621,9 @@ class SlotsHandler:
         for name in list(self.logical_slots_processing_queue):
             primary_logical_xmin = self.logical_slots_processing_queue[name]
             standby_logical_slot = self._replication_slots.get(name, {})
-            standby_logical_xmin = standby_logical_slot.get('catalog_xmin')
+            standby_logical_xmin = standby_logical_slot.get('catalog_xmin', 0)
+            if TYPE_CHECKING:
+                assert primary_logical_xmin is not None
 
             if (
                     not standby_logical_slot

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -621,16 +621,16 @@ class SlotsHandler:
         """
         # Make a copy of processing queue keys as a list as the queue dictionary is modified inside the loop.
         for name in list(self.logical_slots_processing_queue):
-            primary_logical_xmin = self.logical_slots_processing_queue[name]
+            primary_logical_catalog_xmin = self.logical_slots_processing_queue[name]
             standby_logical_slot = self._replication_slots.get(name, {})
-            standby_logical_xmin = standby_logical_slot.get('catalog_xmin', 0)
+            standby_logical_catalog_xmin = standby_logical_slot.get('catalog_xmin', 0)
             if TYPE_CHECKING:
-                assert primary_logical_xmin is not None
+                assert primary_logical_catalog_xmin is not None
 
             if (
                     not standby_logical_slot
                     or primary_physical_catalog_xmin is not None
-                    and primary_logical_xmin <= primary_physical_catalog_xmin <= standby_logical_xmin
+                    and primary_logical_catalog_xmin <= primary_physical_catalog_xmin <= standby_logical_catalog_xmin
             ):
 
                 del self.logical_slots_processing_queue[name]

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -583,9 +583,9 @@ class SlotsHandler:
                                              catalog_xmin: Optional[int] = None) -> bool:
         """Store pending logical slot information for ``catalog_xmin`` on the primary.
 
-        Remember ``catalog_xmin`` of logical slots on the primary when ``catalog_xmin`` of the physical slot became valid.
-        Logical slots on replica will be safe to use after promote when ``catalog_xmin`` of the physical slot overtakes
-        these values.
+        Remember ``catalog_xmin`` of logical slots on the primary when ``catalog_xmin`` of the physical slot became
+        valid. Logical slots on replica will be safe to use after promote when ``catalog_xmin`` of the physical slot
+        overtakes these values.
 
         :param catalog_xmin: ``catalog_xmin`` of the physical slot used by this replica to stream changes from primary.
         :param slots: dictionary of slot information from the primary

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -121,12 +121,12 @@ class TestSlotsHandler(BaseTestPostgresql):
         self.s.copy_logical_slots(self.cluster, ['ls'])
         with patch.object(MockCursor, '__iter__', Mock(return_value=iter([('postgresql0', None)]))),\
                 patch.object(MockCursor, 'fetchone', Mock(side_effect=Exception)):
-            self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, False, None))
+            self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, None))
         with patch.object(MockCursor, '__iter__', Mock(return_value=iter([('postgresql0', None)]))),\
                 patch.object(MockCursor, 'fetchone', Mock(return_value=(False,))):
-            self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, False, None))
+            self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, None))
         with patch.object(MockCursor, '__iter__', Mock(return_value=iter([('ls', 100)]))):
-            self.s.check_logical_slots_readiness(self.cluster, False, None)
+            self.s.check_logical_slots_readiness(self.cluster, None)
 
     @patch.object(Postgresql, 'stop', Mock(return_value=True))
     @patch.object(Postgresql, 'start', Mock(return_value=True))

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -93,7 +93,7 @@ class TestSlotsHandler(BaseTestPostgresql):
     def test__ensure_logical_slots_replica(self):
         self.p.set_role('replica')
         self.cluster.slots['ls'] = 12346
-        with patch.object(SlotsHandler, 'check_logical_slots_readiness', Mock()):
+        with patch.object(SlotsHandler, 'check_logical_slots_readiness', Mock(return_value=False)):
             self.assertEqual(self.s.sync_replication_slots(self.cluster, False), [])
         self.s._schedule_load_slots = False
         with patch.object(MockCursor, 'execute', Mock(side_effect=psycopg.OperationalError)),\
@@ -121,10 +121,10 @@ class TestSlotsHandler(BaseTestPostgresql):
         self.s.copy_logical_slots(self.cluster, ['ls'])
         with patch.object(MockCursor, '__iter__', Mock(return_value=iter([('postgresql0', None)]))),\
                 patch.object(MockCursor, 'fetchone', Mock(side_effect=Exception)):
-            self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, None))
+            self.assertFalse(self.s.check_logical_slots_readiness(self.cluster, None))
         with patch.object(MockCursor, '__iter__', Mock(return_value=iter([('postgresql0', None)]))),\
                 patch.object(MockCursor, 'fetchone', Mock(return_value=(False,))):
-            self.assertIsNone(self.s.check_logical_slots_readiness(self.cluster, None))
+            self.assertFalse(self.s.check_logical_slots_readiness(self.cluster, None))
         with patch.object(MockCursor, '__iter__', Mock(return_value=iter([('ls', 100)]))):
             self.s.check_logical_slots_readiness(self.cluster, None)
 


### PR DESCRIPTION
This PR addresses 2 streams of work.

* During analysis of replication slot process for better understanding, and possible future work related to the integration of the extension of `pg_failover_slots`, we have refactored the methods used to make decisions in slot replication. Enhances readability of the code and descriptive naming of methods, variables, arguments, etc.
* Write docstrings for `dcs/__init__.py` and `postgresql/slots.py`.

There are some minor code tweaks to things like rewriting loops to generator statements and some linter fixes.