### PR TITLE
reset failsafe state when promote

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -97,6 +97,14 @@ class Failsafe(object):
             self._api_url = data['api_url']
             self._slots = data.get('slots')
 
+    def reset_state(self) -> None:
+        with self._lock:
+            self._last_update = 0
+            self._name = None
+            self._conn_url = None
+            self._api_url = None
+            self._slots = None
+
     @property
     def leader(self) -> Optional[Leader]:
         with self._lock:
@@ -770,6 +778,9 @@ class Ha(object):
                 self.state_handler.sync_handler.set_synchronous_standby_names(
                     CaseInsensitiveSet('*') if self.global_config.is_synchronous_mode_strict else CaseInsensitiveSet())
             if self.state_handler.role not in ('master', 'promoted', 'primary'):
+                # reset failsafe state when promote
+                self._failsafe.reset_state()
+
                 def before_promote():
                     self.notify_citus_coordinator('before_promote')
 


### PR DESCRIPTION
consider the scenario(enable failsafe_mode):
0. node1(primary) - node2(replica)
1. stop all etcd nodes; wait ttl seconds; start all etcd nodes; (node2's failsafe will contain the info about node1)
2. switchover to node2; (node2's failsafe still contain the info about node1)
3. stop all etcd nodes; wait ttl seconds; start all etcd nodes;
4. node2 will demote because it consider node1 as primary
reset failsafe state when promote could solve this problem.


