### PR TITLE
Set permissions for files and directories created in PGDATA

### DIFF
--- a/patroni/file_perm.py
+++ b/patroni/file_perm.py
@@ -11,7 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 class __FilePermissions:
-    """Class that helps with figuring out file and directory permissions based on permissions of PGDATA. """
+    """Helper class for managing permissions of directories and files under PGDATA.
+    
+    Execute :meth:`set_permissions_from_data_directory` to figure out which permissions should be used for files and
+    directories under PGDATA based on permissions of PGDATA root directory.
+    """
 
     # Mode mask for data directory permissions that only allows the owner to read/write directories and files -- mask 077.
     __PG_MODE_MASK_OWNER = stat.S_IRWXG | stat.S_IRWXO

--- a/patroni/file_perm.py
+++ b/patroni/file_perm.py
@@ -12,12 +12,13 @@ logger = logging.getLogger(__name__)
 
 class __FilePermissions:
     """Helper class for managing permissions of directories and files under PGDATA.
-    
+
     Execute :meth:`set_permissions_from_data_directory` to figure out which permissions should be used for files and
     directories under PGDATA based on permissions of PGDATA root directory.
     """
 
-    # Mode mask for data directory permissions that only allows the owner to read/write directories and files -- mask 077.
+    # Mode mask for data directory permissions that only allows the owner to
+    # read/write directories and files -- mask 077.
     __PG_MODE_MASK_OWNER = stat.S_IRWXG | stat.S_IRWXO
 
     # Mode mask for data directory permissions that also allows group read/execute -- mask 027.
@@ -42,9 +43,10 @@ class __FilePermissions:
 
     def __set_umask(self) -> None:
         """Set umask value based on calculations.
-        
+
         .. note::
-            Should only be called once either :meth:`__set_owner_permissions` or :meth:`__set_group_permissions` has been executed.
+            Should only be called once either :meth:`__set_owner_permissions`
+            or :meth:`__set_group_permissions` has been executed.
         """
         try:
             os.umask(self.__pg_mode_mask)

--- a/patroni/file_perm.py
+++ b/patroni/file_perm.py
@@ -13,31 +13,35 @@ logger = logging.getLogger(__name__)
 class __FilePermissions:
     """Class that helps with figuring out file and directory permissions based on permissions of PGDATA. """
 
-    # Mode mask for data directory permissions that only allows the owner to read/write directories and files.
+    # Mode mask for data directory permissions that only allows the owner to read/write directories and files -- mask 077.
     __PG_MODE_MASK_OWNER = stat.S_IRWXG | stat.S_IRWXO
 
-    # Mode mask for data directory permissions that also allows group read/execute.
+    # Mode mask for data directory permissions that also allows group read/execute -- mask 027.
     __PG_MODE_MASK_GROUP = stat.S_IWGRP | stat.S_IRWXO
 
-    # Default mode for creating directories
+    # Default mode for creating directories -- mode 700.
     __PG_DIR_MODE_OWNER = stat.S_IRWXU
 
-    # Mode for creating directories that allows group read/execute
+    # Mode for creating directories that allows group read/execute -- mode 750.
     __PG_DIR_MODE_GROUP = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP
 
-    # Default mode for creating files
+    # Default mode for creating files -- mode 600.
     __PG_FILE_MODE_OWNER = stat.S_IRUSR | stat.S_IWUSR
 
-    # Mode for creating files that allows group read
+    # Mode for creating files that allows group read -- mode 640.
     __PG_FILE_MODE_GROUP = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP
 
     def __init__(self) -> None:
-        """Create a :class:`__FilePermissions` object and sets default permissions."""
+        """Create a :class:`__FilePermissions` object and set default permissions."""
         self.__set_owner_permissions()
         self.__set_umask()
 
     def __set_umask(self) -> None:
-        """Set umask value based on calculations."""
+        """Set umask value based on calculations.
+        
+        .. note::
+            Should only be called once either :meth:`__set_owner_permissions` or :meth:`__set_group_permissions` has been executed.
+        """
         try:
             os.umask(self.__pg_mode_mask)
         except Exception as e:
@@ -78,7 +82,7 @@ class __FilePermissions:
 
     @property
     def file_create_mode(self) -> int:
-        """File permissions"""
+        """File permissions."""
         return self.__pg_file_create_mode
 
 

