### PR TITLE
Enhancement to `tox` behave tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -125,10 +125,11 @@ commands =
         --file features/Dockerfile
 allowlist_externals = docker
 
-[testenv:pg{12,13,14,15,16}-docker-behave-{etcd}-{lin,mac}]
+[testenv:pg{12,13,14,15,16}-docker-behave-{etcd,etcd3}-{lin,mac}]
 description = Run behaviour tests in patroni-dev docker container
 setenv =
     etcd: DCS=etcd
+    etcd3: DCS=etcd3
     {[common]postgres_matrix}
     CONTAINER_NAME = tox-{env_name}-{env:PYTHONHASHSEED}
 labels =
@@ -159,7 +160,7 @@ platform =
 ;    win: win32
     mac: darwin
 
-[testenv:py{36,38,39,310,311}-behave-{etcd}-{lin,win,mac}]
+[testenv:py{36,38,39,310,311}-behave-{etcd,etcd3}-{lin,win,mac}]
 description = Run behaviour tests (locally with tox)
 deps =
     -r requirements.txt
@@ -167,7 +168,8 @@ deps =
     coverage
     {[common]psycopg_deps}
 setenv =
-    DCS = {env:DCS:etcd}
+    etcd: DCS = {env:DCS:etcd}
+    etcd3: DCS = {env:DCS:etcd3}
 passenv =
     ETCD_UNSUPPORTED_ARCH
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -150,7 +150,7 @@ commands =
         --tty \
         {env:PATRONI_DEV_IMAGE:patroni-dev:{env:PG_MAJOR}} \
         tox run -x 'tox.env_list=py{[common]python_matrix}-behave-{env:DCS}-lin' \
-        -- --format plain {posargs}
+        -- {posargs}
 
 allowlist_externals =
     docker
@@ -173,7 +173,10 @@ setenv =
 passenv =
     ETCD_UNSUPPORTED_ARCH
 commands =
-    python3 -m behave {posargs}
+    python3 -m behave --format json --format plain --outfile result.json {posargs}
+    mv result.json features/output
+allowlist_externals =
+    mv
 platform =
     {[common]platforms}
 


### PR DESCRIPTION
This PR performs a couple changes to behave tests that are run through `tox`:

* Add `etcd3` as a possible DCS. Previously it only ran with `etcd`;
* Add a JSON report. That makes it easier to parse the results.

References: PAT-212.