### PR TITLE
Refactor is_failover_possible()

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1218,12 +1218,11 @@ class Ha(object):
             if not failover.candidate or failover.candidate != self.state_handler.name:
                 if not failover.candidate and self.is_paused():
                     logger.warning('Failover is possible only to a specific candidate in a paused state')
+                elif self.is_failover_possible():
+                    ret = self._async_executor.try_run_async('manual failover: demote', self.demote, ('graceful',))
+                    return ret or 'manual failover: demoting myself'
                 else:
-                    if self.is_failover_possible():
-                        ret = self._async_executor.try_run_async('manual failover: demote', self.demote, ('graceful',))
-                        return ret or 'manual failover: demoting myself'
-                    else:
-                        logger.warning('manual failover: no healthy members found, failover is not possible')
+                    logger.warning('manual failover: no healthy members found, failover is not possible')
             else:
                 logger.warning('manual failover: I am already the leader, no need to failover')
         else:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -201,6 +201,10 @@ class Ha(object):
             self._is_leader = time.time() + self.dcs.ttl if value else 0
 
     def sync_mode_is_active(self) -> bool:
+        """Check whether synchronous replication is requested and already active.
+
+        :returns: ``True`` if the primary already put its name into the ``/sync`` in DCS.
+        """
         return self.is_synchronous_mode() and not self.cluster.sync.is_empty
 
     def load_cluster_from_dcs(self) -> None:
@@ -902,8 +906,7 @@ class Ha(object):
                     logger.info('Wal position of %s is ahead of my wal position', st.member.name)
                     # In synchronous mode the former leader might be still accessible and even be ahead of us.
                     # We should not disqualify himself from the leader race in such a situation.
-                    if not self.is_synchronous_mode() or self.cluster.sync.is_empty\
-                            or not self.cluster.sync.leader_matches(st.member.name):
+                    if not self.sync_mode_is_active() or not self.cluster.sync.leader_matches(st.member.name):
                         return False
                     logger.info('Ignoring the former leader being ahead of us')
         return True

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -748,7 +748,6 @@ class TestHa(PostgresInit):
         self.p.is_leader = true
         self.ha.has_lock = true
         self.ha.is_synchronous_mode = true
-        self.ha.is_failover_possible = false
         self.ha.process_sync_replication = Mock()
         self.ha.cluster = get_cluster_initialized_with_leader(Failover(0, self.p.name, 'a', None), (self.p.name, None))
         self.assertEqual('no action. I am (postgresql0), the leader with the lock', self.ha.run_cycle())


### PR DESCRIPTION
Move all the members filtering inside `is_failover_possible()`. Rename "members list" to "candidates list"