--- a/patroni/file_perm.py
+++ b/patroni/file_perm.py
@@ -1,0 +1,85 @@
+"""Helper object that helps with figuring out file and directory permissions based on permissions of PGDATA.
+
+:var logger: logger of this module.
+:var pg_perm: instance of the :class:`__FilePermissions` object.
+"""
+import logging
+import os
+import stat
+
+logger = logging.getLogger(__name__)
+
+
+class __FilePermissions:
+    """Class that helps with figuring out file and directory permissions based on permissions of PGDATA. """
+
+    # Mode mask for data directory permissions that only allows the owner to read/write directories and files.
+    __PG_MODE_MASK_OWNER = stat.S_IRWXG | stat.S_IRWXO
+
+    # Mode mask for data directory permissions that also allows group read/execute.
+    __PG_MODE_MASK_GROUP = stat.S_IWGRP | stat.S_IRWXO
+
+    # Default mode for creating directories
+    __PG_DIR_MODE_OWNER = stat.S_IRWXU
+
+    # Mode for creating directories that allows group read/execute
+    __PG_DIR_MODE_GROUP = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP
+
+    # Default mode for creating files
+    __PG_FILE_MODE_OWNER = stat.S_IRUSR | stat.S_IWUSR
+
+    # Mode for creating files that allows group read
+    __PG_FILE_MODE_GROUP = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP
+
+    def __init__(self) -> None:
+        """Create a :class:`__FilePermissions` object and sets default permissions."""
+        self.__set_owner_permissions()
+        self.__set_umask()
+
+    def __set_umask(self) -> None:
+        """Set umask value based on calculations."""
+        try:
+            os.umask(self.__pg_mode_mask)
+        except Exception as e:
+            logger.error('Can not set umask to %03o: %r', self.__pg_mode_mask, e)
+
+    def __set_owner_permissions(self) -> None:
+        """Make directories/files accessible only by the owner."""
+        self.__pg_dir_create_mode = self.__PG_DIR_MODE_OWNER
+        self.__pg_file_create_mode = self.__PG_FILE_MODE_OWNER
+        self.__pg_mode_mask = self.__PG_MODE_MASK_OWNER
+
+    def __set_group_permissions(self) -> None:
+        """Make directories/files accessible by the owner and readable by group."""
+        self.__pg_dir_create_mode = self.__PG_DIR_MODE_GROUP
+        self.__pg_file_create_mode = self.__PG_FILE_MODE_GROUP
+        self.__pg_mode_mask = self.__PG_MODE_MASK_GROUP
+
+    def set_permissions_from_data_directory(self, data_dir: str) -> None:
+        """Set new permissions based on provided *data_dir*.
+
+        :param data_dir: reference to PGDATA to calculate permissions from.
+        """
+        try:
+            st = os.stat(data_dir)
+            if (st.st_mode & self.__PG_DIR_MODE_GROUP) == self.__PG_DIR_MODE_GROUP:
+                self.__set_group_permissions()
+            else:
+                self.__set_owner_permissions()
+        except Exception as e:
+            logger.error('Can not check permissions on %s: %r', data_dir, e)
+        else:
+            self.__set_umask()
+
+    @property
+    def dir_create_mode(self) -> int:
+        """Directory permissions."""
+        return self.__pg_dir_create_mode
+
+    @property
+    def file_create_mode(self) -> int:
+        """File permissions"""
+        return self.__pg_file_create_mode
+
+
+pg_perm = __FilePermissions()

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -369,6 +369,13 @@ class ConfigHandler(object):
         return configuration
 
     def set_file_permissions(self, file_name: str) -> None:
+        """Set permissions of file *file_name* according to the expected permissions if it resides under PGDATA.
+
+        .. note::
+            Do nothing if the file is not under PGDATA.
+
+        :param file_name: path to a file which permissions might need to be adjusted.
+        """
         if is_subpath(self._postgresql.data_dir, file_name):
             pg_perm.set_permissions_from_data_directory(self._postgresql.data_dir)
             os.chmod(file_name, pg_perm.file_create_mode)

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -6,9 +6,10 @@ import socket
 import stat
 import time
 
+from contextlib import contextmanager
 from urllib.parse import urlparse, parse_qsl, unquote
 from types import TracebackType
-from typing import Any, Collection, Dict, List, Optional, Union, Tuple, Type, TYPE_CHECKING
+from typing import Any, Collection, Dict, Iterator, List, Optional, Union, Tuple, Type, TYPE_CHECKING
 
 from .validator import recovery_parameters, transform_postgresql_parameter_value, transform_recovery_parameter_value
 from ..collections import CaseInsensitiveDict, CaseInsensitiveSet
@@ -368,17 +369,29 @@ class ConfigHandler(object):
             configuration.append('pg_ident.conf')
         return configuration
 
-    def set_file_permissions(self, file_name: str) -> None:
-        """Set permissions of file *file_name* according to the expected permissions if it resides under PGDATA.
+    def set_file_permissions(self, filename: str) -> None:
+        """Set permissions of file *filename* according to the expected permissions if it resides under PGDATA.
 
         .. note::
             Do nothing if the file is not under PGDATA.
 
