### PR TITLE
Return system id to the ctl list title

### DIFF
--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1561,8 +1561,11 @@ def output_members(obj: Dict[str, Any], cluster: Cluster, name: str,
             rows.append([member.get(n.lower().replace(' ', '_'), '') for n in columns])
 
     title = 'Citus cluster' if is_citus_cluster else 'Cluster'
-    group_title = '' if group is None else 'group: {0}, '.format(group)
-    title = f' {title}: {name} ({group_title}{initialize}) '
+    title_details = f' ({initialize})'
+    if is_citus_cluster:
+        title_details = '' if group is None else f' (group: {group}, {initialize})'
+
+    title = f' {title}: {name}{title_details} '
     print_output(columns, rows, {'Group': 'r', 'Lag in MB': 'r', 'TL': 'r'}, fmt, title)
 
     if fmt not in ('pretty', 'topology'):  # Omit service info when using machine-readable formats

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1562,8 +1562,7 @@ def output_members(obj: Dict[str, Any], cluster: Cluster, name: str,
 
     title = 'Citus cluster' if is_citus_cluster else 'Cluster'
     group_title = '' if group is None else 'group: {0}, '.format(group)
-    title_details = group_title and ' ({0}{1})'.format(group_title, initialize)
-    title = ' {0}: {1}{2} '.format(title, name, title_details)
+    title = f' {title}: {name} ({group_title}{initialize}) '
     print_output(columns, rows, {'Group': 'r', 'Lag in MB': 'r', 'TL': 'r'}, fmt, title)
 
     if fmt not in ('pretty', 'topology'):  # Omit service info when using machine-readable formats

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -406,10 +406,14 @@ class TestCtl(unittest.TestCase):
         result = self.runner.invoke(ctl, ['list'])
         assert '127.0.0.1' in result.output
         assert result.exit_code == 0
-        assert 'Citus cluster: alpha (12345678901)' in result.output
+        assert 'Citus cluster: alpha -' in result.output
 
         result = self.runner.invoke(ctl, ['list', '--group', '0'])
-        assert 'Citus cluster: alpha (group: 0, 12345678901)' in result.output
+        assert 'Citus cluster: alpha (group: 0, 12345678901) -' in result.output
+
+        with patch('patroni.ctl.load_config', Mock(return_value={'scope': 'alpha'})):
+            result = self.runner.invoke(ctl, ['list'])
+            assert 'Cluster: alpha (12345678901) -' in result.output
 
         with patch('patroni.ctl.load_config', Mock(return_value={})):
             self.runner.invoke(ctl, ['list'])

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -402,9 +402,15 @@ class TestCtl(unittest.TestCase):
     @patch('patroni.ctl.get_dcs')
     def test_members(self, mock_get_dcs):
         mock_get_dcs.return_value.get_cluster = get_cluster_initialized_with_leader
+
         result = self.runner.invoke(ctl, ['list'])
         assert '127.0.0.1' in result.output
         assert result.exit_code == 0
+        assert 'Citus cluster: alpha (12345678901)' in result.output
+
+        result = self.runner.invoke(ctl, ['list', '--group', '0'])
+        assert 'Citus cluster: alpha (group: 0, 12345678901)' in result.output
+
         with patch('patroni.ctl.load_config', Mock(return_value={})):
             self.runner.invoke(ctl, ['list'])
 


### PR DESCRIPTION
Since https://github.com/zalando/patroni/commit/4872ac51e00abefc98678f1771dd93aead59f4ce `patronictl list` was only showing system id for a Citus cluster with the `--group` option specified

Close #2839 