### PR TITLE
Release v3.1.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - master
+    - 'REL_[0-9]+_[0-9]+'
 
 env:
   CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/docs/contributing_guidelines.rst
+++ b/docs/contributing_guidelines.rst
@@ -143,12 +143,12 @@ If you want to disable this facility set the env var `OPEN_CMD` to the `:` no-op
 Behave tests
 ^^^^^^^^^^^^
 
-Behave tests with `-m behave` will build docker images based on PG_MAJOR version 11 through 15 and then run all
+Behave tests with `-m behave` will build docker images based on PG_MAJOR version 11 through 16 and then run all
 behave tests. This can take quite a long time to run so you might want to limit the scope to a select version of
 Postgres or to a specific feature set or steps.
 
 To specify the version of postgres include the full name of the dependent image build env that you want and then the
-behave env name. For instance if you want Postgres 15 use:
+behave env name. For instance if you want Postgres 16 use:
 
 .. code-block:: bash
 

--- a/docs/contributing_guidelines.rst
+++ b/docs/contributing_guidelines.rst
@@ -148,7 +148,7 @@ behave tests. This can take quite a long time to run so you might want to limit 
 Postgres or to a specific feature set or steps.
 
 To specify the version of postgres include the full name of the dependent image build env that you want and then the
-behave env name. For instance if you want Postgres 16 use:
+behave env name. For instance if you want Postgres 14 use:
 
 .. code-block:: bash
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -28,6 +28,10 @@ Version 3.1.1
 
   Patroni can't create logical replication slots in the standby cluster, thus they should be ignored if they are defined in the global configuration.
 
+- Avoid showing docstring in ``patronictl --help`` output (Israel Barth Rubio)
+
+  The ``click`` module needs to get a special hint for that.
+
 - Fixed bug with ``kubernetes.standby_leader_label_value`` (Alexander Kukushkin)
 
   This feature effectively never worked.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -3,6 +3,60 @@
 Release notes
 =============
 
+Version 3.1.1
+-------------
+
+**Bugfixes**
+
+- Reset failsafe state when promote (ChenChangAo)
+
+  If switchover/failover happened shortly after failsafe mode was than the newly promoted primary demoted itself after failsafe condition stopped.
+
+- Silence useless warnings in ``patronictl`` (Alexander Kukushkin)
+
+  If ``patronictl`` uses the same patroni.yaml file as Patroni and can access ``PGDATA`` directory it might have showing annoying warning about incorrect values in the global configuration.
+
+- Explicitly enable synchronous mode (Alexander Kukushkin)
+
+  Synchronous mode effectively was never actived if there is no replicas streaming from the primary.
+
+- Fixed bug with validation ``0`` integer values (Israel Barth Rubio)
+
+  In most cases it didn't cause any issues, just warnings.
+
+- Don't return logical slots for standby cluster (Alexander Kukushkin)
+
+  Patroni can't create logical replication slots in the standby cluster and if they should be ignored if they are defined in the global configuration.
+
+- Fixed bug with ``kubernetes.standby_leader_label_value`` (Alexander Kukushkin)
+
+  This feature effectively never worked.
+
+- Returned cluster system identifier to the ``patronictl list`` output (Polina Bungina)
+
+  The problem was introduced while implementing support of Citus, where we need to hide the identifier because it is different for coordinator and all workers.
+
+- Override ``write_leader_optime`` method in Kubernetes implementation (Alexander Kukushkin)
+
+  The method is supposed to write shutdown LSN to the leader Endpoint/ConfigMap when there are no healthy replicas available to become the new primary.
+
+- Don't start stopped postgres in pause (Alexander Kukushkin)
+
+  Due to a race condition Patroni was falsely assuming that the standby should be restarted because some recovery parameters (``primary_conninfo`` or similar) were changed.
+
+- Fixed bug in ``patronictl query`` command (Israel Barth Rubio)
+
+  It didn't work when only ``-m`` argument was provided or when none of ``-r`` or ``-m`` were provided.
+
+- Properly treat integer parameters that are used in command line to start postgres (Polina Bungina)
+
+  If values are supplied as strings and not casted to integer it was resulting in incorrect calculation of ``max_prepared_transactions`` based on ``max_connections`` for Citus clusters.
+
+- Don't rely on ``pg_stat_wal_receiver`` when deciding on ``pg_rewind`` (Alexander Kukushkin)
+
+  It could happen that ``received_tli`` reported by ``pg_stat_wal_recevier`` is ahead of the actual replayed timeline, while the timeline reported by ``DENTIFY_SYSTEM`` via replication connection is always correct.
+
+
 Version 3.1.0
 -------------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -18,7 +18,7 @@ Version 3.1.1
 
 - Explicitly enable synchronous mode for a corner case (Alexander Kukushkin)
 
-  Synchronous mode effectively was never activated if there is no replicas streaming from the primary.
+  Synchronous mode effectively was never activated if there are no replicas streaming from the primary.
 
 - Fixed bug with ``0`` integer values validation (Israel Barth Rubio)
 
@@ -34,7 +34,7 @@ Version 3.1.1
 
 - Returned cluster system identifier to the ``patronictl list`` output (Polina Bungina)
 
-  The problem was introduced while implementing the support of Citus, where we need to hide the identifier because it is different for coordinator and all workers.
+  The problem was introduced while implementing the support for Citus, where we need to hide the identifier because it is different for coordinator and all workers.
 
 - Override ``write_leader_optime`` method in Kubernetes implementation (Alexander Kukushkin)
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,25 +8,25 @@ Version 3.1.1
 
 **Bugfixes**
 
