### PR TITLE
Skip flaky scenario when running with Raft

### DIFF
--- a/features/basic_replication.feature
+++ b/features/basic_replication.feature
@@ -79,6 +79,7 @@ Feature: basic replication
     When I add the table buz to postgres2
     Then table buz is present on postgres0 after 20 seconds
 
+  @reject-duplicate-name
   Scenario: check graceful rejection when two nodes have the same name
     Given I start duplicate postgres0 on port 8011
     Then there is a "Can't start; there is already a node named 'postgres0' running" CRITICAL in the dup-postgres0 patroni log

--- a/features/environment.py
+++ b/features/environment.py
@@ -1144,3 +1144,5 @@ def before_scenario(context, scenario):
                 break
     if 'dcs-failsafe' in scenario.effective_tags and not context.dcs_ctl._handle:
         scenario.skip('it is not possible to control state of {0} from tests'.format(context.dcs_ctl.name()))
+    if 'reject-duplicate-name' in scenario.effective_tags and context.dcs_ctl.name() == 'raft':
+        scenario.skip('Flaky test with Raft')


### PR DESCRIPTION
Sometimes Patroni doesn't see the latest Raft data on start.