### PR TITLE
Fix `replicatefrom` tag in `postgres2.yml`

### DIFF
--- a/postgres2.yml
+++ b/postgres2.yml
@@ -121,4 +121,4 @@ tags:
     nofailover: false
     noloadbalance: false
     clonefrom: false
-    replicatefrom: postgres1
+    replicatefrom: postgresql1

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -121,4 +121,4 @@ tags:
     nofailover: false
     noloadbalance: false
     clonefrom: false
-    replicatefrom: postgresql1
+#    replicatefrom: postgresql1


### PR DESCRIPTION
The node `postgresql2` in the repository is apparently supposed to be a cascading standby.

However, if that is the case, there is a typo in the name of its upstream node.

This commit fixes that issue.