-- Reset failsafe state when promote (ChenChangAo)
+- Reset failsafe state on promote (ChenChangAo)
 
-  If switchover/failover happened shortly after failsafe mode was than the newly promoted primary demoted itself after failsafe condition stopped.
+  If switchover/failover happened shortly after failsafe mode had been activated, the newly promoted primary was demoting itself after failsafe becomes inactive.
 
 - Silence useless warnings in ``patronictl`` (Alexander Kukushkin)
 
-  If ``patronictl`` uses the same patroni.yaml file as Patroni and can access ``PGDATA`` directory it might have showing annoying warning about incorrect values in the global configuration.
+  If ``patronictl`` uses the same patroni.yaml file as Patroni and can access ``PGDATA`` directory it might have been showing annoying warnings about incorrect values in the global configuration.
 
-- Explicitly enable synchronous mode (Alexander Kukushkin)
+- Explicitly enable synchronous mode for a corner case (Alexander Kukushkin)
 
-  Synchronous mode effectively was never actived if there is no replicas streaming from the primary.
+  Synchronous mode effectively was never activated if there is no replicas streaming from the primary.
 
-- Fixed bug with validation ``0`` integer values (Israel Barth Rubio)
+- Fixed bug with ``0`` integer values validation (Israel Barth Rubio)
 
-  In most cases it didn't cause any issues, just warnings.
+  In most cases, it didn't cause any issues, just warnings.
 
 - Don't return logical slots for standby cluster (Alexander Kukushkin)
 
-  Patroni can't create logical replication slots in the standby cluster and if they should be ignored if they are defined in the global configuration.
+  Patroni can't create logical replication slots in the standby cluster, thus they should be ignored if they are defined in the global configuration.
 
 - Fixed bug with ``kubernetes.standby_leader_label_value`` (Alexander Kukushkin)
 
@@ -34,7 +34,7 @@ Version 3.1.1
 
 - Returned cluster system identifier to the ``patronictl list`` output (Polina Bungina)
 
-  The problem was introduced while implementing support of Citus, where we need to hide the identifier because it is different for coordinator and all workers.
+  The problem was introduced while implementing the support of Citus, where we need to hide the identifier because it is different for coordinator and all workers.
 
 - Override ``write_leader_optime`` method in Kubernetes implementation (Alexander Kukushkin)
 
@@ -42,15 +42,15 @@ Version 3.1.1
 
 - Don't start stopped postgres in pause (Alexander Kukushkin)
 
-  Due to a race condition Patroni was falsely assuming that the standby should be restarted because some recovery parameters (``primary_conninfo`` or similar) were changed.
+  Due to a race condition, Patroni was falsely assuming that the standby should be restarted because some recovery parameters (``primary_conninfo`` or similar) were changed.
 
 - Fixed bug in ``patronictl query`` command (Israel Barth Rubio)
 
   It didn't work when only ``-m`` argument was provided or when none of ``-r`` or ``-m`` were provided.
 
-- Properly treat integer parameters that are used in command line to start postgres (Polina Bungina)
+- Properly treat integer parameters that are used in the command line to start postgres (Polina Bungina)
 
-  If values are supplied as strings and not casted to integer it was resulting in incorrect calculation of ``max_prepared_transactions`` based on ``max_connections`` for Citus clusters.
+  If values are supplied as strings and not casted to integer it was resulting in an incorrect calculation of ``max_prepared_transactions`` based on ``max_connections`` for Citus clusters.
 
 - Don't rely on ``pg_stat_wal_receiver`` when deciding on ``pg_rewind`` (Alexander Kukushkin)
 

--- a/patroni/version.py
+++ b/patroni/version.py
@@ -2,4 +2,4 @@
 
 :var __version__: the current Patroni version.
 """
-__version__ = '3.1.0'
+__version__ = '3.1.1'

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ postgres_matrix =
     pg13: PG_MAJOR = 13
     pg14: PG_MAJOR = 14
     pg15: PG_MAJOR = 15
+    pg16: PG_MAJOR = 16
 psycopg_deps =
     py{37,38,39,310,311}-{lin,win}: psycopg[binary]
     mac: psycopg2-binary
@@ -106,7 +107,7 @@ description = Reformat code with black
 deps = black
 commands = black {posargs:patroni tests}
 
-[testenv:pg{12,13,14,15}-docker-build]
+[testenv:pg{12,13,14,15,16}-docker-build]
 description = Build docker containers needed for testing
 labels =
     behave
@@ -124,7 +125,7 @@ commands =
         --file features/Dockerfile
 allowlist_externals = docker
 
-[testenv:pg{12,13,14,15}-docker-behave-{etcd}-{lin,mac}]
+[testenv:pg{12,13,14,15,16}-docker-behave-{etcd}-{lin,mac}]
 description = Run behaviour tests in patroni-dev docker container
 setenv =
     etcd: DCS=etcd
@@ -133,7 +134,7 @@ setenv =
 labels =
     behave
 depends =
-    pg{11,12,13,14,15}-docker-build
+    pg{11,12,13,14,15,16}-docker-build
 
 # There's a bug which affects calling multiple envs on the command line
 # This should be a valid command: tox -e 'py{36,37,38,39,310,311}-behave-{env:DCS}-lin'


### PR DESCRIPTION
* Bump version
* Update release notes
* Update contributing guidelines and tox.ini (include v16)
* Enable tests for `REL*` branches