### PR TITLE
[WIP] Implement generate-config

### DIFF
--- a/patroni/collections.py
+++ b/patroni/collections.py
@@ -3,7 +3,7 @@
 Provides a case insensitive :class:`dict` and :class:`set` object types.
 """
 from collections import OrderedDict
-from typing import Any, Collection, Dict, Iterator, MutableMapping, MutableSet, Optional
+from typing import Any, Collection, Dict, Iterator, KeysView, MutableMapping, MutableSet, Optional
 
 
 class CaseInsensitiveSet(MutableSet[str]):
@@ -186,6 +186,9 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
         :return: a new dict object with the same keys and values of this dict.
         """
         return CaseInsensitiveDict({v[0]: v[1] for v in self._values.values()})
+
+    def keys(self) -> KeysView[str]:
+        return self._values.keys()
 
     def __repr__(self) -> str:
         """Get a string representation of the dict.

--- a/patroni/config_generator.py
+++ b/patroni/config_generator.py
@@ -1,0 +1,286 @@
+"""patroni --generate-config machinery."""
+import os
+import socket
+import sys
+import yaml
+
+from typing import Any, Dict, Optional
+
+from .config import Config
+from .exceptions import PatroniException
+from .postgresql.config import ConfigHandler
+from .postgresql.misc import postgres_major_version_to_int
+from .utils import get_major_version, patch_config
+
+
+def get_ip() -> str:
+    """
+    Try to get an ip address of the hostname returned by :func:`gethostname`.
+
+    .. note::
+            Can also return local ip
+
+    :returns: the first element in the sorted list of the addresses returned by :func:`getaddrinfo`.
+              Sorting guarantees it will prefer ipv4.
+    """
+    hostname = None
+    try:
+        hostname = socket.gethostname()
+        return sorted(socket.getaddrinfo(hostname, 0, socket.AF_UNSPEC, socket.SOCK_STREAM, 0),
+                      key=lambda x: x[0])[0][4][0]
+    except OSError as e:
+        sys.exit(f'Failed to define ip address: {e}')
+    except IndexError:
+        sys.exit(f'Failed to define ip address. No address returned by getaddrinfo for {hostname}')
+
+
+def get_int_major_version(config: Optional[Dict[str, Any]] = None) -> int:
+    """Get major version of PostgreSQL from the binary as an integer.
+
+    :param config: optional dictionary representing Patroni config. If contains bin_dir and/or the custom
+    bin_name for postgres, the values are used for the version retrieval.
+    """
+    config = config or {}
+    postgres_bin = ((config.get('postgresql') or {}).get('bin_name') or {}).get('postgres', 'postgres')
+    return postgres_major_version_to_int(get_major_version(config['postgresql'].get('bin_dir') or None, postgres_bin))
+
+
+def get_bin_dir_from_running_instance(data_dir: str) -> str:
+    """Define the directory postgres binaries reside using postmaster's pid executable."""
+    postmaster_pid = None
+    try:
+        with open(f"{data_dir}/postmaster.pid", 'r') as f:
+            postmaster_pid = f.readline()
+            if not postmaster_pid:
+                sys.exit('Failed to obtain postmaster pid from postmaster.pid file')
+            postmaster_pid = int(postmaster_pid.strip())
+    except OSError as e:
+        sys.exit(f'Error while reading postmaster.pid file: {e}')
+    import psutil
+    try:
+        return os.path.dirname(psutil.Process(postmaster_pid).exe())
+    except psutil.NoSuchProcess:
+        sys.exit('Obtained postmaster pid doesn\'t exist')
+
+
+def enrich_config_from_running_instance(config: Dict[str, Any], no_value_msg: str, dsn: Optional[str] = None) -> None:
+    """Extend the passed ``config`` dictionary with the values gathered from a running instance.
+
+    Get
+    - non-internal GUC values having configuration file, postmaster command line or environment variable as a source
+    - postgresql.connect_address, postgresql.listen,
+    - postgresql.pg_hba and postgresql.pg_ident if hba_file/ident_file is set to the default value
+    - superuser auth parameters (from the options used for connection)
+    And redefine scope with the clister_name GUC value if set
+
+    :param config: configuration parameters dict to be enriched
+    :param no_value_msg: str value to be used when a parameter value is not available
+    :param dsn: optional DSN string for the source running instance
+    """
+    from getpass import getuser, getpass
+    from patroni.postgresql.config import parse_dsn
+    from patroni.config import AUTH_ALLOWED_PARAMETERS_MAPPING
+
+    su_params: Dict[str, str] = {}
+    parsed_dsn = {}
+
+    if dsn:
+        parsed_dsn = parse_dsn(dsn)
+        if not parsed_dsn:
+            sys.exit('Failed to parse DSN string')
+
+    # gather auth parameters for the superuser config
+    for conn_param, env_var in AUTH_ALLOWED_PARAMETERS_MAPPING.items():
+        val = parsed_dsn.get(conn_param, os.getenv(env_var))
+        if val:
+            su_params[conn_param] = val
+    patroni_env_su_username = ((config.get('authentication') or {}).get('superuser') or {}).get('username')
+    patroni_env_su_pwd = ((config.get('authentication') or {}).get('superuser') or {}).get('password')
+    # because we use "username" in the config for some reason
+    su_params['username'] = su_params.pop('user', patroni_env_su_username) or getuser()
+    su_params['password'] = su_params.get('password', patroni_env_su_pwd) or getpass('Please enter the user password:')
+
+    from . import psycopg
+    try:
+        conn = psycopg.connect(dsn=dsn, password=su_params['password'])
+    except psycopg.Error as e:
+        sys.exit(f'Failed to establish PostgreSQL connection: {e}')
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_roles WHERE rolname=%s AND rolsuper='t';", (su_params['username'],))
+        if cur.rowcount < 1:
+            sys.exit('The provided user does not have superuser privilege')
+
+        required_params = ['hba_file', 'ident_file', 'config_file',
+                           'data_directory'] + list(ConfigHandler.CMDLINE_OPTIONS.keys())
+        cur.execute("SELECT name, current_setting(name) FROM pg_settings \
+                     WHERE context <> 'internal' \
+                     AND source IN ('configuration file', 'command line', 'environment variable') \
+                     AND category <> 'Write-Ahead Log / Recovery Target' \
+                     AND setting <> '(disabled)' \
+                     OR name = ANY(%s);", (required_params,))
+
+        helper_dict = dict.fromkeys(['port', 'listen_addresses'])
+        # adjust values
+        for p, v in cur.fetchall():
+            if p == 'data_directory':
+                config['postgresql']['data_dir'] = v
+            elif p == 'cluster_name' and v:
+                config['scope'] = v
+            elif p in ('archive_command', 'restore_command', 'archive_cleanup_command',
+                       'recovery_end_command', 'ssl_passphrase_command',
+                       'hba_file', 'ident_file', 'config_file'):
+                # write commands to the local config due to security implications
+                # write hba/ident/config_file to local config to ensure they are not removed later
+                config['postgresql'].setdefault('parameters', {})
+                config['postgresql']['parameters'][p] = v
+            elif p in helper_dict:
+                helper_dict[p] = v
+            else:
+                config['bootstrap']['dcs']['postgresql']['parameters'][p] = v
+
+    conn.close()
+
+    connect_port = parsed_dsn.get('port', os.getenv('PGPORT', helper_dict['port']))
+    config['postgresql']['connect_address'] = f'{get_ip()}:{connect_port}'
+    config['postgresql']['listen'] = f'{helper_dict["listen_addresses"]}:{helper_dict["port"]}'
+
+    # it makes sense to define postgresql.pg_hba/pg_ident only if hba_file/ident_file are set to defaults
+    default_hba_path = os.path.join(config['postgresql']['data_dir'], 'pg_hba.conf')
+    if config['postgresql']['parameters']['hba_file'] == default_hba_path:
+        try:
+            allowed_records = ['local', 'host', 'hostssl', 'hostnossl', 'hostgssenc', 'hostnogssenc']
+            if get_int_major_version(config) >= 16:
+                allowed_records += ['include', 'include_if_exists', 'include_dir']
+            with open(default_hba_path, 'r') as f:
+                config['postgresql']['pg_hba'] = list(filter(lambda i: i and i.split()[0] in allowed_records,
+                                                             (li.strip() for li in f.readlines())))
+        except OSError as e:
+            sys.exit(f'Failed to read pg_hba.conf: {e}')
+
+    default_ident_path = os.path.join(config['postgresql']['data_dir'], 'pg_ident.conf')
+    if config['postgresql']['parameters']['ident_file'] == default_ident_path:
+        try:
+            with open(default_ident_path, 'r') as f:
+                config['postgresql']['pg_ident'] = [i.strip() for i in f.readlines()
+                                                    if i.strip() and not i.startswith('#')]
+        except OSError as e:
+            sys.exit(f'Failed to read pg_ident.conf: {e}')
+        if not config['postgresql']['pg_ident']:
+            del config['postgresql']['pg_ident']
+
+    config['postgresql']['authentication'] = {
+        'superuser': su_params,
+        'replication': {'username': no_value_msg, 'password': no_value_msg}
+    }
+
+
+def generate_config(file: str, sample: bool, dsn: Optional[str]) -> None:
+    """Generate Patroni configuration file.
+
+    Gather all the available non-internal GUC values having configuration file, postmaster command line or environment
+    variable as a source and store them in the appropriate part of Patroni configuration (``postgresql.parameters`` or
+    ``bootsrtap.dcs.postgresql.parameters``). Either the provided DSN (takes precedence) or PG ENV vars will be used
+    for the connection. If password is not provided, it should be entered via prompt.
+
+    The created configuration contains:
+    - ``scope``: cluster_name GUC value or PATRONI_SCOPE ENV variable value if available
+    - ``name``: PATRONI_NAME ENV variable value if set, otherewise hostname
+    - ``bootsrtap.dcs``: section with all the parameters (incl. the majority of PG GUCs) set to their default values
+      defined by Patroni and adjusted by the source instances's configuration values.
+    - ``postgresql.parameters``: the source instance's archive_command, restore_command, archive_cleanup_command,
+      recovery_end_command, ssl_passphrase_command, hba_file, ident_file, config_file GUC values
+    - ``postgresql.bin_dir``: path to Postgres binaries gathered from the running instance or, if not available,
+      the value of PATRONI_POSTGRESQL_BIN_DIR ENV variable. Otherwise, an empty string.
+    - ``postgresql.datadir``: the value gathered from the corresponding PG GUC
+    - ``postgresql.listen``: source instance's listen_addresses and port GUC values
+    - ``postgresql.connect_address``: if possible, generated from the connection params
+    - ``postgresql.authentication``:
+        - superuser and replication users defined (if possible, usernames are set from the respective Patroni ENV vars,
+          otherwise the default 'postgres' and 'replicator' values are used).
+          If not a sample config, either DSN or PG ENV vars are used to define superuser authentication parameters.
+        - rewind user is defined for a sample config if PG version can be defined and PG version is 11+
+          (if possible, username is set from the respective Patroni ENV var)
+    - ``bootsrtap.dcs.postgresql.use_pg_rewind``
+    - ``postgresql.pg_hba`` defaults or the lines gathered from the source instance's hba_file
+    - ``postgresql.pg_ident`` the lines gathered from the source instance's ident_file
+
+    :param file: Full path to the configuration file to be created (/tmp/patroni.yml by default).
+    :param sample: Optional flag. If set, no source instance will be used - generate config with some sane defaults.
+    :param dsn: Optional DSN string for the local instance to get GUC values from.
+    """
+    no_value_msg = '#FIXME'
+    pg_version = None
+    local_ip = get_ip()
+
+    config = Config('', None).local_configuration  # Get values from env
+    dynamic_config = Config.get_default_config()
+    dynamic_config['postgresql']['parameters'] = dict(dynamic_config['postgresql']['parameters'])
+    config.setdefault('bootstrap', {})['dcs'] = dynamic_config
+    config.setdefault('postgresql', {})
+
+    template_config: Dict[str, Any] = {
+        'scope': no_value_msg,
+        'name': socket.gethostname(),
+        'postgresql': {
+            'data_dir': no_value_msg,
+            'connect_address': no_value_msg + ':5432',
+            'listen': no_value_msg + ':5432',
+            'bin_dir': '',
+            'authentication': {
+                'superuser': {
+                    'username': 'postgres',
+                    'password': no_value_msg
+                },
+                'replication': {
+                    'username': 'replicator',
+                    'password': no_value_msg
+                }
+            }
+        },
+        'restapi': {
+            'connect_address': local_ip + ':8008',
+            'listen': local_ip + ':8008'
+        }
+    }
+
+    if not sample:
+        enrich_config_from_running_instance(config, no_value_msg, dsn)
+        config['postgresql']['bin_dir'] = get_bin_dir_from_running_instance(config['postgresql']['data_dir'])
+
+    try:
+        pg_version = get_int_major_version(config)
+    except PatroniException as e:
+        sys.exit(str(e))
+
+    patch_config(template_config, config)
+    config = template_config
+
+    # generate sample config
+    if sample:
+        auth_method = 'scram-sha-256' if pg_version and pg_version >= 100000 else 'md5'
+        config['postgresql']['parameters'] = {'password_encryption': auth_method}
+        config['postgresql']['pg_hba'] = [
+            f'host all all all {auth_method}',
+            f'host replication {config["postgresql"]["authentication"]["replication"]["username"]} all {auth_method}'
+        ]
+
+        # add version-specific configuration
+        wal_keep_param = 'wal_keep_segments' if pg_version < 130000 else 'wal_keep_size'
+        config['bootstrap']['dcs']['postgresql']['parameters'][wal_keep_param] =\
+            ConfigHandler.CMDLINE_OPTIONS[wal_keep_param][0]
+
+        config['bootstrap']['dcs']['postgresql']['use_pg_rewind'] = True
+        if pg_version >= 110000:
+            config['postgresql']['authentication'].setdefault(
+                'rewind', {'username': 'rewind_user'}).setdefault(
+                    'password', no_value_msg)
+
+    # redundant values from the default config
+    del config['bootstrap']['dcs']['standby_cluster']
+
+    dir_path = os.path.dirname(file)
+    if dir_path and not os.path.isdir(dir_path):
+        os.makedirs(dir_path)
+    with open(file, 'w') as fd:
+        yaml.safe_dump(config, fd, default_flow_style=False)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -118,6 +118,21 @@ class MockCursor(object):
                                '"state":"streaming","sync_state":"async","sync_priority":0}]'
             now = datetime.datetime.now(tzutc)
             self.results = [(now, 0, '', 0, '', False, now, 'streaming', None, replication_info)]