-        :param file_name: path to a file which permissions might need to be adjusted.
+        :param filename: path to a file which permissions might need to be adjusted.
         """
-        if is_subpath(self._postgresql.data_dir, file_name):
+        if is_subpath(self._postgresql.data_dir, filename):
             pg_perm.set_permissions_from_data_directory(self._postgresql.data_dir)
-            os.chmod(file_name, pg_perm.file_create_mode)
+            os.chmod(filename, pg_perm.file_create_mode)
+
+    @contextmanager
+    def config_writer(self, filename: str) -> Iterator[ConfigWriter]:
+        """Create :class:`ConfigWriter` object and set permissions on a *filename*.
+
+        :param filename: path to a config file.
+
+        :yields: :class:`ConfigWriter` object.
+        """
+        with ConfigWriter(filename) as writer:
+            yield writer
+        self.set_file_permissions(filename)
 
     def save_configuration_files(self, check_custom_bootstrap: bool = False) -> bool:
         """
@@ -425,8 +438,7 @@ class ConfigHandler(object):
         if self._postgresql.enforce_hot_standby_feedback:
             configuration['hot_standby_feedback'] = 'on'
 
-        with ConfigWriter(self._postgresql_conf) as f:
-            self.set_file_permissions(self._postgresql_conf)
+        with self.config_writer(self._postgresql_conf) as f:
             include = self._config.get('custom_conf') or self._postgresql_base_conf_name
             f.writeline("include '{0}'\n".format(ConfigWriter.escape(include)))
             for name, value in sorted((configuration).items()):
@@ -455,7 +467,6 @@ class ConfigHandler(object):
     def append_pg_hba(self, config: List[str]) -> bool:
         if not self.hba_file and not self._config.get('pg_hba'):
             with open(self._pg_hba_conf, 'a') as f:
-                self.set_file_permissions(self._pg_hba_conf)
                 f.write('\n{}\n'.format('\n'.join(config)))
             self.set_file_permissions(self._pg_hba_conf)
         return True
@@ -477,16 +488,14 @@ class ConfigHandler(object):
                                   self.local_replication_address['host'], self.local_replication_address['port'],
                                   0, socket.SOCK_STREAM, socket.IPPROTO_TCP)})
 
-            with ConfigWriter(self._pg_hba_conf) as f:
-                self.set_file_permissions(self._pg_hba_conf)
+            with self.config_writer(self._pg_hba_conf) as f:
                 for address, t in addresses.items():
                     f.writeline((
                         '{0}\treplication\t{1}\t{3}\ttrust\n'
                         '{0}\tall\t{2}\t{3}\ttrust'
                     ).format(t, self.replication['username'], self._superuser.get('username') or 'all', address))
         elif not self.hba_file and self._config.get('pg_hba'):
-            with ConfigWriter(self._pg_hba_conf) as f:
-                self.set_file_permissions(self._pg_hba_conf)
+            with self.config_writer(self._pg_hba_conf) as f:
                 f.writelines(self._config['pg_hba'])
             return True
 
