### PR TITLE
[Refactor] Rename _is_leader to _leader_expiry

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -193,10 +193,16 @@ class Ha(object):
         return self.global_config.is_standby_cluster
 
     def is_leader(self) -> bool:
+        """:returns: `True` if the current node is the leader, based on expiration set when it last held the key."""
         with self._leader_expiry_lock:
             return self._leader_expiry > time.time()
 
     def set_is_leader(self, value: bool) -> None:
+        """Updates the current node's view of it's own leadership status. Will update the expiry timestamp to match
+        the dcs ttl if setting leadership to true, otherwise will set the expiry to the past to immediately
+        invalidate.
+
+        :param value: Is the current node the leader."""
         with self._leader_expiry_lock:
             self._leader_expiry = time.time() + self.dcs.ttl if value else 0
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -198,11 +198,13 @@ class Ha(object):
             return self._leader_expiry > time.time()
 
     def set_is_leader(self, value: bool) -> None:
-        """Updates the current node's view of it's own leadership status. Will update the expiry timestamp to match
-        the dcs ttl if setting leadership to true, otherwise will set the expiry to the past to immediately
-        invalidate.
+        """Update the current node's view of it's own leadership status.
 
-        :param value: Is the current node the leader."""
+        Will update the expiry timestamp to match the dcs ttl if setting leadership to true,
+        otherwise will set the expiry to the past to immediately invalidate.
+
+        :param value: Is the current node the leader.
+        """
         with self._leader_expiry_lock:
             self._leader_expiry = time.time() + self.dcs.ttl if value else 0
 

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -203,7 +203,7 @@ class Ha(object):
         Will update the expiry timestamp to match the dcs ttl if setting leadership to true,
         otherwise will set the expiry to the past to immediately invalidate.
 
-        :param value: Is the current node the leader.
+        :param value: is the current node the leader.
         """
         with self._leader_expiry_lock:
             self._leader_expiry = time.time() + self.dcs.ttl if value else 0


### PR DESCRIPTION
In `class Ha` the private variable `_is_leader` reads like a `bool` and is initialized as a `bool`, but in practice it is a numeric timestamp representing the the time that this node's leadership will expire (0 if explicitly not leader).

Renamed to `_leader_expiry` and updated initialization to reflect this without changing the behavior of the public `is_leader` or `set_is_leader` functions