+        elif sql.startswith('SELECT name, current_setting(name) FROM pg_settings'):
+            self.results = [('data_directory', 'data'),
+                            ('hba_file', os.path.join('data', 'pg_hba.conf')),
+                            ('ident_file', os.path.join('data', 'pg_ident.conf')),
+                            ('max_connections', 42),
+                            ('max_locks_per_transaction', 73),
+                            ('max_prepared_transactions', 0),
+                            ('max_replication_slots', 21),
+                            ('max_wal_senders', 37),
+                            ('track_commit_timestamp', 'off'),
+                            ('wal_level', 'replica'),
+                            ('listen_addresses', '6.6.6.6'),
+                            ('port', 1984),
+                            ('archive_command', 'my archive command'),
+                            ('cluster_name', 'my_cluster')]
         elif sql.startswith('SELECT name, setting'):
             self.results = [('wal_segment_size', '2048', '8kB', 'integer', 'internal'),
                             ('wal_block_size', '8192', None, 'integer', 'internal'),
@@ -139,6 +154,9 @@ class MockCursor(object):
             self.results = [(2,)]
         elif sql.startswith('SELECT nodeid, groupid'):
             self.results = [(1, 0, 'host1', 5432, 'primary'), (2, 1, 'host2', 5432, 'primary')]
+        elif sql.startswith('SELECT 1'):
+            self.results = [(1,)]
+            self.rowcount = 1
         else:
             self.results = [(None, None, None, None, None, None, None, None, None, None)]
 

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -1,17 +1,22 @@
 import etcd
 import logging
 import os
+import psutil
 import signal
 import time
 import unittest
 
+from copy import deepcopy
+
+from . import MockCursor
 import patroni.config as config
 from http.server import HTTPServer
-from mock import Mock, PropertyMock, patch
+from mock import MagicMock, Mock, PropertyMock, mock_open, patch
 from patroni.api import RestApiServer
 from patroni.async_executor import AsyncExecutor
 from patroni.dcs import Cluster, Member
 from patroni.dcs.etcd import AbstractEtcdClientWithFailover
+from patroni.config import Config
 from patroni.exceptions import DCSError
 from patroni.postgresql import Postgresql
 from patroni.postgresql.config import ConfigHandler
@@ -236,3 +241,257 @@ class TestPatroni(unittest.TestCase):
             # Only if the api of the running node is reachable do we throw an error
             with patch.object(self.p, 'request', Mock()):
                 self.assertRaises(SystemExit, self.p.ensure_unique_name)
+
+
+@patch('patroni.psycopg.connect', psycopg_connect)
+@patch('socket.getaddrinfo', Mock(return_value=[(0, 0, 0, 0, ('1.9.8.4', 1984))]))
+@patch('builtins.open', MagicMock())
+@patch('socket.gethostname', Mock(return_value='testhost'))
+@patch('subprocess.check_output', Mock(return_value=b"postgres (PostgreSQL) 13.2"))
+@patch('psutil.Process.exe', Mock(return_value='/bin/dir/from/running/postgres'))
+@patch('psutil.Process.__init__', Mock(return_value=None))
+class TestGenerateConfig(unittest.TestCase):
+
+    no_value_msg = '#FIXME'
+
+    def setUp(self):
+        self.maxDiff = None
+
+        os.environ['PATRONI_SCOPE'] = 'scope_from_env'
+        os.environ['PATRONI_POSTGRESQL_BIN_DIR'] = '/bin/from/env'
+        os.environ['PATRONI_SUPERUSER_USERNAME'] = 'su_user_from_env'
+        os.environ['PATRONI_SUPERUSER_PASSWORD'] = 'su_pwd_from_env'
+        os.environ['PATRONI_REPLICATION_USERNAME'] = 'repl_user_from_env'
+        os.environ['PATRONI_REPLICATION_PASSWORD'] = 'repl_pwd_from_env'
+        os.environ['PATRONI_REWIND_USERNAME'] = 'rewind_user_from_env'
+        os.environ['PGUSER'] = 'pguser_from_env'
+        os.environ['PGPASSWORD'] = 'pguser_pwd_from_env'
+        os.environ['PATRONI_RESTAPI_CONNECT_ADDRESS'] = 'localhost:8080'
+        os.environ['PATRONI_RESTAPI_LISTEN'] = 'localhost:8080'
+        os.environ['PATRONI_POSTGRESQL_BIN_POSTGRES'] = 'custom_postgres_bin_from_env'
+
+        self.environ = deepcopy(os.environ)
+
+        dynamic_config = Config.get_default_config()
+        dynamic_config['postgresql']['parameters'] = dict(dynamic_config['postgresql']['parameters'])
+        del dynamic_config['standby_cluster']
+        dynamic_config['postgresql']['parameters']['wal_keep_segments'] = 8
+        dynamic_config['postgresql']['use_pg_rewind'] = True
+
+        self.config = {
+            'scope': self.environ['PATRONI_SCOPE'],
+            'name': 'testhost',
+            'bootstrap': {
+                'dcs': dynamic_config
+            },
+            'postgresql': {
+                'connect_address': self.no_value_msg + ':5432',
+                'data_dir': self.no_value_msg,
+                'listen': self.no_value_msg + ':5432',
+                'pg_hba': ['host all all all md5',
+                           f'host replication {self.environ["PATRONI_REPLICATION_USERNAME"]} all md5'],
+                'authentication': {'superuser': {'username': self.environ['PATRONI_SUPERUSER_USERNAME'],
+                                                 'password': self.environ['PATRONI_SUPERUSER_PASSWORD']},
+                                   'replication': {'username': self.environ['PATRONI_REPLICATION_USERNAME'],
+                                                   'password': self.environ['PATRONI_REPLICATION_PASSWORD']},
+                                   'rewind': {'username': self.environ['PATRONI_REWIND_USERNAME']}},
+                'bin_dir': self.environ['PATRONI_POSTGRESQL_BIN_DIR'],
+                'bin_name': {'postgres': self.environ['PATRONI_POSTGRESQL_BIN_POSTGRES']},
+                'parameters': {'password_encryption': 'md5'}
+            },
+            'restapi': {
+                'connect_address': self.environ['PATRONI_RESTAPI_CONNECT_ADDRESS'],
+                'listen': self.environ['PATRONI_RESTAPI_LISTEN']
+            }
+        }
+
+    def _set_running_instance_config_vals(self):
+        # values are taken from tests/__init__.py
+        self.config['scope'] = 'my_cluster'  # cluster_name
+        self.config['postgresql']['connect_address'] = '1.9.8.4:bar'
+        self.config['postgresql']['listen'] = '6.6.6.6:1984'
+        self.config['postgresql']['data_dir'] = 'data'
+        self.config['postgresql']['bin_dir'] = '/bin/dir/from/running'
+
+        self.config['postgresql']['parameters'] = {'archive_command': 'my archive command'}
+        self.config['postgresql']['parameters']['hba_file'] = os.path.join('data', 'pg_hba.conf')
+        self.config['postgresql']['parameters']['ident_file'] = os.path.join('data', 'pg_ident.conf')
+
+        self.config['bootstrap']['dcs']['postgresql']['parameters']['max_connections'] = 42
+        self.config['bootstrap']['dcs']['postgresql']['parameters']['max_locks_per_transaction'] = 73
+        self.config['bootstrap']['dcs']['postgresql']['parameters']['max_replication_slots'] = 21
+        self.config['bootstrap']['dcs']['postgresql']['parameters']['max_wal_senders'] = 37
+        self.config['bootstrap']['dcs']['postgresql']['parameters']['wal_level'] = 'replica'
+        del self.config['bootstrap']['dcs']['postgresql']['parameters']['wal_keep_segments']
+
+        self.config['postgresql']['authentication']['superuser'] = {
+            'username': 'foobar',
+            'password': 'qwerty',
+            'channel_binding': 'prefer',
+            'gssencmode': 'prefer',
+            'sslmode': 'prefer'
+        }
+        self.config['postgresql']['authentication']['replication'] = {'username': self.no_value_msg,
+                                                                      'password': self.no_value_msg}
+
+        # Rewind is not configured for a running instance config
+        del self.config['bootstrap']['dcs']['postgresql']['use_pg_rewind']
+        del self.config['postgresql']['authentication']['rewind']
+
+    def _get_running_instance_open_res(self):
+        hba_content = '\n'.join(self.config['postgresql']['pg_hba'] + ['#host all all all md5',
+                                                                       '  host all all all md5',
+                                                                       '',
+                                                                       'hostall all all md5'])
+        ident_content = '\n'.join(['# something very interesting', '  '])
+
+        self.config['postgresql']['pg_hba'] += ['host all all all md5']
+        return [
+            mock_open(read_data=hba_content)(),
+            mock_open(read_data=ident_content)(),
+            mock_open(read_data='1984')(),
+            mock_open()()
+        ]
+
+    @patch('os.makedirs')
+    @patch('yaml.safe_dump')
+    def test_generate_sample_config_pre_13_dir_creation(self, mock_config_dump, mock_makedir):
+        with patch('sys.argv', ['patroni.py', '--generate-sample-config', '/foo/bar.yml']),\
+             patch('subprocess.check_output', Mock(return_value=b"postgres (PostgreSQL) 9.4.3")) as pg_bin_mock,\
+             self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertEqual(e.exception.code, 0)
+        self.assertEqual(self.config, mock_config_dump.call_args[0][0])
+        mock_makedir.assert_called_once()
+        pg_bin_mock.assert_called_once_with([os.path.join(self.environ['PATRONI_POSTGRESQL_BIN_DIR'],
+                                                          self.environ['PATRONI_POSTGRESQL_BIN_POSTGRES']),
+                                             '--version'])
+
+    @patch('os.makedirs', Mock())
+    @patch('yaml.safe_dump')
+    def test_generate_sample_config_13(self, mock_config_dump):
+        del self.config['bootstrap']['dcs']['postgresql']['parameters']['wal_keep_segments']
+        self.config['bootstrap']['dcs']['postgresql']['parameters']['wal_keep_size'] = '128MB'
+        self.config['postgresql']['authentication']['rewind'] = {'username': self.environ['PATRONI_REWIND_USERNAME'],
+                                                                 'password': self.no_value_msg}
+        self.config['postgresql']['parameters']['password_encryption'] = 'scram-sha-256'
+        self.config['postgresql']['pg_hba'] = \
+            ['host all all all scram-sha-256',
+             f'host replication {self.environ["PATRONI_REPLICATION_USERNAME"]} all scram-sha-256']
+
+        with patch('sys.argv', ['patroni.py', '--generate-sample-config', '/foo/bar.yml']),\
+             self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertEqual(e.exception.code, 0)
+        self.assertEqual(self.config, mock_config_dump.call_args[0][0])
+
+    @patch('os.makedirs', Mock())
+    @patch('yaml.safe_dump')
+    def test_generate_config_running_instance_13(self, mock_config_dump):
+        self._set_running_instance_config_vals()
+
+        with patch('builtins.open', Mock(side_effect=self._get_running_instance_open_res())),\
+             patch('sys.argv', ['patroni.py', '--generate-config',
+                                '--dsn', 'host=foo port=bar user=foobar password=qwerty']),\
+                self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertEqual(e.exception.code, 0)
+        self.assertEqual(self.config, mock_config_dump.call_args[0][0])
+
+    @patch('os.makedirs', Mock())
+    @patch('yaml.safe_dump')
+    def test_generate_config_running_instance_13_connect_from_env(self, mock_config_dump):
+        self._set_running_instance_config_vals()
+        # su auth params and connect host from env
+        os.environ['PGCHANNELBINDING'] =\
+            self.config['postgresql']['authentication']['superuser']['channel_binding'] = 'disable'
+        del self.config['postgresql']['authentication']['superuser']['gssencmode']
+        del self.config['postgresql']['authentication']['superuser']['sslmode']
+        self.config['postgresql']['authentication']['superuser']['username'] = self.environ['PGUSER']
+        self.config['postgresql']['authentication']['superuser']['password'] = self.environ['PGPASSWORD']
+        self.config['postgresql']['connect_address'] = '1.9.8.4:1984'
+
+        with patch('builtins.open', Mock(side_effect=self._get_running_instance_open_res())),\
+             patch('sys.argv', ['patroni.py', '--generate-config']),\
+             self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertEqual(e.exception.code, 0)
+        self.assertEqual(self.config, mock_config_dump.call_args[0][0])
+
+    def test_generate_config_running_instance_errors(self):
+        # 1. Wrong DSN format
+        with patch('sys.argv', ['patroni.py', '--generate-config', '--dsn', 'host:foo port:bar user:foobar']),\
+             self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertIn('Failed to parse DSN string', e.exception.code)
+
+        # 2. User is not a superuser
+        with patch('sys.argv', ['patroni.py',
+                                '--generate-config', '--dsn', 'host=foo port=bar user=foobar password=pwd_from_dsn']),\
+             patch.object(MockCursor, 'rowcount', PropertyMock(return_value=0), create=True),\
+             self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertIn('The provided user does not have superuser privilege', e.exception.code)
+
+        # 3. Error while calling postgres --version
+        with patch('subprocess.check_output', Mock(side_effect=OSError)),\
+             patch('sys.argv', ['patroni.py', '--generate-sample-config']),\
+             self.assertRaises(SystemExit) as e:
+            _main()
+        self.assertIn('Failed to get postgres version:', e.exception.code)
+
+        with patch('sys.argv', ['patroni.py', '--generate-config']):
+
+            # 4. empty postmaster.pid
+            with patch('builtins.open', Mock(side_effect=[mock_open(read_data='hba_content')(),
+                                                          mock_open(read_data='ident_content')(),
+                                                          mock_open(read_data='')()])),\
+                 self.assertRaises(SystemExit) as e:
+                _main()
+            self.assertIn('Failed to obtain postmaster pid from postmaster.pid file', e.exception.code)
+
+            # 5. Failed to open postmaster.pid
+            with patch('builtins.open', Mock(side_effect=[mock_open(read_data='hba_content')(),
+                                                          mock_open(read_data='ident_content')(),
+                                                          OSError])),\
+                 self.assertRaises(SystemExit) as e:
+                _main()
+            self.assertIn('Error while reading postmaster.pid file', e.exception.code)
+
+            # 6. Invalid postmaster pid
+            with patch('builtins.open', Mock(side_effect=[mock_open(read_data='hba_content')(),
+                                                          mock_open(read_data='ident_content')(),
+                                                          mock_open(read_data='1984')()])),\
+                 patch('psutil.Process.__init__', Mock(return_value=None)),\
+                 patch('psutil.Process.exe', Mock(side_effect=psutil.NoSuchProcess(1984))),\
+                 self.assertRaises(SystemExit) as e:
+                _main()
+            self.assertIn("Obtained postmaster pid doesn't exist", e.exception.code)
+
+            # 7. Failed to open pg_hba
+            with patch('builtins.open', Mock(side_effect=OSError)),\
+                 self.assertRaises(SystemExit) as e:
+                _main()
+            self.assertIn('Failed to read pg_hba.conf', e.exception.code)
+
+            # 8. Failed to open pg_ident
+            with patch('builtins.open', Mock(side_effect=[mock_open(read_data='hba_content')(), OSError])),\
+                 self.assertRaises(SystemExit) as e:
+                _main()
+            self.assertIn('Failed to read pg_ident.conf', e.exception.code)
+
+            # 9. Failed PG connecttion
+            from . import psycopg
+            with patch('patroni.psycopg.connect', side_effect=psycopg.Error),\
+                 self.assertRaises(SystemExit) as e:
+                _main()
+            self.assertIn('Failed to establish PostgreSQL connection', e.exception.code)
+
+            # 10. Failed to get local IP
+            with patch('socket.getaddrinfo', Mock(side_effect=[OSError, []])):
+                with self.assertRaises(SystemExit) as e:
+                    _main()
+                self.assertIn('Failed to define ip address', e.exception.code)
+                with self.assertRaises(SystemExit) as e:
+                    _main()
+                self.assertIn('Failed to define ip address. No address returned by getaddrinfo for', e.exception.code)


### PR DESCRIPTION
new `patroni.py` option that allows to
- generate `patroni.yml` configuration file with the values from a running cluster
- generate a sample `patroni.yml` configuration file

Documentation will follow in a separate PR

Resolve https://github.com/zalando/patroni/issues/391