### PR TITLE
Add a documentation page for `patronictl`

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -209,10 +209,10 @@ REST API
 CTL
 ---
 -  **PATRONICTL\_CONFIG\_FILE**: (optional) location of the configuration file.
--  **PATRONI\_CTL\_USERNAME**: (optional) Basic-auth username for accessing protected REST API endpoints. If not provided patronictl will use the value provided for REST API "username" parameter.
--  **PATRONI\_CTL\_PASSWORD**: (optional) Basic-auth password for accessing protected REST API endpoints. If not provided patronictl will use the value provided for REST API "password" parameter.
+-  **PATRONI\_CTL\_USERNAME**: (optional) Basic-auth username for accessing protected REST API endpoints. If not provided :ref:`patronictl` will use the value provided for REST API "username" parameter.
+-  **PATRONI\_CTL\_PASSWORD**: (optional) Basic-auth password for accessing protected REST API endpoints. If not provided :ref:`patronictl` will use the value provided for REST API "password" parameter.
 -  **PATRONI\_CTL\_INSECURE**: (optional) Allow connections to REST API without verifying SSL certs.
--  **PATRONI\_CTL\_CACERT**: (optional) Specifies the file with the CA_BUNDLE file or directory with certificates of trusted CAs to use while verifying REST API SSL certs. If not provided patronictl will use the value provided for REST API "cafile" parameter.
+-  **PATRONI\_CTL\_CACERT**: (optional) Specifies the file with the CA_BUNDLE file or directory with certificates of trusted CAs to use while verifying REST API SSL certs. If not provided :ref:`patronictl` will use the value provided for REST API "cafile" parameter.
 -  **PATRONI\_CTL\_CERTFILE**: (optional) Specifies the file with the client certificate in the PEM format.
 -  **PATRONI\_CTL\_KEYFILE**: (optional) Specifies the file with the client secret key in the PEM format.
 -  **PATRONI\_CTL\_KEYFILE\_PASSWORD**: (optional) Specifies a password for decrypting the client keyfile.

--- a/docs/citus.rst
+++ b/docs/citus.rst
@@ -57,7 +57,7 @@ clusters that are just logically groupped together using the
 PostgreSQL. Therefore in most cases it is not possible to manage them as a
 single entity.
 
-It results in two major differences in ``patronictl`` behaviour when
+It results in two major differences in :ref:`patronictl` behaviour when
 ``patroni.yaml`` has the ``citus`` section comparing with the usual:
 
 1. The ``list`` and the ``topology`` by default output all members of the Citus
@@ -65,12 +65,12 @@ It results in two major differences in ``patronictl`` behaviour when
    which Citus group they belong to.
 2. For all ``patronictl`` commands the new option is introduced, named
    ``--group``. For some commands the default value for the group might be
-   taken from the ``patroni.yaml``. For example, ``patronictl pause`` will
+   taken from the ``patroni.yaml``. For example, :ref:`patronictl_pause` will
    enable the maintenance mode by default for the ``group`` that is set in the
-   ``citus`` section, but for example for ``patronictl  switchover`` or
-   ``patronictl remove`` the group must be explicitly specified.
+   ``citus`` section, but for example for :ref:`patronictl_switchover` or
+   :ref:`patronictl_remove` the group must be explicitly specified.
 
-An example of ``patronictl list`` output for the Citus cluster::
+An example of :ref:`patronictl_list` output for the Citus cluster::
 
     postgres@coord1:~$ patronictl list demo
     + Citus cluster: demo ----------+--------------+---------+----+-----------+
@@ -115,7 +115,7 @@ the coordinator for the shards hosted on a worker node. The switchover then
 happens while the traffic is kept on the coordinator, and resumes as soon as a
 new primary worker node is ready to accept read-write queries.
 
-An example of ``patronictl switchover`` on the worker cluster::
+An example of :ref:`patronictl_switchover` on the worker cluster::
 
     postgres@coord1:~$ patronictl switchover demo
     + Citus cluster: demo ----------+--------------+---------+----+-----------+
@@ -343,7 +343,7 @@ Citus upgrades and PostgreSQL major upgrades
 
 First, please read about upgrading Citus version in the `documentation`__.
 There is one minor change in the process. When executing upgrade, you have to
-use ``patronictl restart`` instead of ``systemctl restart`` to restart
+use :ref:`patronictl_restart` instead of ``systemctl restart`` to restart
 PostgreSQL.
 
 __ https://docs.citusdata.com/en/latest/admin_guide/upgrading_citus.html

--- a/docs/dcs_failsafe_mode.rst
+++ b/docs/dcs_failsafe_mode.rst
@@ -60,4 +60,4 @@ F.A.Q.
 
 - How to enable the Failsafe Mode?
 
-  Before enabling the ``failsafe_mode`` please make sure that Patroni version on all members is up-to-date. After that, you can use either the ``PATCH /config`` :ref:`REST API <rest_api>` or ``patronictl edit-config -s failsafe_mode=true``
+  Before enabling the ``failsafe_mode`` please make sure that Patroni version on all members is up-to-date. After that, you can use either the ``PATCH /config`` :ref:`REST API <rest_api>` or :ref:`patronictl edit-config -s failsafe_mode=true <patronictl_edit_config_parameters>`

--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -6,7 +6,7 @@ Dynamic Configuration Settings
 
 Dynamic configuration is stored in the DCS (Distributed Configuration Store) and applied on all cluster nodes.
 
-In order to change the dynamic configuration you can use either ``patronictl edit-config`` tool or Patroni :ref:`REST API <rest_api>`.
+In order to change the dynamic configuration you can use either :ref:`patronictl_edit_config` tool or Patroni :ref:`REST API <rest_api>`.
 
 -  **loop\_wait**: the number of seconds the loop will sleep. Default value: 10
 -  **ttl**: the TTL to acquire the leader lock (in seconds). Think of it as the length of time before initiation of the automatic failover process. Default value: 30

--- a/docs/existing_data.rst
+++ b/docs/existing_data.rst
@@ -42,12 +42,12 @@ You can find below an overview of steps for converting an existing Postgres clus
 
    #. Start Patroni using the ``patroni`` systemd service unit. It automatically detects that Postgres is already running and starts monitoring the instance.
 
-#. Hand over Postgres "start up procedure" to Patroni. In order to do that you need to restart the cluster members through ``patronictl restart cluster-name member-name`` command. For minimal downtime you might want to split this step into:
+#. Hand over Postgres "start up procedure" to Patroni. In order to do that you need to restart the cluster members through :ref:`patronictl restart cluster-name member-name <patronictl_restart_parameters>` command. For minimal downtime you might want to split this step into:
 
    #. Immediate restart of the standby nodes.
    #. Scheduled restart of the primary node within a maintenance window.
 
-#. If you configured permanent slots in step ``1.2.``, then you should remove them from ``slots`` configuration through ``patronictl edit-config cluster-name member-name`` command once the ``restart_lsn`` of the slots created by Patroni is able to catch up with the ``restart_lsn`` of the original slots for the corresponding members. By removing the slots from ``slots`` configuration you will allow Patroni to drop the original slots from your cluster once they are not needed anymore. You can find below an example query to check the ``restart_lsn`` of a couple slots, so you can compare them:
+#. If you configured permanent slots in step ``1.2.``, then you should remove them from ``slots`` configuration through :ref:`patronictl edit-config cluster-name member-name <patronictl_edit_config_parameters>` command once the ``restart_lsn`` of the slots created by Patroni is able to catch up with the ``restart_lsn`` of the original slots for the corresponding members. By removing the slots from ``slots`` configuration you will allow Patroni to drop the original slots from your cluster once they are not needed anymore. You can find below an example query to check the ``restart_lsn`` of a couple slots, so you can compare them:
 
    .. code-block:: sql
 
@@ -73,7 +73,7 @@ The only possible way to do a major upgrade currently is:
 #. Stop Patroni
 #. Upgrade PostgreSQL binaries and perform `pg_upgrade <https://www.postgresql.org/docs/current/pgupgrade.html>`_ on the primary node
 #. Update patroni.yml
-#. Remove the initialize key from DCS or wipe complete cluster state from DCS. The second one could be achieved by running ``patronictl remove <cluster-name>``. It is necessary because pg_upgrade runs initdb which actually creates a new database with a new PostgreSQL system identifier.
+#. Remove the initialize key from DCS or wipe complete cluster state from DCS. The second one could be achieved by running :ref:`patronictl remove cluster-name <patronictl_remove_parameters>` . It is necessary because pg_upgrade runs initdb which actually creates a new database with a new PostgreSQL system identifier.
 #. If you wiped the cluster state in the previous step, you may wish to copy patroni.dynamic.json from old data dir to the new one.  It will help you to retain some PostgreSQL parameters you had set before.
 #. Start Patroni on the primary node.
 #. Upgrade PostgreSQL binaries, update patroni.yml and wipe the data_dir on standby nodes.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Currently supported PostgreSQL versions: 9.3 to 16.
    installation
    patroni_configuration
    rest_api
+   patronictl
    replica_bootstrap
    replication_modes
    watchdog

--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -15,7 +15,7 @@ There are 3 types of Patroni configuration:
 
 - Global :ref:`dynamic configuration <dynamic_configuration>`.
 	These options are stored in the DCS (Distributed Configuration Store) and applied on all cluster nodes.
