### PR TITLE
Enforce loop_wait/retry_timeout/ttl rule

### DIFF
--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -8,9 +8,18 @@ Dynamic configuration is stored in the DCS (Distributed Configuration Store) and
 
 In order to change the dynamic configuration you can use either ``patronictl edit-config`` tool or Patroni :ref:`REST API <rest_api>`.
 
--  **loop\_wait**: the number of seconds the loop will sleep. Default value: 10
--  **ttl**: the TTL to acquire the leader lock (in seconds). Think of it as the length of time before initiation of the automatic failover process. Default value: 30
--  **retry\_timeout**: timeout for DCS and PostgreSQL operation retries (in seconds). DCS or network issues shorter than this will not cause Patroni to demote the leader. Default value: 10
+-  **loop\_wait**: the number of seconds the loop will sleep. Default value: 10, minimal possible value: 1
+-  **ttl**: the TTL to acquire the leader lock (in seconds). Think of it as the length of time before initiation of the automatic failover process. Default value: 30, minimal possible value: 20
+-  **retry\_timeout**: timeout for DCS and PostgreSQL operation retries (in seconds). DCS or network issues shorter than this will not cause Patroni to demote the leader. Default value: 10, minimal possible value: 3
+
+.. warning::
+    when changing values of **loop_wait**, **retry_timeout**, or **ttl** you have to follow the rule:
+
+    .. code-block:: python
+
+        loop_wait + 2 * retry_timeout <= ttl
+
+
 -  **maximum\_lag\_on\_failover**: the maximum bytes a follower may lag to be able to participate in leader election.
 -  **maximum\_lag\_on\_syncnode**: the maximum bytes a synchronous follower may lag before it is considered as an unhealthy candidate and swapped by healthy asynchronous follower. Patroni utilize the max replica lsn if there is more than one follower, otherwise it will use leader's current wal lsn. Default is -1, Patroni will not take action to swap synchronous unhealthy follower when the value is set to 0 or below. Please set the value high enough so Patroni won't swap synchrounous follower fequently during high transaction volume.
 -  **max\_timelines\_history**: maximum number of timeline history items kept in DCS.  Default value: 0. When set to 0, it keeps the full history in DCS.

--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -8,9 +8,9 @@ Dynamic configuration is stored in the DCS (Distributed Configuration Store) and
 
 In order to change the dynamic configuration you can use either ``patronictl edit-config`` tool or Patroni :ref:`REST API <rest_api>`.
 
--  **loop\_wait**: the number of seconds the loop will sleep. Default value: 10, minimal possible value: 1
--  **ttl**: the TTL to acquire the leader lock (in seconds). Think of it as the length of time before initiation of the automatic failover process. Default value: 30, minimal possible value: 20
--  **retry\_timeout**: timeout for DCS and PostgreSQL operation retries (in seconds). DCS or network issues shorter than this will not cause Patroni to demote the leader. Default value: 10, minimal possible value: 3
+-  **loop\_wait**: the number of seconds the loop will sleep. Default value: 10, minimum possible value: 1
+-  **ttl**: the TTL to acquire the leader lock (in seconds). Think of it as the length of time before initiation of the automatic failover process. Default value: 30, minimum possible value: 20
+-  **retry\_timeout**: timeout for DCS and PostgreSQL operation retries (in seconds). DCS or network issues shorter than this will not cause Patroni to demote the leader. Default value: 10, minimum possible value: 3
 
 .. warning::
     when changing values of **loop_wait**, **retry_timeout**, or **ttl** you have to follow the rule:

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -400,8 +400,8 @@ class Config(object):
                     except Exception:
                         logger.error('Can not remove temporary file %s', tmpfile)
 
-    def __get_and_maybe_adjust_value(self, config: Dict[str, Any], param: str, min_value: int) -> int:
-        """Get, validated and maybe adjust a *param* value from the *config* :class:`dict`.
+    def __get_and_maybe_adjust_int_value(self, config: Dict[str, Any], param: str, min_value: int) -> int:
+        """Get, validate and maybe adjust a *param* integer value from the *config* :class:`dict`.
 
         .. note:
             If the value is smaller than provided *min_value* we update the *config*.
