### PR TITLE
Pin version of sphinx-github-style

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,5 +1,4 @@
 sphinx>=4
 sphinx_rtd_theme>1
 sphinxcontrib-apidoc
-sphinx-github-style
-pyyaml
+sphinx-github-style<1.0.3


### PR DESCRIPTION
1.0.3 removed support of `top_level` configuration parameter and builds now are failing.

Besides that remove redundant pyyaml from requirements.docs.txt