### PR TITLE
Factor out tags handling into a dedicated class

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -23,6 +23,7 @@ import dateutil.parser
 
 from ..exceptions import PatroniFatalException
 from ..utils import deep_compare, uri
+from ..tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..config import Config
@@ -191,11 +192,11 @@ _Version = Union[int, str]
 _Session = Union[int, float, str, None]
 
 
-class Member(NamedTuple('Member',
-                        [('version', _Version),
-                         ('name', str),
-                         ('session', _Session),
-                         ('data', Dict[str, Any])])):
+class Member(Tags, NamedTuple('Member',
+                              [('version', _Version),
+                               ('name', str),
+                               ('session', _Session),
+                               ('data', Dict[str, Any])])):
     """Immutable object (namedtuple) which represents single member of PostgreSQL cluster.
 
     .. note::
@@ -317,19 +318,9 @@ class Member(NamedTuple('Member',
         return self.data.get('tags', {})
 
     @property
-    def nofailover(self) -> bool:
-        """The value for ``nofailover`` in :attr:`Member`.tags`` if defined, otherwise ``False``."""
-        return self.tags.get('nofailover', False)
-
-    @property
-    def replicatefrom(self) -> Optional[str]:
-        """The value for ``replicatefrom`` in :attr:`Member`.tags`` if defined."""
-        return self.tags.get('replicatefrom')
-
-    @property
     def clonefrom(self) -> bool:
         """``True`` if both ``clonefrom`` tag is ``True`` and a connection URL is defined."""
-        return self.tags.get('clonefrom', False) and bool(self.conn_url)
+        return super().clonefrom and bool(self.conn_url)
 
     @property
     def state(self) -> str:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -20,31 +20,28 @@ from .postgresql.callback_executor import CallbackAction
 from .postgresql.misc import postgres_version_to_int
 from .postgresql.postmaster import PostmasterProcess
 from .postgresql.rewind import Rewind
+from .tags import Tags
 from .utils import polling_loop, tzutc
 
 logger = logging.getLogger(__name__)
 
 
-class _MemberStatus(NamedTuple):
-    """Node status distilled from API response:
+class _MemberStatus(Tags, NamedTuple('_MemberStatus',
+                                     [('member', Member),
+                                      ('reachable', bool),
+                                      ('in_recovery', Optional[bool]),
+                                      ('wal_position', int),
+                                      ('data', Dict[str, Any])])):
+    """Node status distilled from API response.
 
-        member - dcs.Member object of the node
-        reachable - `!False` if the node is not reachable or is not responding with correct JSON
-        in_recovery - `!True` if pg_is_in_recovery() == true
-        dcs_last_seen - timestamp from JSON of last succesful communication with DCS
-        timeline - timeline value from JSON
-        wal_position - maximum value of `replayed_location` or `received_location` from JSON
-        tags - dictionary with values of different tags (i.e. nofailover)
-        watchdog_failed - indicates that watchdog is required by configuration but not available or failed
+    Consists of the following fields:
+
+    :ivar member: :class:`Member` object of the node.
+    :ivar reachable: ``False`` if the node is not reachable or is not responding with correct JSON.
+    :ivar in_recovery: ``False`` if the node is running as a primary (`if pg_is_in_recovery() == true`).
+    :ivar wal_position: maximum value of ``replayed_location`` or ``received_location`` from JSON.
+    :ivar data: the whole JSON response for future usage.
     """
-    member: Member
-    reachable: bool
-    in_recovery: Optional[bool]
-    dcs_last_seen: int
-    timeline: int
-    wal_position: int
-    tags: Dict[str, Any]
-    watchdog_failed: bool
 
     @classmethod
     def from_api_response(cls, member: Member, json: Dict[str, Any]) -> '_MemberStatus':
@@ -57,21 +54,33 @@ class _MemberStatus(NamedTuple):
         wal: Dict[str, Any] = json.get('wal') or json['xlog']
         # abuse difference in primary/replica response format
         in_recovery = not (bool(wal.get('location')) or json.get('role') in ('master', 'primary'))
