### PR TITLE
Debian docker image pip error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ nosetests.xml
 coverage.xml
 htmlcov
 junit.xml
-features/output
+features/output*
 dummy
 
 # Translations

--- a/features/Dockerfile
+++ b/features/Dockerfile
@@ -27,7 +27,8 @@ RUN set -ex \
     && apt-get update \
     && apt-get reinstall init-system-helpers \
     && apt-get install -y \
-      python3-full \
+      python3-dev \
+      python3-venv \
       rsync \
       curl \
       gcc \

--- a/features/Dockerfile
+++ b/features/Dockerfile
@@ -27,8 +27,7 @@ RUN set -ex \
     && apt-get update \
     && apt-get reinstall init-system-helpers \
     && apt-get install -y \
-      python3-pip \
-      python3-dev \
+      python3-full \
       rsync \
       curl \
       gcc \
@@ -40,7 +39,9 @@ RUN set -ex \
       net-tools \
       iputils-ping \
     && rm -rf /var/cache/apt \
-    && python3 -m pip install --no-cache-dir tox \
+    \
+    && python3 -m venv /tox \
+    && /tox/bin/pip install --no-cache-dir tox>=4 \
     \
     && mkdir -p "$PGHOME" \
     && sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
@@ -50,6 +51,7 @@ RUN set -ex \
     && curl -sL "$ETCDURL/etcd-v$ETCDVERSION-linux-$(dpkg --print-architecture).tar.gz" \
        | tar xz -C /usr/local/bin --strip=1 --wildcards --no-anchored etcd etcdctl
 
+ENV PATH="/tox/bin:$PATH"
 
 # This Dockerfile syntax only works with docker buildx and the syntax
 # line at the top of this file.


### PR DESCRIPTION
The current Dockerfile uses pip to install global packages which throws an error on latest base image of Debian.