@@ -445,9 +445,9 @@ class Config(object):
         """
 
         min_loop_wait = 1
-        loop_wait = self.__get_and_maybe_adjust_value(config, 'loop_wait', min_loop_wait)
-        retry_timeout = self.__get_and_maybe_adjust_value(config, 'retry_timeout', 3)
-        ttl = self.__get_and_maybe_adjust_value(config, 'ttl', 20)
+        loop_wait = self. __get_and_maybe_adjust_int_value(config, 'loop_wait', min_loop_wait)
+        retry_timeout = self. __get_and_maybe_adjust_int_value(config, 'retry_timeout', 3)
+        ttl = self. __get_and_maybe_adjust_int_value(config, 'ttl', 20)
 
         if min_loop_wait + 2 * retry_timeout > ttl:
             config['loop_wait'] = min_loop_wait

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -475,10 +475,9 @@ class Config(object):
             self._modify_version = configuration.modify_version
             configuration = configuration.data
 
-        self._validate_and_adjust_timeouts(configuration)
-
         if not deep_compare(self._dynamic_configuration, configuration):
             try:
+                self._validate_and_adjust_timeouts(configuration)
                 self.__effective_configuration = self._build_effective_configuration(configuration,
                                                                                      self._local_configuration)
                 self._dynamic_configuration = configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,3 +172,27 @@ class TestConfig(unittest.TestCase):
         input_params['max_connections'] = 10
         expected_params.pop('max_connections')
         self.assertEqual(self.config._process_postgresql_parameters(input_params), expected_params)
+
+    def test__validate_and_adjust_timeouts(self):
+        with patch('patroni.config.logger.warning') as mock_logger:
+            self.config._validate_and_adjust_timeouts({'ttl': 15})
+            self.assertEqual(mock_logger.call_args_list[0][0],
+                             ("ttl=%d can't be smaller than %d, adjusting...", 15, 20))
+        with patch('patroni.config.logger.warning') as mock_logger:
+            self.config._validate_and_adjust_timeouts({'loop_wait': 0})
+            self.assertEqual(mock_logger.call_args_list[0][0],
+                             ("loop_wait=%d can't be smaller than %d, adjusting...", 0, 1))
+        with patch('patroni.config.logger.warning') as mock_logger:
+            self.config._validate_and_adjust_timeouts({'retry_timeout': 1})
+            self.assertEqual(mock_logger.call_args_list[0][0],
+                             ("retry_timeout=%d can't be smaller than %d, adjusting...", 1, 3))
+        with patch('patroni.config.logger.warning') as mock_logger:
+            self.config._validate_and_adjust_timeouts({'ttl': 20, 'loop_wait': 11, 'retry_timeout': 5})
+            self.assertEqual(mock_logger.call_args_list[0][0],
+                             ('Violated the rule "loop_wait + 2*retry_timeout <= ttl", where ttl=%d '
+                              'and retry_timeout=%d. Adjusting loop_wait from %d to %d', 20, 5, 11, 10))
+        with patch('patroni.config.logger.warning') as mock_logger:
+            self.config._validate_and_adjust_timeouts({'ttl': 20, 'loop_wait': 10, 'retry_timeout': 10})
+            self.assertEqual(mock_logger.call_args_list[0][0],
+                             ('Violated the rule "loop_wait + 2*retry_timeout <= ttl", where ttl=%d. Adjusting'
+                              ' loop_wait from %d to %d and retry_timeout from %d to %d', 20, 10, 1, 10, 9))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,15 +177,15 @@ class TestConfig(unittest.TestCase):
         with patch('patroni.config.logger.warning') as mock_logger:
             self.config._validate_and_adjust_timeouts({'ttl': 15})
             self.assertEqual(mock_logger.call_args_list[0][0],
-                             ("ttl=%d can't be smaller than %d, adjusting...", 15, 20))
+                             ("%s=%d can't be smaller than %d, adjusting...", 'ttl', 15, 20))
         with patch('patroni.config.logger.warning') as mock_logger:
             self.config._validate_and_adjust_timeouts({'loop_wait': 0})
             self.assertEqual(mock_logger.call_args_list[0][0],
-                             ("loop_wait=%d can't be smaller than %d, adjusting...", 0, 1))
+                             ("%s=%d can't be smaller than %d, adjusting...", 'loop_wait', 0, 1))
         with patch('patroni.config.logger.warning') as mock_logger:
             self.config._validate_and_adjust_timeouts({'retry_timeout': 1})
             self.assertEqual(mock_logger.call_args_list[0][0],
-                             ("retry_timeout=%d can't be smaller than %d, adjusting...", 1, 3))
+                             ("%s=%d can't be smaller than %d, adjusting...", 'retry_timeout', 1, 3))
         with patch('patroni.config.logger.warning') as mock_logger:
             self.config._validate_and_adjust_timeouts({'ttl': 20, 'loop_wait': 11, 'retry_timeout': 5})
             self.assertEqual(mock_logger.call_args_list[0][0],


### PR DESCRIPTION
* hard-code minimal possible values
* make adjustments if values are lower or if the rule is violated and show warnings
* update documentation