-        timeline = json.get('timeline', 0)
-        dcs_last_seen = json.get('dcs_last_seen', 0)
         lsn = int(in_recovery and max(wal.get('received_location', 0), wal.get('replayed_location', 0)))
-        return cls(member, True, in_recovery, dcs_last_seen, timeline, lsn,
-                   json.get('tags', {}), json.get('watchdog_failed', False))
+        return cls(member, True, in_recovery, lsn, json)
+
+    @property
+    def tags(self) -> Dict[str, Any]:
+        """Dictionary with values of different tags (i.e. nofailover)."""
+        return self.data.get('tags', {})
+
+    @property
+    def timeline(self) -> int:
+        """Timeline value from JSON."""
+        return self.data.get('timeline', 0)
+
+    @property
+    def watchdog_failed(self) -> bool:
+        """indicates that watchdog is required by configuration but not available or failed"""
+        return self.data.get('watchdog_failed', False)
 
     @classmethod
     def unknown(cls, member: Member) -> '_MemberStatus':
-        return cls(member, False, None, 0, 0, 0, {}, False)
+        return cls(member, False, None, 0, {})
 
     def failover_limitation(self) -> Optional[str]:
         """Returns reason why this node can't promote or None if everything is ok."""
         if not self.reachable:
             return 'not reachable'
