### PR TITLE
Call check_psycopg() before process_arguments()

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -299,9 +299,9 @@ def main() -> None:
     """
     from patroni import check_psycopg
 
-    args = process_arguments()
-
     check_psycopg()
+
+    args = process_arguments()
 
     if os.getpid() != 1:
         return patroni_main(args.configfile)


### PR DESCRIPTION
Otherwise the last one is causing import of psycopg and fails with cryptic stacktrace, while the first one shows a nice human-readable error message.