### PR TITLE
Don't fail if pg_hba/pg_ident contain comment lines

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -244,9 +244,10 @@ class ConfigWriter(object):
             self._fd.write(line)
             self._fd.write('\n')
 
-    def writelines(self, lines: List[str]) -> None:
+    def writelines(self, lines: List[Optional[str]]) -> None:
         for line in lines:
-            self.writeline(line)
+            if isinstance(line, str):
+                self.writeline(line)
 
     @staticmethod
     def escape(value: Any) -> str:  # Escape (by doubling) any single quotes or backslashes in given string


### PR DESCRIPTION
yaml parser interprets such lines as null and stores it as None into the array of the parsed values, which can not be handled by wrtie() function and crashes the whole bootstrap process.

It is relevant for pg_hba/pg_ident params. Like:
```
postgres:
  pg_hba:
        - #this is a comment
        - local   all             postgres                                peer
```
Even though it is not the proper value, it won't hurt if we just ignore it instead of failing completely.