@@ -499,8 +508,7 @@ class ConfigHandler(object):
         """
 
         if not self.ident_file and self._config.get('pg_ident'):
-            with ConfigWriter(self._pg_ident_conf) as f:
-                self.set_file_permissions(self._pg_ident_conf)
+            with self.config_writer(self._pg_ident_conf) as f:
                 f.writelines(self._config['pg_ident'])
             return True
 
@@ -837,8 +845,7 @@ class ConfigHandler(object):
             self._current_recovery_params = CaseInsensitiveDict({n: [v, restart_required(n), self._postgresql_conf]
                                                                  for n, v in recovery_params.items()})
         else:
-            with ConfigWriter(self._recovery_conf) as f:
-                self.set_file_permissions(self._recovery_conf)
+            with self.config_writer(self._recovery_conf) as f:
                 self._write_recovery_params(f, recovery_params)
 
     def remove_recovery_conf(self) -> None:

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Generator, List, Optional, Union, Tuple, TYPE_CHEC
 from .connection import get_connection_cursor
 from .misc import format_lsn, fsync_dir
 from ..dcs import Cluster, Leader
+from ..file_perm import pg_perm
 from ..psycopg import OperationalError
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -471,23 +472,28 @@ class SlotsHandler(object):
                 logger.error("Failed to copy logical slots from the %s via postgresql connection: %r", leader.name, e)
 
         if copy_slots and self._postgresql.stop():
+            pg_perm.set_permissions_from_data_directory(self._postgresql.data_dir)
             for name, value in copy_slots.items():
-                slot_dir = os.path.join(self._postgresql.slots_handler.pg_replslot_dir, name)
+                slot_dir = os.path.join(self.pg_replslot_dir, name)
                 slot_tmp_dir = slot_dir + '.tmp'
                 if os.path.exists(slot_tmp_dir):
                     shutil.rmtree(slot_tmp_dir)
                 os.makedirs(slot_tmp_dir)
+                os.chmod(slot_tmp_dir, pg_perm.dir_create_mode)
                 fsync_dir(slot_tmp_dir)
-                with open(os.path.join(slot_tmp_dir, 'state'), 'wb') as f:
+                slot_filename = os.path.join(slot_tmp_dir, 'state')
+                with open(slot_filename, 'wb') as f:
+                    os.chmod(slot_filename, pg_perm.file_create_mode)
                     f.write(value['data'])
                     f.flush()
                     os.fsync(f.fileno())
                 if os.path.exists(slot_dir):
                     shutil.rmtree(slot_dir)
                 os.rename(slot_tmp_dir, slot_dir)
+                os.chmod(slot_dir, pg_perm.dir_create_mode)
                 fsync_dir(slot_dir)
                 self._logical_slots_processing_queue[name] = None
-            fsync_dir(self._postgresql.slots_handler.pg_replslot_dir)
+            fsync_dir(self.pg_replslot_dir)
             self._postgresql.start()
 
     def schedule(self, value: Optional[bool] = None) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,7 @@ class TestConfig(unittest.TestCase):
     @patch('os.path.exists', Mock(return_value=True))
     @patch('os.remove', Mock(side_effect=IOError))
     @patch('os.close', Mock(side_effect=IOError))
+    @patch('os.chmod', Mock())
     @patch('shutil.move', Mock(return_value=None))
     @patch('json.dump', Mock())
     def test_save_cache(self):

--- a/tests/test_file_perm.py
+++ b/tests/test_file_perm.py
@@ -1,0 +1,25 @@
+import unittest
+import stat
+
+from mock import Mock, patch
+
+from patroni.file_perm import pg_perm
+
+
+class TestFilePermissions(unittest.TestCase):
+
+    @patch('os.stat')
+    @patch('os.umask')
+    @patch('patroni.file_perm.logger.error')
+    def test_set_umask(self, mock_logger, mock_umask, mock_stat):
+        mock_umask.side_effect = Exception
+        mock_stat.return_value.st_mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP
+        pg_perm.set_permissions_from_data_directory('test')
+        self.assertEqual(mock_umask.call_args[0][0], stat.S_IWGRP | stat.S_IRWXO)
+        self.assertEqual(mock_logger.call_args[0][0], 'Can not set umask to %03o: %r')
+
+    @patch('os.stat', Mock(side_effect=FileNotFoundError))
+    @patch('patroni.file_perm.logger.error')
+    def test_set_permissions_from_data_directory(self, mock_logger):
+        pg_perm.set_permissions_from_data_directory('test')
+        self.assertEqual(mock_logger.call_args[0][0], 'Can not check permissions on %s: %r')

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1415,6 +1415,7 @@ class TestHa(PostgresInit):
     @patch('os.open', Mock())
     @patch('os.fsync', Mock())
     @patch('os.close', Mock())
+    @patch('os.chmod', Mock())
     @patch('os.rename', Mock())
     @patch('patroni.postgresql.Postgresql.is_starting', Mock(return_value=False))
     @patch('builtins.open', mock_open())

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -523,8 +523,9 @@ class TestPostgresql(BaseTestPostgresql):
     def test_save_configuration_files(self):
         self.p.config.save_configuration_files()
 
-    @patch('os.path.isfile', Mock(side_effect=[False, True]))
-    @patch('shutil.copy', Mock(side_effect=IOError))
+    @patch('os.path.isfile', Mock(side_effect=[False, True, False, True]))
+    @patch('shutil.copy', Mock(side_effect=[None, IOError]))
+    @patch('os.chmod', Mock())
     def test_restore_configuration_files(self):
         self.p.config.restore_configuration_files()
 


### PR DESCRIPTION
Postgres supports two types of permissions:
1. owner only
2. group readable

By default the first one is used because it provides better security. But, sometimes people want to run a backup tool with the user that is different from postgres. In this case the second option becomes very useful. Unfortunately it didn't work correctly because Patroni was creating files with owner access only permissions.

This PR changes the behaviour and permissions on files and directories that are created by Patroni will be calculated based on permissions of PGDATA. I.e., they will get group readable access when it is necessary.

Close #1899
Close #1901