-	Dynamic configuration can be set at any time using ``patronictl edit-config`` tool or Patroni :ref:`REST API <rest_api>`.
+	Dynamic configuration can be set at any time using :ref:`patronictl_edit_config` tool or Patroni :ref:`REST API <rest_api>`.
 	If the options changed are not part of the startup configuration, they are applied asynchronously (upon the next wake up cycle)
 	to every node, which gets subsequently reloaded.
 	If the node requires a restart to apply the configuration (for `PostgreSQL parameters <https://www.postgresql.org/docs/current/view-pg-settings.html>`__ with context postmaster, if their values
@@ -24,7 +24,7 @@ There are 3 types of Patroni configuration:
 
 - Local :ref:`configuration file <yaml_configuration>` (patroni.yml).
 	These options are defined in the configuration file and take precedence over dynamic configuration.
-	``patroni.yml`` can be changed and reloaded at runtime (without restart of Patroni) by sending SIGHUP to the Patroni process, performing ``POST /reload`` REST-API request or executing ``patronictl reload``. Local configuration can be either a single YAML file or a directory. When it is a directory, all YAML files in that directory are loaded one by one in sorted order. In case a key is defined in multiple files, the occurrence in the last file takes precedence.
+	``patroni.yml`` can be changed and reloaded at runtime (without restart of Patroni) by sending SIGHUP to the Patroni process, performing ``POST /reload`` REST-API request or executing :ref:`patronictl_reload`. Local configuration can be either a single YAML file or a directory. When it is a directory, all YAML files in that directory are loaded one by one in sorted order. In case a key is defined in multiple files, the occurrence in the last file takes precedence.
 
 - :ref:`Environment configuration <environment>`.
 	It is possible to set/override some of the "Local" configuration parameters with environment variables.
@@ -105,10 +105,10 @@ Changing these parameters require a PostgreSQL restart to take effect, and their
 
 As explained before, Patroni restrict changing their values through :ref:`dynamic configuration <dynamic_configuration>`, which usually consists of:
 
-1. Applying changes through ``patronictl edit-config`` (or via REST API ``/config`` endpoint)
-2. Restarting nodes through ``patronictl restart`` (or via REST API ``/restart`` endpoint)
+1. Applying changes through :ref:`patronictl_edit_config` (or via REST API ``/config`` endpoint)
+2. Restarting nodes through :ref:`patronictl_restart` (or via REST API ``/restart`` endpoint)
 
-**Note:** please keep in mind that you should perform a restart of the PostgreSQL nodes through ``patronictl restart`` command, or via REST API ``/restart`` endpoint. An attempt to restart PostgreSQL by restarting the Patroni daemon, e.g. by executing ``systemctl restart patroni``, can cause a failover to occur in the cluster, if you are restarting the primary node.
+**Note:** please keep in mind that you should perform a restart of the PostgreSQL nodes through :ref:`patronictl_restart` command, or via REST API ``/restart`` endpoint. An attempt to restart PostgreSQL by restarting the Patroni daemon, e.g. by executing ``systemctl restart patroni``, can cause a failover to occur in the cluster, if you are restarting the primary node.
 
 However, as those settings manage shared memory, some extra care should be taken when restarting the nodes:
 

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -18,7 +18,7 @@ Configuration
 
 Those configuration options can come either from environment variables or from a configuration file. Look for the above sections in :ref:`Environment Configuration Settings <environment>` or :ref:`YAML Configuration Settings <yaml_configuration>` to understand how you can set the options for them through environment variables or through a configuration file.
 
-If you opt for using environment variables, it's a straight forward approach. Patroni will read the environment variables and use their values.
+If you opt for using environment variables, it's a straight forward approach. Patronictl will read the environment variables and use their values.
 
 If you opt for using a configuration file, you have different ways to inform ``patronictl`` about the file to be used. By default ``patronictl`` will attempt to load a configuration file named ``patronictl.yaml``, which is expected to be found under either of these paths, according to your system:
 
@@ -129,7 +129,6 @@ Parameters
     - ``replica``: a replica of a Patroni cluster; or
     - ``standby``: same as ``replica``; or
     - ``any``: any role. Same as omitting this parameter; or
-    - ``master``: same as ``primary``.
 
 ``-m`` / ``--member``
     Choose a member of the cluster with the given name.
@@ -148,9 +147,9 @@ Examples
 
 Get DSN of the primary node:
 
-.. code:: text
+.. code:: bash
 
-    patronictl -c postgres0.yml dsn batman -r primary
+    $ patronictl -c postgres0.yml dsn batman -r primary
     host=127.0.0.1 port=5432
 
 Get DSN of the node named ``postgresql1``:
@@ -203,6 +202,8 @@ Parameters
 
 ``--group``
     Change dynamic configuration of the given Citus group.
+    
+    If not given, ``patronictl`` will attempt to fetch that from the ``citus.group`` configuration, if it exists.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
 
@@ -249,7 +250,7 @@ Examples
 
 Change ``max_connections`` Postgres GUC:
 
-.. code:: text
+.. code:: diff
 
     patronictl -c postgres0.yml edit-config batman --pg max_connections="150" --force
     ---
@@ -335,6 +336,7 @@ It is designed to be used when the cluster is not healthy, e.g.:
 - There is no leader; or
 - There is no synchronous standby available in a synchronous cluster.
 
+It also allows to fail over to asynchronous node is synchronous mode is enabled.
 .. note::
     Nothing prevents you from running ``patronictl failover`` in a healthy cluster. However, we recommend using ``patronictl switchover`` in those cases.
 
@@ -572,6 +574,8 @@ Parameters
     Show history of events from the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
+    
+    If not given, ``patronictl`` will attempt to fetch that from the ``citus.group`` configuration, if it exists.
 
 ``-f`` / ``--format``
     How to format the list of events in the output.
@@ -910,6 +914,8 @@ Parameters
     Pause the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
+    
+    If not given, ``patronictl`` will attempt to fetch that from the ``citus.group`` configuration, if it exists.
 
 ``--wait``
     Wait until all Patroni members are paused before returning control to the caller.
@@ -1526,6 +1532,8 @@ Parameters
     Resume the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
+    
+    If not given, ``patronictl`` will attempt to fetch that from the ``citus.group`` configuration, if it exists.
 
 ``--wait``
     Wait until all Patroni members are unpaused before returning control to the caller.
@@ -1580,6 +1588,8 @@ Parameters
     Show dynamic configuration of the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
+    
+    If not given, ``patronictl`` will attempt to fetch that from the ``citus.group`` configuration, if it exists.
 
 .. _patronictl_show_config_examples:
 

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -5,6 +5,8 @@ Patronictl
 
 Patroni has a command-line interface named ``patronictl``, which is used basically to interact with Patroni's REST API and with the DCS. It is intended to make it easier to perform operations in the cluster, and can easily be used by humans or scripts.
 
+.. _patronictl_configuration:
+
 Configuration
 -------------
 
@@ -34,6 +36,8 @@ You can override that behavior either by:
 
 .. note::
     If you are running ``patronictl`` in the same host as ``patroni`` daemon is running, you may just use the same configuration file if it contains all the configuration sections required by ``patronictl``.
+
+.. _patronictl_usage:
 
 Usage
 -----
@@ -78,8 +82,12 @@ This is the synopsis for running a command from the ``patronictl``:
 
 In the following sub-sections you can find a description of each command implemented by ``patronictl``. For sake of example, we will use the configuration files present in the GitHub repository of Patroni (files ``postgres0.yml``, ``postgres1.yml`` and ``postgres2.yml``).
 
+.. _patronictl_dsn:
+
 patronictl dsn
 ^^^^^^^^^^^^^^
+
+.. _patronictl_dsn_synopsis:
 
 Synopsis
 """"""""
@@ -91,12 +99,16 @@ Synopsis
       [ { { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } | { -m | --member } MEMBER_NAME } ]
       [ --group CITUS_GROUP ]
 
+.. _patronictl_dsn_description:
+
 Description
 """""""""""
 
 ``patronictl dsn`` gets the connection string for one member of the Patroni cluster.
 
 If multiple members match the parameters of this command, one of them will be chosen, prioritizing the primary node.
+
+.. _patronictl_dsn_parameters:
 
 Parameters
 """"""""""
@@ -129,6 +141,8 @@ Parameters
 
     ``CITUS_GROUP`` is the ID of the Citus group.
 
+.. _patronictl_dsn_examples:
+
 Examples
 """"""""
 
@@ -146,8 +160,12 @@ Get DSN of the node named ``postgresql1``:
     patronictl -c postgres0.yml dsn batman --member postgresql1
     host=127.0.0.1 port=5433
 
+.. _patronictl_edit_config:
+
 patronictl edit-config
 ^^^^^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_edit_config_synopsis:
 
 Synopsis
 """"""""
@@ -163,6 +181,8 @@ Synopsis
       [ { --apply | --replace } CONFIG_FILE ]
       [ --force ]
 
+.. _patronictl_edit_config_description:
+
 Description
 """""""""""
 
@@ -170,6 +190,8 @@ Description
 
 .. note::
     When invoked through a TTY the command attempts to show a diff of the dynamic configuration through a pager. By default, it attempts to use either ``less`` or ``more``. If you want a different pager, set the ``PAGER`` environment variable with the desired one.
+
+.. _patronictl_edit_config_parameters:
 
 Parameters
 """"""""""
@@ -219,6 +241,8 @@ Parameters
     Flag to skip confirmation prompts when changing the dynamic configuration.
 
     Useful for scripts.
+
+.. _patronictl_edit_config_examples:
 
 Examples
 """"""""
@@ -280,8 +304,12 @@ Remove ``maximum_lag_on_failover`` setting from dynamic configuration:
 
     Configuration changed
 
+.. _patronictl_failover:
+
 patronictl failover
 ^^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_failover_synopsis:
 
 Synopsis
 """"""""
@@ -294,6 +322,8 @@ Synopsis
       [ { --leader | --primary | --master } LEADER_NAME ]
       --candidate CANDIDATE_NAME
       [ --force ]
+
+.. _patronictl_failover_description:
 
 Description
 """""""""""
@@ -310,6 +340,8 @@ It is designed to be used when the cluster is not healthy, e.g.:
 
 .. warning::
     Triggering a failover can cause data loss depending on how up-to-date the promoted replica is in comparison to the primary.
+
+.. _patronictl_failover_parameters:
 
 Parameters
 """"""""""
@@ -341,6 +373,8 @@ Parameters
 
     Useful for scripts.
 
+.. _patronictl_failover_examples:
+
 Examples
 """"""""
 
@@ -366,9 +400,12 @@ Fail over to node ``postgresql2``:
     | postgresql2 | 127.0.0.1:5434 | Leader  | running |  3 |           |
     +-------------+----------------+---------+---------+----+-----------+
 
+.. _patronictl_flush:
 
 patronictl flush
 ^^^^^^^^^^^^^^^^
+
+.. _patronictl_flush_synopsis:
 
 Synopsis
 """"""""
@@ -383,10 +420,14 @@ Synopsis
       [ { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } ]
       [ --force ]
 
+.. _patronictl_flush_description:
+
 Description
 """""""""""
 
 ``patronictl flush`` discards scheduled events, if any.
+
+.. _patronictl_flush_parameters:
 
 Parameters
 """"""""""
@@ -434,6 +475,8 @@ Parameters
 
     Useful for scripts.
 
+.. _patronictl_flush_examples:
+
 Examples
 """"""""
 
@@ -474,8 +517,12 @@ Discard scheduled restart of nodes ``postgresql0`` and ``postgresql1``:
     Success: flush scheduled restart for member postgresql0
     Success: flush scheduled restart for member postgresql1
 
+.. _patronictl_history:
+
 patronictl history
 ^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_flush_synopsis:
 
 Synopsis
 """"""""
@@ -486,6 +533,8 @@ Synopsis
       [ CLUSTER_NAME ]
       [ --group CITUS_GROUP ]
       [ { -f | --format } { pretty | tsv | json | yaml } ]
+
+.. _patronictl_flush_description:
 
 Description
 """""""""""
@@ -508,6 +557,8 @@ The following information is included in the output:
 
 ``New Leader``
     Patroni member that has been promoted during the event.
+
+.. _patronictl_flush_parameters:
 
 Parameters
 """"""""""
@@ -538,6 +589,8 @@ Parameters
     Flag to skip confirmation prompts when performing the flush.
 
     Useful for scripts.
+
+.. _patronictl_flush_examples:
 
 Examples
 """"""""
@@ -582,8 +635,12 @@ Show the history of events in YAML format:
       TL: 4
       Timestamp: '2023-09-12T11:53:09.620136+00:00'
 
+.. _patronictl_list:
+
 patronictl list
 ^^^^^^^^^^^^^^^
+
+.. _patronictl_list_synopsis:
 
 Synopsis
 """"""""
@@ -597,6 +654,8 @@ Synopsis
       [ { -t | --timestamp } ]
       [ { -f | --format } { pretty | tsv | json | yaml } ]
       [ { -W | { -w | --watch } TIME } ]
+
+.. _patronictl_list_description:
 
 Description
 """""""""""
@@ -709,6 +768,8 @@ Besides that, the following information may be included in the output:
 
         Only shown if the cluster is paused, and output format is ``pretty``.
 
+.. _patronictl_list_parameters:
+
 Parameters
 """"""""""
 
@@ -752,6 +813,8 @@ Parameters
     Automatically refresh information at the specified interval.
 
     ``TIME`` is the interval between refreshes, in seconds.
+
+.. _patronictl_list_examples:
 
 Examples
 """"""""
@@ -809,8 +872,12 @@ Show information about the cluster in YAML format, with timestamp of execution:
       State: streaming
       TL: 5
 
+.. _patronictl_pause:
+
 patronictl pause
 ^^^^^^^^^^^^^^^^
+
+.. _patronictl_pause_synopsis:
 
 Synopsis
 """"""""
@@ -822,10 +889,14 @@ Synopsis
       [ --group CITUS_GROUP ]
       [ --wait ]
 
+.. _patronictl_pause_description:
+
 Description
 """""""""""
 
 ``patronictl pause`` temporarily puts the Patroni cluster in maintenance mode and disables automatic failover.
+
+.. _patronictl_pause_parameters:
 
 Parameters
 """"""""""
@@ -843,6 +914,8 @@ Parameters
 ``--wait``
     Wait until all Patroni members are paused before returning control to the caller.
 
+.. _patronictl_pause_examples:
+
 Examples
 """"""""
 
@@ -854,8 +927,12 @@ Put the cluster in maintenance mode, and wait until all nodes have been paused:
     'pause' request sent, waiting until it is recognized by all nodes
     Success: cluster management is paused
 
+.. _patronictl_query:
+
 patronictl query
 ^^^^^^^^^^^^^^^^
+
+.. _patronictl_query_synopsis:
 
 Synopsis
 """"""""
@@ -874,10 +951,14 @@ Synopsis
       [ --delimiter ]
       [ { -W | { -w | --watch } TIME } ]
 
+.. _patronictl_query_description:
+
 Description
 """""""""""
 
 ``patronictl query`` executes a SQL command or script against a member of the Patroni cluster.
+
+.. _patronictl_query_parameters:
 
 Parameters
 """"""""""
@@ -958,6 +1039,8 @@ Parameters
 
     ``TIME`` is the interval between re-runs, in seconds.
 
+.. _patronictl_query_examples:
+
 Examples
 """"""""
 
@@ -1023,8 +1106,12 @@ Run a SQL command on any of the standbys:
     port
     5433
 
+.. _patronictl_reinit:
+
 patronictl reinit
 ^^^^^^^^^^^^^^^^^
+
+.. _patronictl_reinit_synopsis:
 
 Synopsis
 """"""""
@@ -1038,10 +1125,14 @@ Synopsis
       [ --wait ]
       [ --force ]
 
+.. _patronictl_reinit_description:
+
 Description
 """""""""""
 
 ``patronictl reinit`` rebuilds a Postgres standby instance managed by a replica member of the Patroni cluster.
+
+.. _patronictl_reinit_parameters:
 
 Parameters
 """"""""""
@@ -1066,6 +1157,8 @@ Parameters
     Flag to skip confirmation prompts when rebuilding Postgres standby instances.
 
     Useful for scripts.
+
+.. _patronictl_reinit_examples:
 
 Examples
 """"""""
@@ -1101,8 +1194,12 @@ Request a rebuild of ``postgresql2`` and wait for it to complete:
     Waiting for reinitialize to complete on: postgresql2
     Reinitialize is completed on: postgresql2
 
+.. _patronictl_reload:
+
 patronictl reload
 ^^^^^^^^^^^^^^^^^
+
+.. _patronictl_reload_synopsis:
 
 Synopsis
 """"""""
@@ -1116,10 +1213,14 @@ Synopsis
       [ { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } ]
       [ --force ]
 
+.. _patronictl_reload_description:
+
 Description
 """""""""""
 
 ``patronictl reload`` requests a reload of local configuration for one or more Patroni members.
+
+.. _patronictl_reload_parameters:
 
 Parameters
 """"""""""
@@ -1155,6 +1256,8 @@ Parameters
 
     Useful for scripts.
 
+.. _patronictl_reload_examples:
+
 Examples
 """"""""
 
@@ -1174,8 +1277,12 @@ Request a reload of the local configuration of all members of the Patroni cluste
     Reload request received for member postgresql1 and will be processed within 10 seconds
     Reload request received for member postgresql2 and will be processed within 10 seconds
 
+.. _patronictl_remove:
+
 patronictl remove
 ^^^^^^^^^^^^^^^^^
+
+.. _patronictl_remove_synopsis:
 
 Synopsis
 """"""""
@@ -1187,6 +1294,8 @@ Synopsis
       [ --group CITUS_GROUP ]
       [ { -f | --format } { pretty | tsv | json | yaml } ]
 
+.. _patronictl_remove_description:
+
 Description
 """""""""""
 
@@ -1196,6 +1305,8 @@ It is an interactive action.
 
 .. warning::
     This operation will destroy the information of the Patroni cluster from the DCS.
+
+.. _patronictl_remove_parameters:
 
 Parameters
 """"""""""
@@ -1220,6 +1331,8 @@ Parameters
 
     The default is ``pretty``.
 
+.. _patronictl_remove_examples:
+
 Examples
 """"""""
 
@@ -1239,8 +1352,12 @@ Remove information about Patroni cluster ``batman`` from the DCS:
     You are about to remove all information in DCS for batman, please type: "Yes I am aware": Yes I am aware
     This cluster currently is healthy. Please specify the leader name to continue: postgresql0
 
+.. _patronictl_restart:
+
 patronictl restart
 ^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_restart_synopsis:
 
 Synopsis
 """"""""
@@ -1259,12 +1376,16 @@ Synopsis
       [ --scheduled TIMESTAMP ]
       [ --force ]
 
+.. _patronictl_restart_description:
+
 Description
 """""""""""
 
 ``patronictl restart`` requests a restart of the Postgres instance managed by a member of the Patroni cluster.
 
 The restart can be performed immediately or scheduled for later.
+
+.. _patronictl_restart_parameters:
 
 Parameters
 """"""""""
@@ -1316,6 +1437,8 @@ Parameters
 
     Useful for scripts.
 
+.. _patronictl_restart_examples:
+
 Examples
 """"""""
 
@@ -1365,8 +1488,12 @@ Schedule a restart to occur at ``2023-09-13T18:00-03:00``:
     Success: restart scheduled on member postgresql1
     Success: restart scheduled on member postgresql2
 
+.. _patronictl_resume:
+
 patronictl resume
 ^^^^^^^^^^^^^^^^^
+
+.. _patronictl_resume_synopsis:
 
 Synopsis
 """"""""
@@ -1378,10 +1505,14 @@ Synopsis
       [ --group CITUS_GROUP ]
       [ --wait ]
 
+.. _patronictl_resume_description:
+
 Description
 """""""""""
 
 ``patronictl resume`` takes the Patroni cluster out of maintenance mode and re-enables automatic failover.
+
+.. _patronictl_resume_parameters:
 
 Parameters
 """"""""""
@@ -1399,6 +1530,8 @@ Parameters
 ``--wait``
     Wait until all Patroni members are unpaused before returning control to the caller.
 
+.. _patronictl_resume_examples:
+
 Examples
 """"""""
 
@@ -1410,8 +1543,12 @@ Put the cluster out of maintenance mode:
     'resume' request sent, waiting until it is recognized by all nodes
     Success: cluster management is resumed
 
+.. _patronictl_show_config:
+
 patronictl show-config
 ^^^^^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_show_config_synopsis:
 
 Synopsis
 """"""""
@@ -1422,10 +1559,14 @@ Synopsis
       [ CLUSTER_NAME ]
       [ --group CITUS_GROUP ]
 
+.. _patronictl_show_config_description:
+
 Description
 """""""""""
 
 ``patronictl show-config`` shows the dynamic configuration of the cluster that is stored in the DCS.
+
+.. _patronictl_show_config_parameters:
 
 Parameters
 """"""""""
@@ -1439,6 +1580,8 @@ Parameters
     Show dynamic configuration of the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
+
+.. _patronictl_show_config_examples:
 
 Examples
 """"""""
@@ -1459,8 +1602,12 @@ Show dynamic configuration of cluster ``batman``:
     retry_timeout: 10
     ttl: 30
 
+.. _patronictl_switchover:
+
 patronictl switchover
 ^^^^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_switchover_synopsis:
 
 Synopsis
 """"""""
@@ -1474,6 +1621,8 @@ Synopsis
       --candidate CANDIDATE_NAME
       [ --force ]
 
+.. _patronictl_switchover_description:
+
 Description
 """""""""""
 
@@ -1486,6 +1635,8 @@ It is designed to be used when the cluster is healthy, e.g.:
 
 .. note::
     If your cluster is unhealthy you might be interested in ``patronictl failover`` instead.
+
+.. _patronictl_switchover_parameters:
 
 Parameters
 """"""""""
@@ -1519,6 +1670,8 @@ Parameters
     Flag to skip confirmation prompts when performing the switchover.
 
     Useful for scripts.
+
+.. _patronictl_switchover_examples:
 
 Examples
 """"""""
@@ -1570,8 +1723,12 @@ Schedule a switchover between ``postgresql0`` and ``postgresql2`` to occur at ``
                         from: postgresql0
                         to: postgresql2
 
+.. _patronictl_topology:
+
 patronictl topology
 ^^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_topology_synopsis:
 
 Synopsis
 """"""""
@@ -1582,6 +1739,8 @@ Synopsis
       [ CLUSTER_NAME [, ... ] ]
       [ --group CITUS_GROUP ]
       [ { -W | { -w | --watch } TIME } ]
+
+.. _patronictl_topology_description:
 
 Description
 """""""""""
@@ -1689,6 +1848,8 @@ Besides that, the following information may be included in the output:
 
         Only shown if the cluster is paused.
 
+.. _patronictl_topology_parameters:
+
 Parameters
 """"""""""
 
@@ -1710,6 +1871,8 @@ Parameters
 
     ``TIME`` is the interval between refreshes, in seconds.
 
+.. _patronictl_topology_examples:
+
 Examples
 """"""""
 
@@ -1726,8 +1889,12 @@ Show topology of the cluster ``batman`` -- ``postgresql1`` and ``postgresql2`` a
     | + postgresql2 | 127.0.0.1:5434 | Replica | streaming |  8 |         0 |
     +---------------+----------------+---------+-----------+----+-----------+
 
+.. _patronictl_version:
+
 patronictl version
 ^^^^^^^^^^^^^^^^^^
+
+.. _patronictl_version_synopsis:
 
 Synopsis
 """"""""
@@ -1739,10 +1906,14 @@ Synopsis
       [ MEMBER_NAME [, ... ] ]
       [ --group CITUS_GROUP ]
 
+.. _patronictl_version_description:
+
 Description
 """""""""""
 
 ``patronictl version`` gets the version of ``patronictl`` application. Besides that it may also include version information about Patroni clusters and their members.
+
+.. _patronictl_version_parameters:
 
 Parameters
 """"""""""
@@ -1757,6 +1928,8 @@ Parameters
     Consider a Patroni cluster with the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
+
+.. _patronictl_version_examples:
 
 Examples
 """"""""

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -20,12 +20,12 @@ If you opt for using environment variables, it's a straight forward approach. Pa
 
 If you opt for using a configuration file, you have different ways to inform ``patronictl`` about the file to be used. By default ``patronictl`` will attempt to load a configuration file named ``patronictl.yaml``, which is expected to be found under either of these paths, according to your system:
 
-- Mac OS X: ``~/Library/Application Support/Foo Bar/patroni``
-- Mac OS X (POSIX): ``~/.foo-bar/patroni``
-- Unix: ``~/.config/foo-bar/patroni``
-- Unix (POSIX): ``~/.foo-bar/patroni``
-- Windows (roaming): ``C:\Users\<user>\AppData\Roaming\Foo Bar/patroni``
-- Windows (not roaming): ``C:\Users\<user>\AppData\Local\Foo Bar/patroni``
+- Mac OS X: ``~/Library/Application Support/patroni``
+- Mac OS X (POSIX): ``~/.patroni``
+- Unix: ``~/.config/patroni``
+- Unix (POSIX): ``~/.patroni``
+- Windows (roaming): ``C:\Users\<user>\AppData\Roaming\patroni``
+- Windows (not roaming): ``C:\Users\<user>\AppData\Local\patroni``
 
 You can override that behavior either by:
 

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -179,7 +179,7 @@ Parameters
 
     If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
 
-``group``
+``--group``
     Change dynamic configuration of the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
@@ -316,7 +316,7 @@ Parameters
 
     If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
 
-``group``
+``--group``
     Perform a failover in the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
@@ -362,3 +362,109 @@ Failover to node ``postgresql2``:
     | postgresql1 | 127.0.0.1:5433 | Replica | running |  3 |         0 |
     | postgresql2 | 127.0.0.1:5434 | Leader  | running |  3 |           |
     +-------------+----------------+---------+---------+----+-----------+
+
+
+patronictl flush
+^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    flush
+      CLUSTER_NAME
+      [ MEMBER_NAME [, ... ] ]
+      { restart | switchover }
+      [ --group CITUS_GROUP ]
+      [ { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } ]
+      [ --force ]
+
+Description
+"""""""""""
+
+``patronictl flush`` discards scheduled events, if any.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+``MEMBER_NAME``
+    Discard scheduled events for the given Patroni member(s).
+
+    .. note::
+        Only used if discarding scheduled restart events.
+
+``restart``
+    Discard scheduled restart events.
+
+``switchover``
+    Discard scheduled switchover event.
+
+``--group``
+    Discard scheduled events from the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``-r`` / ``--role``
+    Discard scheduled events for members that have the given role.
+
+    Role can be one of:
+
+    - ``leader``: the leader of either a regular Patroni cluster or a standby Patroni cluster; or
+    - ``primary``: the leader of a regular Patroni cluster; or
+    - ``standby-leader``: the leader of a standby Patroni cluster; or
+    - ``replica``: a replica of a Patroni cluster; or
+    - ``standby``: same as ``replica``; or
+    - ``any``: any role. Same as omitting this parameter; or
+    - ``master``: same as ``primary``.
+
+    .. note::
+        Only used if discarding scheduled restart events.
+
+``--force``
+    Flag to skip confirmation prompts when performing the flush.
+
+    Useful for scripts.
+
+Examples
+""""""""
+
+Discard a scheduled switchover event:
+
+.. code:: text
+
+    patronictl -c postgres0.yml flush batman switchover --force
+    Success: scheduled switchover deleted
+
+Discard scheduled restart of all standby nodes:
+
+.. code:: text
+
+    patronictl -c postgres0.yml flush batman restart -r replica --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+---------------------------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB | Scheduled restart         |
+    +-------------+----------------+---------+-----------+----+-----------+---------------------------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |           | 2023-09-12T17:17:00+00:00 |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |         0 | 2023-09-12T17:17:00+00:00 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |         0 | 2023-09-12T17:17:00+00:00 |
+    +-------------+----------------+---------+-----------+----+-----------+---------------------------+
+    Success: flush scheduled restart for member postgresql1
+    Success: flush scheduled restart for member postgresql2
+
+Discard scheduled restart of nodes ``postgresql0`` and ``postgresql1``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml flush batman postgresql0 postgresql1 restart --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+---------------------------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB | Scheduled restart         |
+    +-------------+----------------+---------+-----------+----+-----------+---------------------------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |           | 2023-09-12T17:17:00+00:00 |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |         0 | 2023-09-12T17:17:00+00:00 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |         0 | 2023-09-12T17:17:00+00:00 |
+    +-------------+----------------+---------+-----------+----+-----------+---------------------------+
+    Success: flush scheduled restart for member postgresql0
+    Success: flush scheduled restart for member postgresql1

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1235,3 +1235,129 @@ Remove information about Patroni cluster ``batman`` from the DCS:
     Please confirm the cluster name to remove: batman
     You are about to remove all information in DCS for batman, please type: "Yes I am aware": Yes I am aware
     This cluster currently is healthy. Please specify the leader name to continue: postgresql0
+
+patronictl restart
+^^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    restart
+      CLUSTER_NAME
+      [ MEMBER_NAME [, ...] ]
+      [ --group CITUS_GROUP ]
+      [ { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } ]
+      [ --any ]
+      [ --pg-version PG_VERSION ]
+      [ --pending ]
+      [ --timeout TIMEOUT ]
+      [ --scheduled TIMESTAMP ]
+      [ --force ]
+
+Description
+"""""""""""
+
+``patronictl restart`` requests a restart of the Postgres instance managed by a member of the Patroni cluster.
+
+The restart can be performed immediately or scheduled for later.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+``--group``
+    Remove information about the Patroni cluster related with the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``-r`` / ``--role``
+    Choose members that have the given role.
+
+    Role can be one of:
+
+    - ``leader``: the leader of either a regular Patroni cluster or a standby Patroni cluster; or
+    - ``primary``: the leader of a regular Patroni cluster; or
+    - ``standby-leader``: the leader of a standby Patroni cluster; or
+    - ``replica``: a replica of a Patroni cluster; or
+    - ``standby``: same as ``replica``; or
+    - ``any``: any role. Same as omitting this parameter; or
+    - ``master``: same as ``primary``.
+
+``--any``
+    Restart a single random node among the ones that respect the given filters.
+
+``--pg-version``
+    Select only members which version of the managed Postgres instance is older than the given version.
+
+    ``PG_VERSION`` is the Postgres version to be compared.
+
+``--pending``
+    Select only members which are flagged as ``Pending restart``.
+
+``timeout``
+    Abort the restart if it takes more than the specified timeout, and fail over to a replica if the issue is on the primary.
+
+    ``TIMEOUT`` is the amount of seconds to wait before aborting the restart.
+
+``--scheduled``
+    Schedule a restart to occur at the given timestamp.
+
+    ``TIMESTAMP`` is the timestamp when the restart should occur. Specify it in unambiguous format, preferrably with time zone. You can also use the literal ``now`` for the restart to be executed immediately.
+
+``--force``
+    Flag to skip confirmation prompts when requesting the restart operations.
+
+    Useful for scripts.
+
+Examples
+""""""""
+
+Restart all members of the cluster immediately:
+
+.. code:: text
+
+    patronictl -c postgres0.yml restart batman --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Success: restart on member postgresql0
+    Success: restart on member postgresql1
+    Success: restart on member postgresql2
+
+Restart a random member of the cluster immediately:
+
+.. code:: text
+
+    patronictl -c postgres0.yml restart batman --any --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Success: restart on member postgresql1
+
+Schedule a restart to occur at ``2023-09-13T18:00-03:00``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml restart batman --scheduled 2023-09-13T18:00-03:00 --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  6 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  6 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  6 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Success: restart scheduled on member postgresql0
+    Success: restart scheduled on member postgresql1
+    Success: restart scheduled on member postgresql2

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -394,6 +394,8 @@ Parameters
 ``MEMBER_NAME``
     Discard scheduled events for the given Patroni member(s).
 
+    Multiple members can be specified. If no members are specified, all of them are considered.
+
     .. note::
         Only used if discarding scheduled restart events.
 
@@ -1017,3 +1019,81 @@ Run a SQL command on any of the standbys:
     patronictl -c postgres0.yml query batman -r replica -c "SHOW port"
     port
     5433
+
+patronictl reinit
+^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    reinit
+      CLUSTER_NAME
+      [ MEMBER_NAME [, ... ] ]
+      [ --group CITUS_GROUP ]
+      [ --wait ]
+      [ --force ]
+
+Description
+"""""""""""
+
+``patronictl reinit`` rebuilds a Postgres standby instance managed by a replica member of the Patroni cluster.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+``MEMBER_NAME``
+    Name of the replica member which Postgres instance is to be rebuilt.
+
+    Multiple replica members can be specified. If no members are specified, the command does nothing.
+
+``--group``
+    Rebuild a replica member of the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``--wait``
+    Wait until the reinitialization of the Postgres standby node(s) is finished.
+
+``--force``
+    Flag to skip confirmation prompts when rebuilding Postgres standby instances.
+
+    Useful for scripts.
+
+Examples
+""""""""
+
+Request a rebuild of all replica members of the Patroni cluster and immediately return control to the caller:
+
+.. code:: text
+
+    patronictl -c postgres0.yml reinit batman postgresql1 postgresql2 --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Success: reinitialize for member postgresql1
+    Success: reinitialize for member postgresql2
+
+Request a rebuild of ``postgresql2`` and wait for it to complete:
+
+.. code:: text
+
+    patronictl -c postgres0.yml reinit batman postgresql2 --wait --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Success: reinitialize for member postgresql2
+    Waiting for reinitialize to complete on: postgresql2
+    Reinitialize is completed on: postgresql2

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1548,6 +1548,7 @@ Switch over with node ``postgresql2``:
 Schedule a switchover between ``postgresql0`` and ``postgresql2`` to occur at ``2023-09-13T18:00:00-03:00``:
 
 .. code:: text
+
     patronictl -c postgres0.yml switchover batman --leader postgresql0 --candidate postgresql2 --scheduled 2023-09-13T18:00-03:00 --force
     Current cluster topology
     + Cluster: batman (7277694203142172922) -+-----------+----+-----------+

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1,6 +1,6 @@
 .. _patronictl:
 
-Patronictl
+patronictl
 ==========
 
 Patroni has a command-line interface named ``patronictl``, which is used basically to interact with Patroni's REST API and with the DCS. It is intended to make it easier to perform operations in the cluster, and can easily be used by humans or scripts.

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -468,3 +468,102 @@ Discard scheduled restart of nodes ``postgresql0`` and ``postgresql1``:
     +-------------+----------------+---------+-----------+----+-----------+---------------------------+
     Success: flush scheduled restart for member postgresql0
     Success: flush scheduled restart for member postgresql1
+
+patronictl history
+^^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    history
+      [ CLUSTER_NAME ]
+      [ --group CITUS_GROUP ]
+      [ { -f | --format } { pretty | tsv | json | yaml } ]
+
+Description
+"""""""""""
+
+``patronictl history`` shows a history of failover and/or switchover events from the cluster, if any.
+
+The following information is included in the output:
+
+- ``TL``: the Postgres timeline at which the event occurred;
+- ``LSN``: Postgres LSN at which the event occurred;
+- ``Reason``: reason fetched from the Postgres ``.history`` file;
+- ``Timestamp``: time when the event occurred;
+- ``New Leader``: the Patroni member that has been promoted during the event.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+
+``--group``
+    Show history of events from the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``-f`` / ``--format``
+    How to format the list of events in the output.
+
+    Format can be one of:
+
+    - ``pretty``: prints history as a pretty table; or
+    - ``tsv``: prints history as tabular information, with columns delimited by ``\t``; or
+    - ``json``: prints history in JSON format; or
+    - ``yaml``: prints history in YAML format.
+
+    The default is ``pretty``.
+
+``--force``
+    Flag to skip confirmation prompts when performing the flush.
+
+    Useful for scripts.
+
+Examples
+""""""""
+
+Show the history of events:
+
+.. code:: text
+
+    patronictl -c postgres0.yml history batman
+    +----+----------+------------------------------+----------------------------------+-------------+
+    | TL |      LSN | Reason                       | Timestamp                        | New Leader  |
+    +----+----------+------------------------------+----------------------------------+-------------+
+    |  1 | 24392648 | no recovery target specified | 2023-09-11T22:11:27.125527+00:00 | postgresql0 |
+    |  2 | 50331864 | no recovery target specified | 2023-09-12T11:34:03.148097+00:00 | postgresql0 |
+    |  3 | 83886704 | no recovery target specified | 2023-09-12T11:52:26.948134+00:00 | postgresql2 |
+    |  4 | 83887280 | no recovery target specified | 2023-09-12T11:53:09.620136+00:00 | postgresql0 |
+    +----+----------+------------------------------+----------------------------------+-------------+
+
+Show the history of events in YAML format:
+
+.. code:: text
+
+    patronictl -c postgres0.yml history batman -f yaml
+    - LSN: 24392648
+      New Leader: postgresql0
+      Reason: no recovery target specified
+      TL: 1
+      Timestamp: '2023-09-11T22:11:27.125527+00:00'
+    - LSN: 50331864
+      New Leader: postgresql0
+      Reason: no recovery target specified
+      TL: 2
+      Timestamp: '2023-09-12T11:34:03.148097+00:00'
+    - LSN: 83886704
+      New Leader: postgresql2
+      Reason: no recovery target specified
+      TL: 3
+      Timestamp: '2023-09-12T11:52:26.948134+00:00'
+    - LSN: 83887280
+      New Leader: postgresql0
+      Reason: no recovery target specified
+      TL: 4
+      Timestamp: '2023-09-12T11:53:09.620136+00:00'

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1170,3 +1170,68 @@ Request a reload of the local configuration of all members of the Patroni cluste
     Reload request received for member postgresql0 and will be processed within 10 seconds
     Reload request received for member postgresql1 and will be processed within 10 seconds
     Reload request received for member postgresql2 and will be processed within 10 seconds
+
+patronictl remove
+^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    remove
+      CLUSTER_NAME
+      [ --group CITUS_GROUP ]
+      [ { -f | --format } { pretty | tsv | json | yaml } ]
+
+Description
+"""""""""""
+
+``patronictl remove`` remove information about the cluster from the DCS.
+
+It is an interactive action.
+
+.. warning::
+    This operation will destroy the information about the Patroni cluster in the DCS.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+``--group``
+    Remove information about the Patroni cluster related with the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``-f`` / ``--format``
+    How to format the list of members in the output when prompting for confirmation.
+
+    Format can be one of:
+
+    - ``pretty``: prints members as a pretty table; or
+    - ``tsv``: prints members as tabular information, with columns delimited by ``\t``; or
+    - ``json``: prints members in JSON format; or
+    - ``yaml``: prints members in YAML format.
+
+    The default is ``pretty``.
+
+Examples
+""""""""
+
+Remove information about Patroni cluster ``batman`` from the DCS:
+
+.. code:: text
+
+    patronictl -c postgres0.yml remove batman
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Please confirm the cluster name to remove: batman
+    You are about to remove all information in DCS for batman, please type: "Yes I am aware": Yes I am aware
+    This cluster currently is healthy. Please specify the leader name to continue: postgresql0

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1568,3 +1568,159 @@ Schedule a switchover between ``postgresql0`` and ``postgresql2`` to occur at ``
     Switchover scheduled at: 2023-09-13T18:00:00-03:00
                         from: postgresql0
                         to: postgresql2
+
+patronictl topology
+^^^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    topology
+      [ CLUSTER_NAME [, ... ] ]
+      [ --group CITUS_GROUP ]
+      [ { -W | { -w | --watch } TIME } ]
+
+Description
+"""""""""""
+
+``patronictl topology`` shows information about Patroni cluster and its members with a tree view approach for the members.
+
+The following information is included in the output:
+
+``Cluster``
+    Name of the Patroni cluster.
+
+    .. note::
+        Shown in the table header.
+
+``System identifier``
+    Postgres system identifier.
+
+    .. note::
+        Shown in the table header.
+
+``Member``
+    Name of the Patroni member.
+
+    .. note::
+        Information in this column is shown as a tree view of members in terms of replication connections.
+
+``Host``
+    Host where the member is located.
+
+``Role``
+    Current role of the member.
+
+    Can be one among:
+
+    * ``Leader``: the current leader of a regular Patroni cluster; or
+    * ``Standby Leader``: the current leader of a Patroni standby cluster; or
+    * ``Sync Standby``: a synchronous standby of a Patroni cluster with synchronous mode enabled; or
+    * ``Replica``: a regular standby of a Patroni cluster.
+
+``State``
+    Current state of Postgres in the Patroni member.
+
+    Some examples among the possible states:
+
+    * ``running``: if Postgres is currently up and running;
+    * ``streaming``: if a replica and Postgres is currently streaming WALs from the primary node;
+    * ``in archive recovery``: if a replica and Postgres is currently fetching WALs from the archive;
+    * ``stopped``: if Postgres had been shut down;
+    * ``crashed``: if Postgres has crashed.
+
+``TL``
+    Current Postgres timeline in the Patroni member.
+
+``Lag in MB``
+    Amount worth of replication lag in megabytes between the Patroni member and its upstream.
+
+Besides that, the following information may be included in the output:
+
+``Group``
+    Citus group ID.
+
+    .. note::
+        Shown in the table header.
+
+        Only shown if a Citus cluster.
+
+``Pending restart``
+    ``*`` indicates the node needs a restart for some Postgres configuration to take effect. An empty value indicates the node does not require a restart.
+
+    .. note::
+        Shown as a member attribute.
+
+        Shown if node requires a restart.
+
+``Scheduled restart``
+    Timestamp at which a restart has been scheduled for the Postgres instance managed by the Patroni member. An empty value indicates there is no scheduled restart for the member.
+
+    .. note::
+        Shown as a member attribute.
+
+        Shown if node has a scheduled restart.
+
+``Tags``
+    Contains tags set for the Patroni member. An empty value indicates that either no tags have been configured, or that they have been configured with default values.
+
+    .. note::
+        Shown as a member attribute.
+
+        Shown if node has any custom tags, or any default tags with non-default values.
+
+``Scheduled switchover``
+    Timestamp at which a switchover has been scheduled for the Patroni cluster, if any.
+
+    .. note::
+        Shown in the table footer.
+
+        Only shown if there is a scheduled switchover.
+
+``Maintenance mode``
+
+    If the cluster monitoring is currently paused.
+
+    .. note::
+        Shown in the table footer.
+
+        Only shown if the cluster is paused.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+
+``--group``
+    Show information about members from the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``-W``
+    Automatically refresh information every 2 seconds.
+
+``-w`` / ``--watch``
+    Automatically refresh information at the specified interval.
+
+    ``TIME`` is the interval between refreshes, in seconds.
+
+Examples
+""""""""
+
+Show topology of the cluster ``batman`` -- ``postgresql1`` and ``postgresql2`` are replicating from ``postgresql0``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml topology batman
+    + Cluster: batman (7277694203142172922) ---+-----------+----+-----------+
+    | Member        | Host           | Role    | State     | TL | Lag in MB |
+    +---------------+----------------+---------+-----------+----+-----------+
+    | postgresql0   | 127.0.0.1:5432 | Leader  | running   |  8 |           |
+    | + postgresql1 | 127.0.0.1:5433 | Replica | streaming |  8 |         0 |
+    | + postgresql2 | 127.0.0.1:5434 | Replica | streaming |  8 |         0 |
+    +---------------+----------------+---------+-----------+----+-----------+

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1361,3 +1361,48 @@ Schedule a restart to occur at ``2023-09-13T18:00-03:00``:
     Success: restart scheduled on member postgresql0
     Success: restart scheduled on member postgresql1
     Success: restart scheduled on member postgresql2
+
+patronictl resume
+^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    resume
+      [ CLUSTER_NAME ]
+      [ --group CITUS_GROUP ]
+      [ --wait ]
+
+Description
+"""""""""""
+
+``patronictl resume`` takes the Patroni cluster out of the maintenance mode and re-enables automatic failover.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+
+``--group``
+    Resume the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``--wait``
+    Wait until all Patroni members are unpaused before returning control the the caller.
+
+Examples
+""""""""
+
+Put the cluster out of maintenance mode:
+
+.. code:: text
+
+    patronictl -c postgres0.yml resume batman --wait
+    'resume' request sent, waiting until it is recognized by all nodes
+    Success: cluster management is resumed

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -522,7 +522,7 @@ Discard scheduled restart of nodes ``postgresql0`` and ``postgresql1``:
 patronictl history
 ^^^^^^^^^^^^^^^^^^
 
-.. _patronictl_flush_synopsis:
+.. _patronictl_history_synopsis:
 
 Synopsis
 """"""""
@@ -534,7 +534,7 @@ Synopsis
       [ --group CITUS_GROUP ]
       [ { -f | --format } { pretty | tsv | json | yaml } ]
 
-.. _patronictl_flush_description:
+.. _patronictl_history_description:
 
 Description
 """""""""""
@@ -558,7 +558,7 @@ The following information is included in the output:
 ``New Leader``
     Patroni member that has been promoted during the event.
 
-.. _patronictl_flush_parameters:
+.. _patronictl_history_parameters:
 
 Parameters
 """"""""""
@@ -590,7 +590,7 @@ Parameters
 
     Useful for scripts.
 
-.. _patronictl_flush_examples:
+.. _patronictl_history_examples:
 
 Examples
 """"""""

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -139,7 +139,7 @@ Get DSN of the primary node:
     patronictl -c postgres0.yml dsn batman -r primary
     host=127.0.0.1 port=5432
 
-Get DSN of the standby node named ``postgresql1``:
+Get DSN of the node named ``postgresql1``:
 
 .. code:: text
 
@@ -1273,7 +1273,7 @@ Parameters
     Name of the Patroni cluster.
 
 ``--group``
-    Remove information about the Patroni cluster related with the given Citus group.
+    Restart the Patroni cluster related with the given Citus group.
 
     ``CITUS_GROUP`` is the ID of the Citus group.
 

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1097,3 +1097,76 @@ Request a rebuild of ``postgresql2`` and wait for it to complete:
     Success: reinitialize for member postgresql2
     Waiting for reinitialize to complete on: postgresql2
     Reinitialize is completed on: postgresql2
+
+patronictl reload
+^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    reload
+      CLUSTER_NAME
+      [ MEMBER_NAME [, ... ] ]
+      [ --group CITUS_GROUP ]
+      [ { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } ]
+      [ --force ]
+
+Description
+"""""""""""
+
+``patronictl reload`` requests a reload of local configuration for one or more Patroni members.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+``MEMBER_NAME``
+    Request a reload of local configuration for the given Patroni member(s).
+
+    Multiple members can be specified. If no members are specified, all of them are considered.
+
+``--group``
+    Request a reload of members of the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``-r`` / ``--role``
+    Select members that have the given role.
+
+    Role can be one of:
+
+    - ``leader``: the leader of either a regular Patroni cluster or a standby Patroni cluster; or
+    - ``primary``: the leader of a regular Patroni cluster; or
+    - ``standby-leader``: the leader of a standby Patroni cluster; or
+    - ``replica``: a replica of a Patroni cluster; or
+    - ``standby``: same as ``replica``; or
+    - ``any``: any role. Same as omitting this parameter; or
+    - ``master``: same as ``primary``.
+
+``--force``
+    Flag to skip confirmation prompts when requesting a reload of the local configuration.
+
+    Useful for scripts.
+
+Examples
+""""""""
+
+Request a reload of the local configuration of all members of the Patroni cluster:
+
+.. code:: text
+
+    patronictl -c postgres0.yml reload batman --force
+    + Cluster: batman (7277694203142172922) -+-----------+----+-----------+
+    | Member      | Host           | Role    | State     | TL | Lag in MB |
+    +-------------+----------------+---------+-----------+----+-----------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |           |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |         0 |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |         0 |
+    +-------------+----------------+---------+-----------+----+-----------+
+    Reload request received for member postgresql0 and will be processed within 10 seconds
+    Reload request received for member postgresql1 and will be processed within 10 seconds
+    Reload request received for member postgresql2 and will be processed within 10 seconds

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1,0 +1,127 @@
+.. _patronictl:
+
+Patronictl
+==========
+
+Patroni has a command-line interface named ``patronictl``, which is used basically to interact with Patroni's REST API and with the DCS. It is intended to make it easier to perform operations in the cluster, and can easily be used by humans or scripts.
+
+Configuration
+-------------
+
+``patronictl`` uses 3 sections of the configuration:
+
+- **restapi**: where the REST API server is serving requests. ``patronictl`` is mainly interested in ``restapi.connect_address`` setting;
+- **ctl**: how to authenticate against the REST API server, and how to validate the server identity;
+- DCS (e.g. **etcd**): how to contact and authenticate against the DCS used by Patroni.
+
+Those configuration options can come either from environment variables or from a configuration file. Look for the above sections in :ref:`Environment Configuration Settings <environment>` or :ref:`YAML Configuration Settings <yaml_configuration>` to understand how you can set the options for them through environment variables or through a configuration file.
+
+If you opt for using environment variables, it's a straight forward approach. Patroni will read the environment variables and use their values.
+
+If you opt for using a configuration file, you have different ways to inform ``patronictl`` about the file to be used. By default ``patronictl`` will attempt to load a configuration file named ``patronictl.yaml``, which is expected to be found under either of these paths, according to your system:
+
+- Mac OS X: ``~/Library/Application Support/Foo Bar/patroni``
+- Mac OS X (POSIX): ``~/.foo-bar/patroni``
+- Unix: ``~/.config/foo-bar/patroni``
+- Unix (POSIX): ``~/.foo-bar/patroni``
+- Windows (roaming): ``C:\Users\<user>\AppData\Roaming\Foo Bar/patroni``
+- Windows (not roaming): ``C:\Users\<user>\AppData\Local\Foo Bar/patroni``
+
+You can override that behavior either by:
+
+- Setting the environment variable ``PATRONICTL_CONFIG_FILE`` with the path to a custom configuration file;
+- Using the ``-c`` / ``--config-file`` command-line argument of ``patronictl`` with the path to a custom configuration file.
+
+.. note::
+    If you are running ``patronictl`` in the same host as ``patroni`` daemon is running, you may just use the same configuration file if it contains all the configuration sections required by ``patronictl``.
+
+Usage
+--------------------
+
+``patronictl`` exposes several handy operations. This section is intended to describe each of them.
+
+Before jumping into each of the sub-commands of ``patronictl``, be aware that ``patronictl`` itself has the following command-line arguments:
+
+- ``-c`` / ``--config-file``: as explained before, used to provide a path to a configuration file for ``patronictl``;
+- ``-d`` / ``--dcs-url`` / ``--dcs``: provide a connection string to the DCS used by Patroni. This argument can be used either to override the DCS settings from the ``patronictl`` configuration, or to define it if it's missing in the configuration. The value should be in the format ``DCS://HOST:PORT``, e.g. ``etcd3://localhost:2379`` to connect to etcd v3 running on ``localhost``;
+- ``-k`` / ``--insecure``: bypass validation of REST API server SSL certificate.
+
+This is the synopsis for running a command from the ``patronictl``:
+
+.. code:: text
+
+    patronictl [ { -c | --config-file } CONFIG_FILE ]
+      [ { -d | --dcs-url | --dcs } DCS_URL ] 
+      [ { -k | --insecure } ]
+      COMMAND
+
+.. note::
+
+    This is the syntax for the synopsis:
+
+    - Options between square brackets are optional;
+    - Options between curly brackets represent a "chose one of set" operation;
+    - Things written in uppercase represent a literal that should be given a value to.
+
+    We will use this same syntax when describing ``patronictl`` commands later. Also, when describing commands in the following sub-sections, the commands' synposis should be replace the ``COMMAND`` in the above synopsis.
+
+In the following sub-sections you can find a description of each command implemented by ``patronictl``. For sake of example, we will use the configuration files present in the GitHub repository of Patroni (files ``postgres0.yml``, ``postgres1.yml`` and ``postgres2.yml``).
+
+patronictl dsn
+^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    dsn [ { { -r | --role } { leader | primary | standby-leader | replica | standby | any | master } | { -m | --member } MEMBER_NAME } ]
+      [ --group CITUS_GROUP ]
+      [ CLUSTER_NAME ]
+
+Description
+"""""""""""
+
+``patronictl dsn`` will get the connection string to one member of the Patroni cluster.
+
+If multiple members match the parameters of this command, one of them will be chosen, prioritizing the primary node.
+
+Parameters
+""""""""""
+
+- ``-r`` / ``--role``: chose a member that has the given role:
+
+    - ``leader``: the leader of either a regular Patroni cluster or a standby Patroni cluster;
+    - ``primary``: the leader of a regular Patroni cluster;
+    - ``standby-leader``: the leader of a standby Patroni cluster;
+    - ``replica``: a replica of a Patroni cluster;
+    - ``standby``: same as ``replica``;
+    - ``any``: any role. Same as omitting this parameter;
+    - ``master``: same as ``primary``.
+
+- ``-m`` / ``--member``: chose a member of the cluster with the given name:
+
+    - ``MEMBER_NAME``: name of the member;
+
+- ``--group``: chose a member that is part of the given Citus group:
+
+    - ``CITUS_GROUP``: the ID of the Citus group;
+
+- ``CLUSTER_NAME``: name of the Patroni cluster. If not given, ``patronictl`` will fetch that from ``scope`` configuration.
+
+Examples
+""""""""
+
+Get DSN of the primary node:
+
+.. code:: text
+
+    patronictl -c postgres0.yml dsn batman -r primary
+    host=127.0.0.1 port=5432
+
+Get DSN of the standby node named ``postgresql1``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml dsn batman --member postgresql1
+    host=127.0.0.1 port=5433

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -236,9 +236,9 @@ Change ``max_connections`` Postgres GUC:
     postgresql:
     +  parameters:
     +    max_connections: 150
-    pg_hba:
-    - host replication replicator 127.0.0.1/32 md5
-    - host all all 0.0.0.0/0 md5
+      pg_hba:
+      - host replication replicator 127.0.0.1/32 md5
+      - host all all 0.0.0.0/0 md5
 
     Configuration changed
 
@@ -254,10 +254,10 @@ Change ``loop_wait`` and ``ttl`` settings:
     +loop_wait: 15
     maximum_lag_on_failover: 1048576
     postgresql:
-    pg_hba:
+      pg_hba:
     @@ -6,4 +6,4 @@
-    - host all all 0.0.0.0/0 md5
-    use_pg_rewind: true
+      - host all all 0.0.0.0/0 md5
+      use_pg_rewind: true
     retry_timeout: 10
     -ttl: 30
     +ttl: 45
@@ -275,8 +275,8 @@ Remove ``maximum_lag_on_failover`` setting from dynamic configuration:
     loop_wait: 10
     -maximum_lag_on_failover: 1048576
     postgresql:
-    pg_hba:
-    - host replication replicator 127.0.0.1/32 md5
+      pg_hba:
+      - host replication replicator 127.0.0.1/32 md5
 
     Configuration changed
 
@@ -1406,3 +1406,52 @@ Put the cluster out of maintenance mode:
     patronictl -c postgres0.yml resume batman --wait
     'resume' request sent, waiting until it is recognized by all nodes
     Success: cluster management is resumed
+
+patronictl show-config
+^^^^^^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    show-config
+      [ CLUSTER_NAME ]
+      [ --group CITUS_GROUP ]
+
+Description
+"""""""""""
+
+``patronictl show-config`` shows the dynamic configuration of the cluster that is stored in the DCS.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+
+``--group``
+    Show dynamic configuration of the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+Examples
+""""""""
+
+Show dynamic configuration of cluster ``batman``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml show-config batman
+    loop_wait: 10
+    postgresql:
+      parameters:
+        max_connections: 250
+      pg_hba:
+      - host replication replicator 127.0.0.1/32 md5
+      - host all all 0.0.0.0/0 md5
+      use_pg_rewind: true
+    retry_timeout: 10
+    ttl: 30

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -12,7 +12,7 @@ Configuration
 
 ``patronictl`` uses 3 sections of the configuration:
 
-- **ctl**: how to authenticate against the REST API server, and how to validate the server identity;
+- **ctl**: how to authenticate against the Patroni REST API, and how to validate the server identity;
 - **restapi**: how to authenticate against the REST API server, and how to validate the server identity. Only used if ``ctl`` configuration is not enough. ``patronictl`` is mainly interested in ``restapi.authentication`` section (in case ``ctl.authentication`` is missing) and ``restapi.cafile`` setting (in case ``ctl.cacert`` is missing);
 - DCS (e.g. **etcd**): how to contact and authenticate against the DCS used by Patroni.
 

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -1724,3 +1724,66 @@ Show topology of the cluster ``batman`` -- ``postgresql1`` and ``postgresql2`` a
     | + postgresql1 | 127.0.0.1:5433 | Replica | streaming |  8 |         0 |
     | + postgresql2 | 127.0.0.1:5434 | Replica | streaming |  8 |         0 |
     +---------------+----------------+---------+-----------+----+-----------+
+
+patronictl version
+^^^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    version
+      [ CLUSTER_NAME [, ... ] ]
+      [ MEMBER_NAME [, ... ] ]
+      [ --group CITUS_GROUP ]
+
+Description
+"""""""""""
+
+``patronictl version`` gets the version of ``patronictl`` application. Besides that it may also include version information about Patroni clusters and their members.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+``MEMBER_NAME``
+    Name of the member of the Patroni cluster.
+
+``--group``
+    Consider a Patroni cluster with the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+Examples
+""""""""
+
+Get version of ``patronictl`` only:
+
+.. code:: text
+
+    patronictl -c postgres0.yml version
+    patronictl version 3.1.0
+
+Get version of ``patronictl`` and of all members of cluster ``batman``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml version batman
+    patronictl version 3.1.0
+
+    postgresql0: Patroni 3.1.0 PostgreSQL 15.2
+    postgresql1: Patroni 3.1.0 PostgreSQL 15.2
+    postgresql2: Patroni 3.1.0 PostgreSQL 15.2
+
+Get version of ``patronictl`` and of members ``postgresql1`` and ``postgresql2`` of cluster ``batman``:
+
+.. code:: text
+
+    patronictl -c postgres0.yml version batman postgresql1 postgresql2
+    patronictl version 3.1.0
+
+    postgresql1: Patroni 3.1.0 PostgreSQL 15.2
+    postgresql2: Patroni 3.1.0 PostgreSQL 15.2

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -42,9 +42,18 @@ Usage
 
 Before jumping into each of the sub-commands of ``patronictl``, be aware that ``patronictl`` itself has the following command-line arguments:
 
-- ``-c`` / ``--config-file``: as explained before, used to provide a path to a configuration file for ``patronictl``;
-- ``-d`` / ``--dcs-url`` / ``--dcs``: provide a connection string to the DCS used by Patroni. This argument can be used either to override the DCS settings from the ``patronictl`` configuration, or to define it if it's missing in the configuration. The value should be in the format ``DCS://HOST:PORT``, e.g. ``etcd3://localhost:2379`` to connect to etcd v3 running on ``localhost``;
-- ``-k`` / ``--insecure``: bypass validation of REST API server SSL certificate.
+``-c`` / ``--config-file``
+    As explained before, used to provide a path to a configuration file for ``patronictl``.
+
+``-d`` / ``--dcs-url`` / ``--dcs``
+    Provide a connection string to the DCS used by Patroni.
+
+    This argument can be used either to override the DCS settings from the ``patronictl`` configuration, or to define it if it's missing in the configuration.
+
+    The value should be in the format ``DCS://HOST:PORT``, e.g. ``etcd3://localhost:2379`` to connect to etcd v3 running on ``localhost``.
+
+``-k`` / ``--insecure``
+    Flag to bypass validation of REST API server SSL certificate.
 
 This is the synopsis for running a command from the ``patronictl``:
 
@@ -64,7 +73,8 @@ This is the synopsis for running a command from the ``patronictl``:
     - Options with ``[, ... ]`` can be specified multiple times;
     - Things written in uppercase represent a literal that should be given a value to.
 
-    We will use this same syntax when describing ``patronictl`` sub-commands in the following sub-sections. Also, when describing sub-commands in the following sub-sections, the commands' synposis should replace the ``SUBCOMMAND`` in the above synopsis.
+    We will use this same syntax when describing ``patronictl`` sub-commands in the following sub-sections.
+    Also, when describing sub-commands in the following sub-sections, the commands' synposis should be seen as a replacement for the ``SUBCOMMAND`` in the above synopsis.
 
 In the following sub-sections you can find a description of each command implemented by ``patronictl``. For sake of example, we will use the configuration files present in the GitHub repository of Patroni (files ``postgres0.yml``, ``postgres1.yml`` and ``postgres2.yml``).
 
@@ -84,14 +94,17 @@ Synopsis
 Description
 """""""""""
 
-``patronictl dsn`` will get the connection string to one member of the Patroni cluster.
+``patronictl dsn`` gets the connection string to one member of the Patroni cluster.
 
 If multiple members match the parameters of this command, one of them will be chosen, prioritizing the primary node.
 
 Parameters
 """"""""""
 
-- ``-r`` / ``--role``: chose a member that has the given role:
+``-r`` / ``--role``
+    Choose a member that has the given role.
+
+    Role can be one of:
 
     - ``leader``: the leader of either a regular Patroni cluster or a standby Patroni cluster; or
     - ``primary``: the leader of a regular Patroni cluster; or
@@ -101,15 +114,20 @@ Parameters
     - ``any``: any role. Same as omitting this parameter; or
     - ``master``: same as ``primary``.
 
-- ``-m`` / ``--member``: chose a member of the cluster with the given name:
+``-m`` / ``--member``
+    Choose a member of the cluster with the given name.
 
-    - ``MEMBER_NAME``: name of the member;
+    ``MEMBER_NAME`` is the name of the member.
 
-- ``--group``: chose a member that is part of the given Citus group:
+``--group``
+    Choose a member that is part of the given Citus group.
 
-    - ``CITUS_GROUP``: the ID of the Citus group;
+    ``CITUS_GROUP`` is the ID of the Citus group.
 
-- ``CLUSTER_NAME``: name of the Patroni cluster. If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
 
 Examples
 """"""""
@@ -150,38 +168,57 @@ Description
 
 ``patronictl edit-config`` changes the dynamic configuration of the cluster and updates the DCS with that.
 
-**Note:** when invoked through a TTY the command attempts to show a diff of the dynamic configuration through a pager. By default it attempts to use either ``less`` or ``more``. If you want to use a different pager, set ``PAGER`` environment variable with the desired pager.
+.. note::
+    When invoked through a TTY the command attempts to show a diff of the dynamic configuration through a pager. By default it attempts to use either ``less`` or ``more``. If you want to use a different pager, set ``PAGER`` environment variable with the desired pager.
 
 Parameters
 """"""""""
 
-- ``--group``: change dynamic configuration of the given Citus group:
+``group``
+    Change dynamic configuration of the given Citus group.
 
-    - ``CITUS_GROUP``: the ID of the Citus group;
+    ``CITUS_GROUP`` is the ID of the Citus group.
 
-- ``-q`` / ``--quiet``: flag to skip showing the configuration diff;
+``-q`` / ``--quiet``
+    Flag to skip showing the configuration diff.
 
-- ``-s`` / ``--set``: set a given dynamic configuration option with a given value:
+``-s`` / ``--set``
+    Set a given dynamic configuration option with a given value.
 
-    - ``CONFIG``: name of the dynamic configuration path in the YAML tree, with levels joined by ``.`` ;
-    - ``VALUE``: value for ``CONFIG``. If it is ``null``, then ``CONFIG`` will be removed from the dynamic configuration.
+    ``CONFIG`` is the name of the dynamic configuration path in the YAML tree, with levels joined by ``.`` .
 
-- ``-p`` / ``--pg``: set a given dynamic Postgres configuration option with the given value. It is essentially a shorthand for ``--s`` / ``--set`` with ``CONFIG`` prepended with ``postgresql.parameters.``:
+    ``VALUE`` is the value for ``CONFIG``. If it is ``null``, then ``CONFIG`` will be removed from the dynamic configuration.
 
-    - ``PG_CONFIG``: name of the Postgres configuration;
-    - ``PG_VALUE``: value for ``PG_CONFIG``. If it is ``nulll``, then ``PG_CONFIG`` will be removed from the dynamic configuration.
+``-p`` / ``--pg``
+    Set a given dynamic Postgres configuration option with the given value.
 
-- ``--apply``: apply dynamic configuration from a given file. It is similar to specifying multiple ``-s`` / ``--set``, with each configuration from ``CONFIG_FILE``:
+    It is essentially a shorthand for ``--s`` / ``--set`` with ``CONFIG`` prepended with ``postgresql.parameters.``.
 
-    - ``CONFIG_FILE``: path to a file containing the dynamic configuration to be applied, in YAML format. Use ``-`` if you want to read from ``stdin``.
+    ``PG_CONFIG`` is the name of the Postgres configuration to be set.
 
-- ``--replace``: replace the dynamic configuration in the DCS with the dynamic configuration specified in a given file:
+    ``PG_VALUE`` is the value for ``PG_CONFIG``. If it is ``nulll``, then ``PG_CONFIG`` will be removed from the dynamic configuration.
 
-    - ``CONFIG_FILE``: path to a file containing the new dynamic configuration to take effect, in YAML format. Use ``-`` if you want to read from ``stdin``.
+``--apply``
+    Apply dynamic configuration from the given file.
 
-- ``--force``: skip confirmation prompts when changing the dynamic configuration. Useful for scripts.
+    It is similar to specifying multiple ``-s`` / ``--set`` options, one for each configuration from ``CONFIG_FILE``.
 
-- ``CLUSTER_NAME``: name of the Patroni cluster. If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    ``CONFIG_FILE`` is the path to a file containing the dynamic configuration to be applied, in YAML format. Use ``-`` if you want to read from ``stdin``.
+
+``--replace``
+    Replace the dynamic configuration in the DCS with the dynamic configuration specified in the given file.
+
+    ``CONFIG_FILE`` is the path to a file containing the new dynamic configuration to take effect, in YAML format. Use ``-`` if you want to read from ``stdin``.
+
+``--force``
+    Flag to skip confirmation prompts when changing the dynamic configuration.
+
+    Useful for scripts.
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
 
 Examples
 """"""""

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -803,3 +803,48 @@ Show information about the cluster in YAML format, with timestamp of execution:
       Role: Replica
       State: streaming
       TL: 5
+
+patronictl pause
+^^^^^^^^^^^^^^^^
+
+Synopsis
+""""""""
+
+.. code:: text
+
+    pause
+      [ CLUSTER_NAME ]
+      [ --group CITUS_GROUP ]
+      [ --wait ]
+
+Description
+"""""""""""
+
+``patronictl pause`` temporarily puts the Patroni cluster in maintenance mode and disables automatic failover.
+
+Parameters
+""""""""""
+
+``CLUSTER_NAME``
+    Name of the Patroni cluster.
+
+    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+
+``--group``
+    Pause the given Citus group.
+
+    ``CITUS_GROUP`` is the ID of the Citus group.
+
+``--wait``
+    Wait until all Patroni members are paused before returning control the the caller.
+
+Examples
+""""""""
+
+Put the cluster in maintenance mode:
+
+.. code:: text
+
+    patronictl -c postgres0.yml pause batman --wait
+    'pause' request sent, waiting until it is recognized by all nodes
+    Success: cluster management is paused

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -12,8 +12,8 @@ Configuration
 
 ``patronictl`` uses 3 sections of the configuration:
 
-- **ctl**: how to authenticate against the Patroni REST API, and how to validate the server identity;
-- **restapi**: how to authenticate against the REST API server, and how to validate the server identity. Only used if ``ctl`` configuration is not enough. ``patronictl`` is mainly interested in ``restapi.authentication`` section (in case ``ctl.authentication`` is missing) and ``restapi.cafile`` setting (in case ``ctl.cacert`` is missing);
+- **ctl**: how to authenticate against the Patroni REST API, and how to validate the server identity. Refer to :ref:`ctl settings <patronictl_settings>` for more details;
+- **restapi**: how to authenticate against the Patroni REST API, and how to validate the server identity. Only used if ``ctl`` configuration is not enough. ``patronictl`` is mainly interested in ``restapi.authentication`` section (in case ``ctl.authentication`` is missing) and ``restapi.cafile`` setting (in case ``ctl.cacert`` is missing). Refer to :ref:`REST API settings <restapi_settings>` for more details;
 - DCS (e.g. **etcd**): how to contact and authenticate against the DCS used by Patroni.
 
 Those configuration options can come either from environment variables or from a configuration file. Look for the above sections in :ref:`Environment Configuration Settings <environment>` or :ref:`YAML Configuration Settings <yaml_configuration>` to understand how you can set the options for them through environment variables or through a configuration file.

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -69,7 +69,7 @@ This is the synopsis for running a command from the ``patronictl``:
     This is the syntax for the synopsis:
 
     - Options between square brackets are optional;
-    - Options between curly brackets represent a "chose one of set" operation;
+    - Options between curly brackets represent a "choose one of set" operation;
     - Options with ``[, ... ]`` can be specified multiple times;
     - Things written in uppercase represent a literal that should be given a value to.
 
@@ -94,7 +94,7 @@ Synopsis
 Description
 """""""""""
 
-``patronictl dsn`` gets the connection string to one member of the Patroni cluster.
+``patronictl dsn`` gets the connection string for one member of the Patroni cluster.
 
 If multiple members match the parameters of this command, one of them will be chosen, prioritizing the primary node.
 
@@ -104,7 +104,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``-r`` / ``--role``
     Choose a member that has the given role.
@@ -169,7 +169,7 @@ Description
 ``patronictl edit-config`` changes the dynamic configuration of the cluster and updates the DCS with that.
 
 .. note::
-    When invoked through a TTY the command attempts to show a diff of the dynamic configuration through a pager. By default it attempts to use either ``less`` or ``more``. If you want to use a different pager, set ``PAGER`` environment variable with the desired pager.
+    When invoked through a TTY the command attempts to show a diff of the dynamic configuration through a pager. By default, it attempts to use either ``less`` or ``more``. If you want a different pager, set the ``PAGER`` environment variable with the desired one.
 
 Parameters
 """"""""""
@@ -177,7 +177,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Change dynamic configuration of the given Citus group.
@@ -306,10 +306,10 @@ It is designed to be used when the cluster is not healthy, e.g.:
 - There is no synchronous standby available in a synchronous cluster.
 
 .. note::
-    Nothing prevents you from running ``patronictl failover`` in a healthy cluster. However, we recommend using ``patronictl switchover`` in that case.
+    Nothing prevents you from running ``patronictl failover`` in a healthy cluster. However, we recommend using ``patronictl switchover`` in those cases.
 
 .. warning::
-    Triggering a failover can cause data loss depending on how up-to-date the replica to be promoted is in comparison to the primary.
+    Triggering a failover can cause data loss depending on how up-to-date the promoted replica is in comparison to the primary.
 
 Parameters
 """"""""""
@@ -317,7 +317,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Perform a failover in the given Citus group.
@@ -490,7 +490,7 @@ Synopsis
 Description
 """""""""""
 
-``patronictl history`` shows a history of failover and/or switchover events from the cluster, if any.
+``patronictl history`` shows a history of failover and switchover events from the cluster, if any.
 
 The following information is included in the output:
 
@@ -515,7 +515,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Show history of events from the given Citus group.
@@ -660,7 +660,7 @@ Besides that, the following information may be included in the output:
         Only shown if a Citus cluster.
 
 ``Pending restart``
-    ``*`` indicates the node needs a restart for some Postgres configuration to take effect. An empty value indicates the node does not require a restart.
+    ``*`` indicates that the node needs a restart for some Postgres configuration to take effect. An empty value indicates the node does not require a restart.
 
     .. note::
         Shown as a member attribute.
@@ -715,7 +715,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Show information about members from the given Citus group.
@@ -833,7 +833,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Pause the given Citus group.
@@ -841,12 +841,12 @@ Parameters
     ``CITUS_GROUP`` is the ID of the Citus group.
 
 ``--wait``
-    Wait until all Patroni members are paused before returning control the the caller.
+    Wait until all Patroni members are paused before returning control to the caller.
 
 Examples
 """"""""
 
-Put the cluster in maintenance mode:
+Put the cluster in maintenance mode, and wait until all nodes have been paused:
 
 .. code:: text
 
@@ -885,7 +885,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Query the given Citus group.
@@ -913,7 +913,7 @@ Parameters
 ``-d`` / ``--dbname``
     Database to connect and run the query.
 
-    ``DBNAME`` is the name of the database. If not given, defaults to the same name as ``USERNAME``.
+    ``DBNAME`` is the name of the database. If not given, defaults to ``USERNAME``.
 
 ``-U`` / ``--username``
     User to connect to the database.
@@ -923,7 +923,7 @@ Parameters
 ``--password``
     Prompt for the password of the connecting user.
 
-    As Patroni uses ``libpq``, alternatively you can use create a ``~/.pgpass`` file or set ``PGPASSWORD`` environment variable.
+    As Patroni uses ``libpq``, alternatively you can create a ``~/.pgpass`` file or set the ``PGPASSWORD`` environment variable.
 
 ``--format``
     How to format the output of the query.
@@ -945,10 +945,10 @@ Parameters
 ``-c`` / ``--command``
     Run the given SQL command in the query.
 
-    ``SQL_COMMAND`` is the command to be run.
+    ``SQL_COMMAND`` is the SQL command to be executed.
 
 ``--delimiter``
-    The delimiter when printing information in ``tsv`` format.
+    The delimiter when printing information in ``tsv`` format, or ``\t`` if omitted.
 
 ``-W``
     Automatically re-run the query every 2 seconds.
@@ -1050,7 +1050,7 @@ Parameters
     Name of the Patroni cluster.
 
 ``MEMBER_NAME``
-    Name of the replica member which Postgres instance is to be rebuilt.
+    Name of the replica member for which the Postgres instance will be rebuilt.
 
     Multiple replica members can be specified. If no members are specified, the command does nothing.
 
@@ -1190,12 +1190,12 @@ Synopsis
 Description
 """""""""""
 
-``patronictl remove`` remove information about the cluster from the DCS.
+``patronictl remove`` removes information of the cluster from the DCS.
 
 It is an interactive action.
 
 .. warning::
-    This operation will destroy the information about the Patroni cluster in the DCS.
+    This operation will destroy the information of the Patroni cluster from the DCS.
 
 Parameters
 """"""""""
@@ -1291,7 +1291,7 @@ Parameters
     - ``master``: same as ``primary``.
 
 ``--any``
-    Restart a single random node among the ones that respect the given filters.
+    Restart a single random node among the ones which match the given filters.
 
 ``--pg-version``
     Select only members which version of the managed Postgres instance is older than the given version.
@@ -1381,7 +1381,7 @@ Synopsis
 Description
 """""""""""
 
-``patronictl resume`` takes the Patroni cluster out of the maintenance mode and re-enables automatic failover.
+``patronictl resume`` takes the Patroni cluster out of maintenance mode and re-enables automatic failover.
 
 Parameters
 """"""""""
@@ -1389,7 +1389,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Resume the given Citus group.
@@ -1397,7 +1397,7 @@ Parameters
     ``CITUS_GROUP`` is the ID of the Citus group.
 
 ``--wait``
-    Wait until all Patroni members are unpaused before returning control the the caller.
+    Wait until all Patroni members are unpaused before returning control to the caller.
 
 Examples
 """"""""
@@ -1433,7 +1433,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Show dynamic configuration of the given Citus group.
@@ -1493,7 +1493,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Perform a switchover in the given Citus group.
@@ -1586,7 +1586,7 @@ Synopsis
 Description
 """""""""""
 
-``patronictl topology`` shows information about Patroni cluster and its members with a tree view approach for the members.
+``patronictl topology`` shows information about the Patroni cluster and its members with a tree view approach.
 
 The following information is included in the output:
 
@@ -1695,7 +1695,7 @@ Parameters
 ``CLUSTER_NAME``
     Name of the Patroni cluster.
 
-    If not given, ``patronictl`` will attempt to fetch that from ``scope`` configuration, if it exists.
+    If not given, ``patronictl`` will attempt to fetch that from the ``scope`` configuration, if it exists.
 
 ``--group``
     Show information about members from the given Citus group.

--- a/docs/pause.rst
+++ b/docs/pause.rst
@@ -32,6 +32,6 @@ When Patroni runs in a paused mode, it does not change the state of PostgreSQL, 
 User guide
 ----------
 
-``patronictl`` supports ``pause`` and ``resume`` commands.
+``patronictl`` supports :ref:`pause <patronictl_pause>` and :ref:`resume <patronictl_resume>` commands.
 
 One can also issue a ``PATCH`` request to the ``{namespace}/{cluster}/config`` key with ``{"pause": true/false/null}``

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -191,7 +191,7 @@ There is no further relationship between the standby cluster and the primary
 cluster it replicates from, in particular, they must not share the same DCS
 scope if they use the same DCS. They do not know anything else from each other
 apart from replication information. Also, the standby cluster is not being
-displayed in ``patronictl list`` or ``patronictl topology`` output on the
+displayed in :ref:`patronictl_list` or :ref:`patronictl_topology` output on the
 primary cluster.
 
 For the sake of flexibility, you can specify methods of creating a replica and

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -3,7 +3,7 @@
 Patroni REST API
 ================
 
-Patroni has a rich REST API, which is used by Patroni itself during the leader race, by the ``patronictl`` tool in order to perform failovers/switchovers/reinitialize/restarts/reloads, by HAProxy or any other kind of load balancer to perform HTTP health checks, and of course could also be used for monitoring. Below you will find the list of Patroni REST API endpoints.
+Patroni has a rich REST API, which is used by Patroni itself during the leader race, by the :ref:`patronictl` tool in order to perform failovers/switchovers/reinitialize/restarts/reloads, by HAProxy or any other kind of load balancer to perform HTTP health checks, and of course could also be used for monitoring. Below you will find the list of Patroni REST API endpoints.
 
 Health check endpoints
 ----------------------
@@ -619,9 +619,9 @@ In the JSON body of the ``POST`` request you must specify the ``candidate`` fiel
 	:ref:`Be very careful <failover_healthcheck>` when using this endpoint, as this can cause data loss in certain situations. In most cases, :ref:`the switchover endpoint <switchover_api>` satisfies the administrator's needs. 
 
 
-``POST /switchover`` and ``POST /failover`` endpoints are used by ``patronictl switchover`` and ``patronictl failover``, respectively.
+``POST /switchover`` and ``POST /failover`` endpoints are used by :ref:`patronictl_switchover` and :ref:`patronictl_failover`, respectively.
 
-``DELETE /switchover`` is used by ``patronictl flush <cluster-name> switchover``.
+``DELETE /switchover`` is used by :ref:`patronictl flush cluster-name switchover <patronictl_flush_parameters>`.
 
 .. list-table:: Failover/Switchover comparison
    :widths: 25 25 25
@@ -680,15 +680,15 @@ Restart endpoint
 
 - ``DELETE /restart``: delete the scheduled restart
 
-``POST /restart`` and ``DELETE /restart`` endpoints are used by ``patronictl restart`` and ``patronictl flush <cluster-name> restart`` respectively.
+``POST /restart`` and ``DELETE /restart`` endpoints are used by :ref:`patronictl_restart` and :ref:`patronictl flush cluster-name restart <patronictl_flush_parameters>` respectively.
 
 
 Reload endpoint
 ---------------
 
-The ``POST /reload`` call will order Patroni to re-read and apply the configuration file. This is the equivalent of sending the ``SIGHUP`` signal to the Patroni process. In case you changed some of the Postgres parameters which require a restart (like **shared_buffers**), you still have to explicitly do the restart of Postgres by either calling the ``POST /restart`` endpoint or with the help of ``patronictl restart``.
+The ``POST /reload`` call will order Patroni to re-read and apply the configuration file. This is the equivalent of sending the ``SIGHUP`` signal to the Patroni process. In case you changed some of the Postgres parameters which require a restart (like **shared_buffers**), you still have to explicitly do the restart of Postgres by either calling the ``POST /restart`` endpoint or with the help of :ref:`patronictl_restart`.
 
-The reload endpoint is used by ``patronictl reload``.
+The reload endpoint is used by :ref:`patronictl_reload`.
 
 
 Reinitialize endpoint
@@ -698,4 +698,4 @@ Reinitialize endpoint
 
 The call might fail if Patroni is in a loop trying to recover (restart) a failed Postgres. In order to overcome this problem one can specify ``{"force":true}`` in the request body.
 
-The reinitialize endpoint is used by ``patronictl reinit``.
+The reinitialize endpoint is used by :ref:`patronictl_reinit`.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -9,7 +9,7 @@ A Patroni cluster has two interfaces to be protected from unauthorized access: t
 Protecting DCS
 ==============
 
-Patroni and patronictl both store and retrieve data to/from the DCS.
+Patroni and :ref:`patronictl` both store and retrieve data to/from the DCS.
 
 Despite DCS doesn't contain any sensitive information, it allows changing some of Patroni/Postgres configuration. Therefore the very first thing that should be protected is DCS itself.
 
@@ -22,7 +22,7 @@ Protecting the REST API
 
 Protecting the REST API is a more complicated task.
 
-The Patroni REST API is used by Patroni itself during the leader race, by the ``patronictl`` tool in order to perform failovers/switchovers/reinitialize/restarts/reloads, by HAProxy or any other kind of load balancer to perform HTTP health checks, and of course could also be used for monitoring.
+The Patroni REST API is used by Patroni itself during the leader race, by the :ref:`patronictl` tool in order to perform failovers/switchovers/reinitialize/restarts/reloads, by HAProxy or any other kind of load balancer to perform HTTP health checks, and of course could also be used for monitoring.
 
 From the point of view of security, REST API contains safe (``GET`` requests, only retrieve information) and unsafe (``PUT``, ``POST``, ``PATCH`` and ``DELETE`` requests, change the state of nodes) endpoints.
 
@@ -32,6 +32,6 @@ When TLS for the REST API is enabled and a PKI is established, mutual authentica
 
 The ``restapi`` section parameters enable TLS client authentication to the server. Depending on the value of the ``verify_client`` parameter, the API server requires a successful client certificate verification for both safe and unsafe API calls (``verify_client: required``), or only for unsafe API calls (``verify_client: optional``), or for no API calls (``verify_client: none``).
 
-The ``ctl`` section parameters enable TLS server authentication to the client (the ``patronictl`` tool which uses the same config as patroni). Set ``insecure: true`` to disable the server certificate verification by the client. See :ref:`settings <patronictl_settings>` for a detailed description of the TLS client parameters.
+The ``ctl`` section parameters enable TLS server authentication to the client (the :ref:`patronictl` tool which uses the same config as patroni). Set ``insecure: true`` to disable the server certificate verification by the client. See :ref:`settings <patronictl_settings>` for a detailed description of the TLS client parameters.
 
 Protecting the PostgreSQL database proper from unauthorized access is beyond the scope of this document and is covered in https://www.postgresql.org/docs/current/client-authentication.html

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -34,7 +34,7 @@ Bootstrap configuration
 .. note::
     Once Patroni has initialized the cluster for the first time and settings have been stored in the DCS, all future
     changes to the ``bootstrap.dcs`` section of the YAML configuration will not take any effect! If you want to change
-    them please use either ``patronictl edit-config`` or the Patroni :ref:`REST API <rest_api>`.
+    them please use either :ref:`patronictl_edit_config` or the Patroni :ref:`REST API <rest_api>`.
 
 -  **bootstrap**:
 
@@ -366,10 +366,10 @@ CTL
 
    -  **authentication**:
 
-      -  **username**: Basic-auth username for accessing protected REST API endpoints. If not provided patronictl will use the value provided for REST API "username" parameter.
-      -  **password**: Basic-auth password for accessing protected REST API endpoints. If not provided patronictl will use the value provided for REST API "password" parameter.
+      -  **username**: Basic-auth username for accessing protected REST API endpoints. If not provided :ref:`patronictl` will use the value provided for REST API "username" parameter.
+      -  **password**: Basic-auth password for accessing protected REST API endpoints. If not provided :ref:`patronictl` will use the value provided for REST API "password" parameter.
    -  **insecure**: Allow connections to REST API without verifying SSL certs.
-   -  **cacert**: Specifies the file with the CA_BUNDLE file or directory with certificates of trusted CAs to use while verifying REST API SSL certs. If not provided patronictl will use the value provided for REST API "cafile" parameter.
+   -  **cacert**: Specifies the file with the CA_BUNDLE file or directory with certificates of trusted CAs to use while verifying REST API SSL certs. If not provided :ref:`patronictl` will use the value provided for REST API "cafile" parameter.
    -  **certfile**: Specifies the file with the client certificate in the PEM format.
    -  **keyfile**: Specifies the file with the client secret key in the PEM format.
    -  **keyfile\_password**: Specifies a password for decrypting the client keyfile.
@@ -397,4 +397,4 @@ In addition to these predefined tags, you can also add your own ones:
 -  **key3**: ``1.4``
 -  **key4**: ``"RandomString"``
 
-Tags are visible in the :ref:`REST API <rest_api>` and ``patronictl list`` You can also check for an instance health using these tags. If the tag isn't defined for an instance, or if the respective value doesn't match the querying value, it will return HTTP Status Code 503.
+Tags are visible in the :ref:`REST API <rest_api>` and :ref:`patronictl_list` You can also check for an instance health using these tags. If the tag isn't defined for an instance, or if the respective value doesn't match the querying value, it will return HTTP Status Code 503.


### PR DESCRIPTION
This PR introduces a documentation page for `patronictl` application.

We adopted a top-down approach when writing this document. We start by describing the outer most parts, and then keep writing new sections that specialize the knowledge.

We basically added a section called `patronictl` to the left menu. Inside that section we created a page with this structure:

- `patronictl`: describes what it is
    - `Configuraiton`: how to configure `patronictl`
    - `Usage`: how to use the CLI. Inside this section, there are subsections for each of the subcommands exposed by `patronictl`, and each of them are described using the following subsubsections:
        - `Synopsis`: syntax of the command and its positional and optional arguments
        - `Description`: a description of what the command does
        - `Parameters`: a detailed description of the arguments and how to use them
        - `Examples`: one or more examples of execution of the command

References: PAT-200.