### PR TITLE
Pin sphinx_rtd_theme to >1

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,5 +1,5 @@
 sphinx>=4
-sphinx_rtd_theme
+sphinx_rtd_theme>1
 sphinxcontrib-apidoc
 sphinx-github-style
 pyyaml


### PR DESCRIPTION
readthedocs [installs](https://github.com/readthedocs/readthedocs.org/blob/2f4334dbb3950f8dc4f8720d6e3f5bcca2d92ce6/readthedocs/doc_builder/python_environments.py#L272-L282) pinned old versions for both `sphinx_rtd_theme` and `sphinx` if an undocumented [feature flag](https://docs.readthedocs.io/en/latest/feature-flags.html#feature-flags) is not enabled.
So, to overcome this and install `sphinx_rtd_theme`'s version compatible with the latest `sphinx`, let's pin them all in our requirements file