-        if self.tags.get('nofailover', False):
+        if self.nofailover:
             return 'not allowed to promote'
         if self.watchdog_failed:
             return 'not watchdog capable'

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -69,7 +69,7 @@ class _MemberStatus(Tags, NamedTuple('_MemberStatus',
 
     @property
     def watchdog_failed(self) -> bool:
-        """indicates that watchdog is required by configuration but not available or failed"""
+        """indicates that watchdog is required by configuration but not available or failed."""
         return self.data.get('watchdog_failed', False)
 
     @classmethod

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -69,11 +69,12 @@ class _MemberStatus(Tags, NamedTuple('_MemberStatus',
 
     @property
     def watchdog_failed(self) -> bool:
-        """indicates that watchdog is required by configuration but not available or failed."""
+        """Indicates that watchdog is required by configuration but not available or failed."""
         return self.data.get('watchdog_failed', False)
 
     @classmethod
     def unknown(cls, member: Member) -> '_MemberStatus':
+        """Create a new class instance with empty or null values."""
         return cls(member, False, None, 0, {})
 
     def failover_limitation(self) -> Optional[str]:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -36,7 +36,7 @@ class _MemberStatus(Tags, NamedTuple('_MemberStatus',
 
     Consists of the following fields:
 
-    :ivar member: :class:`Member` object of the node.
+    :ivar member: :class:`~patroni.dcs.Member` object of the node.
     :ivar reachable: ``False`` if the node is not reachable or is not responding with correct JSON.
     :ivar in_recovery: ``False`` if the node is running as a primary (`if pg_is_in_recovery() == true`).
     :ivar wal_position: maximum value of ``replayed_location`` or ``received_location`` from JSON.

--- a/patroni/postgresql/sync.py
+++ b/patroni/postgresql/sync.py
@@ -209,7 +209,7 @@ class _ReplicaList(List[_Replica]):
             # 2. can be mapped to a ``Member`` of the ``Cluster``:
             #   a. ``Member`` doesn't have ``nosync`` tag set;
             #   b. PostgreSQL on the member is known to be running and accepting client connections.
-            if member and row[sort_col] is not None and member.is_running and not member.tags.get('nosync', False):
+            if member and row[sort_col] is not None and member.is_running and not member.nosync:
                 self.append(_Replica(row['pid'], row['application_name'],
                                      row['sync_state'], row[sort_col], bool(member.nofailover)))
 

--- a/patroni/tags.py
+++ b/patroni/tags.py
@@ -36,7 +36,7 @@ class Tags(abc.ABC):
 
     @property
     def clonefrom(self) -> bool:
-        """``True`` if ``clonefrom`` tag is ``True``."""
+        """``True`` if ``clonefrom`` tag is ``True``, else ``False``."""
         return self.tags.get('clonefrom', False)
 
     @property

--- a/patroni/tags.py
+++ b/patroni/tags.py
@@ -1,0 +1,60 @@
+"""Tags handling"""
+import abc
+
+from typing import Any, Dict, Optional
+
+
+class Tags(abc.ABC):
+    """An abstract class that encapsulates all the ``tags`` logic.
+
+    Child classes that want to use provided facilities must implement ``tags`` abstract property.
+    """
+
+    @staticmethod
+    def _filter_tags(tags: Dict[str, Any]) -> Dict[str, Any]:
+        """Get tags configured for this node, if any.
+
+        Handle both predefined Patroni tags and custom defined tags.
+
+        .. note::
+            A custom tag is any tag added to the configuration ``tags`` section that is not one of ``clonefrom``,
+            ``nofailover``, ``noloadbalance`` or ``nosync``.
+
+            For the Patroni predefined tags, the returning object will only contain them if they are enabled as they
+            all are boolean values that default to disabled.
+
+        :returns: a dictionary of tags set for this node. The key is the tag name, and the value is the corresponding
+            tag value.
+        """
+        return {tag: value for tag, value in tags.items()
+                if tag not in ('clonefrom', 'nofailover', 'noloadbalance', 'nosync') or value}
+
+    @property
+    @abc.abstractmethod
+    def tags(self) -> Dict[str, Any]:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def clonefrom(self) -> bool:
+        """``True`` if ``clonefrom`` tag is ``True``."""
+        return self.tags.get('clonefrom', False)
+
+    @property
+    def nofailover(self) -> bool:
+        """``True`` if ``nofailover`` is ``True``, else ``False``."""
+        return bool(self.tags.get('nofailover', False))
+
+    @property
+    def noloadbalance(self) -> bool:
+        """``True`` if ``noloadbalance`` is ``True``, else ``False``."""
+        return bool(self.tags.get('noloadbalance', False))
+
+    @property
+    def nosync(self) -> bool:
+        """``True`` if ``nosync`` is ``True``, else ``False``."""
+        return bool(self.tags.get('nosync', False))
+
+    @property
+    def replicatefrom(self) -> Optional[str]:
+        """Value of ``replicatefrom`` tag, if any."""
+        return self.tags.get('replicatefrom')

--- a/patroni/tags.py
+++ b/patroni/tags.py
@@ -1,4 +1,4 @@
-"""Tags handling"""
+"""Tags handling."""
 import abc
 
 from typing import Any, Dict, Optional
@@ -32,6 +32,10 @@ class Tags(abc.ABC):
     @property
     @abc.abstractmethod
     def tags(self) -> Dict[str, Any]:
+        """Configured tags.
+
+        Must be implemented in a child class.
+        """
         raise NotImplementedError  # pragma: no cover
 
     @property

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,7 +100,7 @@ class MockHa(object):
 
     @staticmethod
     def fetch_nodes_statuses(members):
-        return [_MemberStatus(None, True, None, 0, 0, None, {}, False)]
+        return [_MemberStatus(None, True, None, 0, {})]
 
     @staticmethod
     def schedule_future_restart(data):

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -185,7 +185,7 @@ class TestPatroni(unittest.TestCase):
 
     def test_reload_config(self):
         self.p.reload_config()
-        self.p.get_tags = Mock(side_effect=Exception)
+        self.p._get_tags = Mock(side_effect=Exception)
         self.p.reload_config(local=True)
 
     def test_nosync(self):


### PR DESCRIPTION
The same (almost) logic was used in three different places:
1. `Patroni` class
2. `Member` class
3. `_MemberStatus` class

Now they all inherit newly intoduced `Tags` class.