### PR TITLE
[refactor] make it possible to integrate other mpp database

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -1154,7 +1154,15 @@ class RestApiHandler(BaseHTTPRequestHandler):
     def do_POST_citus(self) -> None:
         """Handle a ``POST`` request to ``/citus`` path.
 
-        Call :func:`~patroni.postgresql.CitusHandler.handle_event` to handle the request, then write a response with
+        Deprecate, dispatch to do_POST_formation
+        """
+        self.do_POST_formation()
+
+    @check_access
+    def do_POST_formation(self) -> None:
+        """Handle a ``POST`` request to ``/formation`` path.
+
+        Call :func:`~patroni.postgresql.AbstractHandler.handle_event` to handle the request, then write a response with
         HTTP status code ``200``.
 
         .. note::
@@ -1165,9 +1173,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
             return
 
         patroni = self.server.patroni
-        if patroni.postgresql.citus_handler.is_coordinator() and patroni.ha.is_leader():
+        formation_handler = patroni.postgresql.formation_handler
+        if formation_handler is not None and formation_handler.is_coordinator() and patroni.ha.is_leader():
             cluster = patroni.dcs.get_cluster()
-            patroni.postgresql.citus_handler.handle_event(cluster, request)
+            formation_handler.handle_event(cluster, request)
         self.write_response(200, 'OK')
 
     def parse_request(self) -> bool:

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -892,6 +892,13 @@ class Config(object):
             bootstrap = config.setdefault('bootstrap', {})
             dcs = bootstrap.setdefault('dcs', {})
             dcs.setdefault('synchronous_mode', True)
+            # propagate group id and cluster type
+            config['group'] = config['citus']['group']
+            config['cluster_type'] = 'citus'
+        elif 'greenplum' in config:
+            config['cluster_type'] = 'greenplum'
+        else:
+            config['cluster_type'] = 'postgresql'
 
         updated_fields = (
             'name',

--- a/patroni/dcs/consul.py
+++ b/patroni/dcs/consul.py
@@ -16,7 +16,7 @@ from urllib.parse import urlencode, urlparse, quote
 from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Union, Tuple, TYPE_CHECKING
 
 from . import AbstractDCS, Cluster, ClusterConfig, Failover, Leader, Member, Status, SyncState, \
-    TimelineHistory, ReturnFalseException, catch_return_false_exception, citus_group_re
+    TimelineHistory, ReturnFalseException, catch_return_false_exception, group_re
 from ..exceptions import DCSError
 from ..utils import deep_compare, parse_bool, Retry, RetryFailedError, split_host_port, uri, USER_AGENT
 if TYPE_CHECKING:  # pragma: no cover
@@ -419,7 +419,7 @@ class Consul(AbstractDCS):
     def _consistency(self) -> str:
         return 'consistent' if self._ctl else self._client.consistency
 
-    def _cluster_loader(self, path: str) -> Cluster:
+    def _postgresql_cluster_loader(self, path: str) -> Cluster:
         _, results = self.retry(self._client.kv.get, path, recurse=True, consistency=self._consistency)
         if results is None:
             raise NotFound
@@ -430,12 +430,12 @@ class Consul(AbstractDCS):
 
         return self._cluster_from_nodes(nodes)
 
-    def _citus_cluster_loader(self, path: str) -> Dict[int, Cluster]:
+    def _formation_cluster_loader(self, path: str) -> Dict[int, Cluster]:
         _, results = self.retry(self._client.kv.get, path, recurse=True, consistency=self._consistency)
         clusters: Dict[int, Dict[str, Cluster]] = defaultdict(dict)
         for node in results or []:
             key = node['Key'][len(path):].split('/', 1)
-            if len(key) == 2 and citus_group_re.match(key[0]):
+            if len(key) == 2 and group_re.match(key[0]):
                 node['Value'] = (node['Value'] or b'').decode('utf-8')
                 clusters[int(key[0])][key[1]] = node
         return {group: self._cluster_from_nodes(nodes) for group, nodes in clusters.items()}

--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -16,7 +16,7 @@ from threading import Condition, Lock, Thread
 from typing import Any, Callable, Collection, Dict, Iterator, List, Optional, Tuple, Type, TYPE_CHECKING, Union
 
 from . import ClusterConfig, Cluster, Failover, Leader, Member, Status, SyncState, \
-    TimelineHistory, catch_return_false_exception, citus_group_re
+    TimelineHistory, catch_return_false_exception, group_re
 from .etcd import AbstractEtcdClientWithFailover, AbstractEtcd, catch_etcd_errors, DnsCachingResolver, Retry
 from ..exceptions import DCSError, PatroniException
 from ..utils import deep_compare, enable_keepalive, iter_response_objects, RetryFailedError, USER_AGENT
@@ -703,7 +703,7 @@ class Etcd3(AbstractEtcd):
 
     @property
     def cluster_prefix(self) -> str:
-        return self._base_path + '/' if self.is_citus_coordinator() else self.client_path('')
+        return self._base_path + '/' if self.is_formation_coordinator() else self.client_path('')
 
     @staticmethod
     def member(node: Dict[str, str]) -> Member:
@@ -757,18 +757,18 @@ class Etcd3(AbstractEtcd):
 
         return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
 
-    def _cluster_loader(self, path: str) -> Cluster:
+    def _postgresql_cluster_loader(self, path: str) -> Cluster:
         nodes = {node['key'][len(path):]: node
                  for node in self._client.get_cluster(path)
                  if node['key'].startswith(path)}
         return self._cluster_from_nodes(nodes)
 
-    def _citus_cluster_loader(self, path: str) -> Dict[int, Cluster]:
+    def _formation_cluster_loader(self, path: str) -> Dict[int, Cluster]:
         clusters: Dict[int, Dict[str, Dict[str, Any]]] = defaultdict(dict)
         path = self._base_path + '/'
         for node in self._client.get_cluster(path):
             key = node['key'][len(path):].split('/', 1)
-            if len(key) == 2 and citus_group_re.match(key[0]):
+            if len(key) == 2 and group_re.match(key[0]):
                 clusters[int(key[0])][key[1]] = node
         return {group: self._cluster_from_nodes(nodes) for group, nodes in clusters.items()}
 

--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -20,7 +20,7 @@ from threading import Condition, Lock, Thread
 from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Type, Union, TYPE_CHECKING
 
 from . import AbstractDCS, Cluster, ClusterConfig, Failover, Leader, Member, Status, SyncState, \
-    TimelineHistory, CITUS_COORDINATOR_GROUP_ID, citus_group_re
+    TimelineHistory, group_re
 from ..exceptions import DCSError
 from ..utils import deep_compare, iter_response_objects, keepalive_socket_options, \
     Retry, RetryFailedError, tzutc, uri, USER_AGENT
@@ -746,7 +746,8 @@ class ObjectCache(Thread):
 
 class Kubernetes(AbstractDCS):
 
-    _CITUS_LABEL = 'citus-group'
+    # For backward compatibility, we keep citus-group here.
+    _CLUSTER_GROUP_LABEL = 'citus-group'
 
     def __init__(self, config: Dict[str, Any]) -> None:
         self._labels = deepcopy(config['labels'])
@@ -760,8 +761,8 @@ class Kubernetes(AbstractDCS):
         self._tmp_role_label = config.get('tmp_role_label')
         self._ca_certs = os.environ.get('PATRONI_KUBERNETES_CACERT', config.get('cacert')) or SERVICE_CERT_FILENAME
         super(Kubernetes, self).__init__({**config, 'namespace': ''})
-        if self._citus_group:
-            self._labels[self._CITUS_LABEL] = self._citus_group
+        if self._formation_group:
+            self._labels[self._CLUSTER_GROUP_LABEL] = self._formation_group
 
         self._retry = Retry(deadline=config['retry_timeout'], max_delay=1, max_tries=-1,
                             retry_exceptions=KubernetesRetriableException)
@@ -936,20 +937,20 @@ class Kubernetes(AbstractDCS):
 
         return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
 
-    def _cluster_loader(self, path: Dict[str, Any]) -> Cluster:
+    def _postgresql_cluster_loader(self, path: Dict[str, Any]) -> Cluster:
         return self._cluster_from_nodes(path['group'], path['nodes'], path['pods'].values())
 
-    def _citus_cluster_loader(self, path: Dict[str, Any]) -> Dict[int, Cluster]:
+    def _formation_cluster_loader(self, path: Dict[str, Any]) -> Dict[int, Cluster]:
         clusters: Dict[str, Dict[str, Dict[str, K8sObject]]] = defaultdict(lambda: defaultdict(dict))
 
         for name, pod in path['pods'].items():
-            group = pod.metadata.labels.get(self._CITUS_LABEL)
-            if group and citus_group_re.match(group):
+            group = pod.metadata.labels.get(self._CLUSTER_GROUP_LABEL)
+            if group and group_re.match(group):
                 clusters[group]['pods'][name] = pod
 
         for name, kind in path['nodes'].items():
-            group = kind.metadata.labels.get(self._CITUS_LABEL)
-            if group and citus_group_re.match(group):
+            group = kind.metadata.labels.get(self._CLUSTER_GROUP_LABEL)
+            if group and group_re.match(group):
                 clusters[group]['nodes'][name] = kind
         return {int(group): self._cluster_from_nodes(group, value['nodes'], value['pods'].values())
                 for group, value in clusters.items()}
@@ -965,9 +966,9 @@ class Kubernetes(AbstractDCS):
             with self._condition:
                 self._wait_caches(stop_time)
                 pods = {name: pod for name, pod in self._pods.copy().items()
-                        if not group or pod.metadata.labels.get(self._CITUS_LABEL) == group}
+                        if not group or pod.metadata.labels.get(self._CLUSTER_GROUP_LABEL) == group}
                 nodes = {name: kind for name, kind in self._kinds.copy().items()
-                         if not group or kind.metadata.labels.get(self._CITUS_LABEL) == group}
+                         if not group or kind.metadata.labels.get(self._CLUSTER_GROUP_LABEL) == group}
             return loader({'group': group, 'pods': pods, 'nodes': nodes})
         except Exception:
             logger.exception('get_cluster')
@@ -976,17 +977,17 @@ class Kubernetes(AbstractDCS):
     def _load_cluster(
             self, path: str, loader: Callable[[Any], Union[Cluster, Dict[int, Cluster]]]
     ) -> Union[Cluster, Dict[int, Cluster]]:
-        group = self._citus_group if path == self.client_path('') else None
+        group = self._formation_group if path == self.client_path('') else None
         return self.__load_cluster(group, loader)
 
-    def get_citus_coordinator(self) -> Optional[Cluster]:
+    def get_formation_coordinator_cluster(self) -> Optional[Cluster]:
         try:
-            ret = self.__load_cluster(str(CITUS_COORDINATOR_GROUP_ID), self._cluster_loader)
+            ret = self.__load_cluster(str(self.coordinator_group_id), self._postgresql_cluster_loader)
             if TYPE_CHECKING:  # pragma: no cover
                 assert isinstance(ret, Cluster)
             return ret
         except Exception as e:
-            logger.error('Failed to load Citus coordinator cluster from Kubernetes: %r', e)
+            logger.error('Failed to load formation coordinator cluster from Kubernetes: %r', e)
 
     @staticmethod
     def compare_ports(p1: K8sObject, p2: K8sObject) -> bool:

--- a/patroni/dcs/zookeeper.py
+++ b/patroni/dcs/zookeeper.py
@@ -13,7 +13,7 @@ from kazoo.security import ACL, make_acl
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple, TYPE_CHECKING
 
 from . import AbstractDCS, ClusterConfig, Cluster, Failover, Leader, Member, Status, SyncState, \
-    TimelineHistory, citus_group_re
+    TimelineHistory, group_re
 from ..exceptions import DCSError
 from ..utils import deep_compare
 if TYPE_CHECKING:  # pragma: no cover
@@ -213,7 +213,7 @@ class ZooKeeper(AbstractDCS):
                 members.append(self.member(member, *data))
         return members
 
-    def _cluster_loader(self, path: str) -> Cluster:
+    def _postgresql_cluster_loader(self, path: str) -> Cluster:
         nodes = set(self.get_children(path))
 
         # get initialize flag
@@ -257,11 +257,11 @@ class ZooKeeper(AbstractDCS):
 
         return Cluster(initialize, config, leader, status, members, failover, sync, history, failsafe)
 
-    def _citus_cluster_loader(self, path: str) -> Dict[int, Cluster]:
+    def _formation_cluster_loader(self, path: str) -> Dict[int, Cluster]:
         ret: Dict[int, Cluster] = {}
         for node in self.get_children(path):
-            if citus_group_re.match(node):
-                ret[int(node)] = self._cluster_loader(path + node + '/')
+            if group_re.match(node):
+                ret[int(node)] = self._postgresql_cluster_loader(path + node + '/')
         return ret
 
     def _load_cluster(

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -176,7 +176,7 @@ class Ha(object):
         # Count of concurrent sync disabling requests. Value above zero means that we don't want to be synchronous
         # standby. Changes protected by _member_state_lock.
         self._disable_sync = 0
-        # Remember the last known member role and state written to the DCS in order to notify Citus coordinator
+        # Remember the last known member role and state written to the DCS in order to notify Formation coordinator
         self._last_state = None
 
         # We need following property to avoid shutdown of postgres when join of Patroni to the postgres
@@ -328,20 +328,22 @@ class Ha(object):
             tags['nosync'] = True
         return tags
 
-    def notify_citus_coordinator(self, event: str) -> None:
-        if self.state_handler.citus_handler.is_worker():
-            coordinator = self.dcs.get_citus_coordinator()
+    def notify_formation_coordinator(self, event: str) -> None:
+        formation_handler = self.state_handler.formation_handler
+        if formation_handler is not None and formation_handler.is_worker():
+            coordinator = self.dcs.get_formation_coordinator_cluster()
             if coordinator and coordinator.leader and coordinator.leader.conn_url:
                 try:
                     data = {'type': event,
-                            'group': self.state_handler.citus_handler.group(),
+                            'group': formation_handler.group(),
                             'leader': self.state_handler.name,
                             'timeout': self.dcs.ttl,
                             'cooldown': self.patroni.config['retry_timeout']}
                     timeout = self.dcs.ttl if event == 'before_demote' else 2
-                    self.patroni.request(coordinator.leader.member, 'post', 'citus', data, timeout=timeout, retries=0)
+                    self.patroni.request(coordinator.leader.member, 'post', 'formation', data,
+                                         timeout=timeout, retries=0)
                 except Exception as e:
-                    logger.warning('Request to Citus coordinator leader %s %s failed: %r',
+                    logger.warning('Request to Formation coordinator leader %s %s failed: %r',
                                    coordinator.leader.name, coordinator.leader.member.api_url, e)
 
     def touch_member(self) -> bool:
@@ -404,7 +406,7 @@ class Ha(object):
             if ret:
                 new_state = (data['state'], {'master': 'primary'}.get(data['role'], data['role']))
                 if self._last_state != new_state and new_state == ('running', 'primary'):
-                    self.notify_citus_coordinator('after_promote')
+                    self.notify_formation_coordinator('after_promote')
                 self._last_state = new_state
             return ret
 
@@ -849,7 +851,8 @@ class Ha(object):
             self.state_handler.set_role('master')
             self.process_sync_replication()
             self.update_cluster_history()
-            self.state_handler.citus_handler.sync_pg_dist_node(self.cluster)
+            if self.state_handler.formation_handler is not None:
+                self.state_handler.formation_handler.sync_coordinator_meta(self.cluster)
             return message
         elif self.state_handler.role in ('master', 'promoted', 'primary'):
             self.process_sync_replication()
@@ -869,7 +872,7 @@ class Ha(object):
                 self._failsafe.set_is_active(0)
 
                 def before_promote():
-                    self.notify_citus_coordinator('before_promote')
+                    self.notify_formation_coordinator('before_promote')
 
                 with self._async_response:
                     self._async_response.reset()
@@ -1230,10 +1233,11 @@ class Ha(object):
                     status['released'] = True
 
         def before_shutdown() -> None:
-            if self.state_handler.citus_handler.is_coordinator():
-                self.state_handler.citus_handler.on_demote()
+            formation_handler = self.state_handler.formation_handler
+            if formation_handler is not None and formation_handler.is_coordinator():
+                formation_handler.on_demote()
             else:
-                self.notify_citus_coordinator('before_demote')
+                self.notify_formation_coordinator('before_demote')
 
         self.state_handler.stop(str(mode_control['stop']), checkpoint=bool(mode_control['checkpoint']),
                                 on_safepoint=self.watchdog.disable if self.watchdog.is_running else None,
@@ -1535,10 +1539,10 @@ class Ha(object):
         self.set_start_timeout(timeout)
 
         def before_shutdown() -> None:
-            self.notify_citus_coordinator('before_demote')
+            self.notify_formation_coordinator('before_demote')
 
         def after_start() -> None:
-            self.notify_citus_coordinator('after_promote')
+            self.notify_formation_coordinator('after_promote')
 
         # For non async cases we want to wait for restart to complete or timeout before returning.
         do_restart = functools.partial(self.state_handler.restart, timeout, self._async_executor.critical_task,
@@ -1995,7 +1999,7 @@ class Ha(object):
                         self.dcs.write_leader_optime(checkpoint_location)
 
             def _before_shutdown() -> None:
-                self.notify_citus_coordinator('before_demote')
+                self.notify_formation_coordinator('before_demote')
 
             on_shutdown = _on_shutdown if self.is_leader() else None
             before_shutdown = _before_shutdown if self.is_leader() else None

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -433,8 +433,9 @@ END;$$""".format(f, quote_ident(rewind['username'], postgresql.connection()))
                             time.sleep(1)  # give a time to postgres to "reload" configuration files
                             postgresql.connection().close()  # close connection to reconnect with a new password
                 else:  # initdb
-                    # We may want create database and extension for citus
-                    self._postgresql.citus_handler.bootstrap()
+                    # We may want create database and extension for formation clusters
+                    if self._postgresql.formation_handler is not None:
+                        self._postgresql.formation_handler.bootstrap()
         except Exception:
             logger.exception('post_bootstrap')
             task.complete(False)

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -955,7 +955,8 @@ class ConfigHandler(object):
             wal_keep_size = parse_int(parameters.pop('wal_keep_size', self.CMDLINE_OPTIONS['wal_keep_size'][0]), 'MB')
             parameters.setdefault('wal_keep_segments', int(((wal_keep_size or 0) + 8) / 16))
 
-        self._postgresql.citus_handler.adjust_postgres_gucs(parameters)
+        if self._postgresql.formation_handler is not None:
+            self._postgresql.formation_handler.adjust_postgres_gucs(parameters)
 
         ret = CaseInsensitiveDict({k: v for k, v in parameters.items() if not self._postgresql.major_version
                                    or self._postgresql.major_version >= self.CMDLINE_OPTIONS.get(k, (0, 1, 90100))[2]})

--- a/patroni/postgresql/handler.py
+++ b/patroni/postgresql/handler.py
@@ -1,0 +1,62 @@
+
+
+"""Abstract class for Formation Cluster Handler."""
+import abc
+from threading import Thread
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+from patroni.dcs import Cluster
+
+if TYPE_CHECKING:  # pragma: no cover
+    from . import Postgresql
+
+
+class AbstractHandler(Thread):
+
+    def __init__(self, postgresql: 'Postgresql', config: Optional[Dict[str, Union[str, int]]]) -> None:
+        super(AbstractHandler, self).__init__()
+        self.daemon = True
+        self._postgresql = postgresql
+        self._config = config
+
+    def is_enabled(self) -> bool:
+        return isinstance(self._config, dict)
+
+    @abc.abstractmethod
+    def is_coordinator(self) -> bool:
+        """Am I the Coordinator cluster of the formation?"""
+
+    def is_worker(self) -> bool:
+        """Am I a Worker cluster of the formation?"""
+        return self.is_enabled() and not self.is_coordinator()
+
+    def group(self) -> Optional[int]:
+        return int(self._config['group']) if isinstance(self._config, dict) else None
+
+    @abc.abstractmethod
+    def bootstrap(self) -> None:
+        """Behaviour should be taken after the PostgreSQL instance started."""
+
+    @abc.abstractmethod
+    def handle_event(self, cluster: Cluster, event: Dict[str, Any]) -> None:
+        """Handle events from restapi."""
+
+    @abc.abstractmethod
+    def schedule_cache_rebuild(self) -> None:
+        """"""
+
+    @abc.abstractmethod
+    def sync_coordinator_meta(self, cluster: Cluster) -> None:
+        """"""
+
+    @abc.abstractmethod
+    def on_demote(self) -> None:
+        """Behaviour should be taken when demoting the instance."""
+
+    @abc.abstractmethod
+    def adjust_postgres_gucs(self, parameters: Dict[str, Any]) -> None:
+        """"""
+
+    @abc.abstractmethod
+    def ignore_replication_slot(self, slot: Dict[str, str]) -> bool:
+        """"""

--- a/patroni/postgresql/slots.py
+++ b/patroni/postgresql/slots.py
@@ -289,7 +289,7 @@ class SlotsHandler:
         :param name: name of the slot to ignore
 
         :returns: ``True`` if slot *name* matches any slot specified in ``ignore_slots`` configuration,
-                 otherwise will pass through and return result of :meth:`CitusHandler.ignore_replication_slot`.
+                 otherwise will pass through and return result of :meth:`AbstractHandler.ignore_replication_slot`.
         """
         slot = self._replication_slots[name]
         if cluster.config:
@@ -300,7 +300,9 @@ class SlotsHandler:
                                 for a in ('database', 'plugin', 'type'))
                 ):
                     return True
-        return self._postgresql.citus_handler.ignore_replication_slot(slot)
+        if self._postgresql.formation_handler is not None:
+            return self._postgresql.formation_handler.ignore_replication_slot(slot)
+        return False
 
     def drop_replication_slot(self, name: str) -> Tuple[bool, bool]:
         """Drop a named slot from Postgres.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,7 +60,7 @@ class MockPostgresql:
     wal_flush = '_flush'
     POSTMASTER_START_TIME = 'pg_catalog.pg_postmaster_start_time()'
     TL_LSN = 'CASE WHEN pg_catalog.pg_is_in_recovery()'
-    citus_handler = Mock()
+    formation_handler = Mock()
 
     @staticmethod
     def postmaster_start_time():

--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -6,13 +6,13 @@ from . import BaseTestPostgresql, MockCursor, psycopg_connect, SleepException
 from .test_ha import get_cluster_initialized_with_leader
 
 
-@patch('patroni.postgresql.citus.Thread', Mock())
+@patch('patroni.postgresql.handler.Thread', Mock())
 @patch('patroni.psycopg.connect', psycopg_connect)
 class TestCitus(BaseTestPostgresql):
 
     def setUp(self):
         super(TestCitus, self).setUp()
-        self.c = self.p.citus_handler
+        self.c = self.p.formation_handler
         self.cluster = get_cluster_initialized_with_leader()
         self.cluster.workers[1] = self.cluster
 

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -130,7 +130,8 @@ class TestConsul(unittest.TestCase):
         self.assertIsInstance(self.c.get_cluster(), Cluster)
 
     def test__get_citus_cluster(self):
-        self.c._citus_group = '0'
+        self.c._formation_group = '0'
+        self.c._cluster_type = 'citus'
         cluster = self.c.get_cluster()
         self.assertIsInstance(cluster, Cluster)
         self.assertIsInstance(cluster.workers[1], Cluster)

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -27,6 +27,8 @@ DEFAULT_CONFIG = {
     'ctl': {'certfile': 'a'},
     'etcd': {'host': 'localhost:2379'},
     'citus': {'database': 'citus', 'group': 0},
+    'group': 0,
+    'cluster_type': 'citus',
     'postgresql': {'data_dir': '.', 'pgpass': './pgpass', 'parameters': {}, 'retry_timeout': 5}
 }
 

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -270,7 +270,8 @@ class TestEtcd(unittest.TestCase):
         self.assertRaises(EtcdError, self.etcd.get_cluster)
 
     def test__get_citus_cluster(self):
-        self.etcd._citus_group = '0'
+        self.etcd._formation_group = '0'
+        self.etcd._cluster_type = 'citus'
         cluster = self.etcd.get_cluster()
         self.assertIsInstance(cluster, Cluster)
         self.assertIsInstance(cluster.workers[1], Cluster)

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -229,7 +229,8 @@ class TestEtcd3(BaseTestEtcd3):
             self.assertRaises(Etcd3Error, self.etcd3.get_cluster)
 
     def test__get_citus_cluster(self):
-        self.etcd3._citus_group = '0'
+        self.etcd3._formation_group = '0'
+        self.etcd3._cluster_type = 'citus'
         cluster = self.etcd3.get_cluster()
         self.assertIsInstance(cluster, Cluster)
         self.assertIsInstance(cluster.workers[1], Cluster)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1538,7 +1538,7 @@ class TestHa(PostgresInit):
         self.ha.patroni.request = Mock()
         self.ha.shutdown()
         self.ha.patroni.request.assert_called()
-        self.assertEqual(self.ha.patroni.request.call_args[0][2], 'citus')
+        self.assertEqual(self.ha.patroni.request.call_args[0][2], 'formation')
         self.assertEqual(self.ha.patroni.request.call_args[0][3]['type'], 'before_demote')
 
     @patch('time.sleep', Mock())
@@ -1641,12 +1641,12 @@ class TestHa(PostgresInit):
     @patch('patroni.postgresql.citus.CitusHandler.is_coordinator', Mock(return_value=False))
     def test_notify_citus_coordinator(self):
         self.ha.patroni.request = Mock()
-        self.ha.notify_citus_coordinator('before_demote')
+        self.ha.notify_formation_coordinator('before_demote')
         self.ha.patroni.request.assert_called_once()
         self.assertEqual(self.ha.patroni.request.call_args[1]['timeout'], 30)
         self.ha.patroni.request = Mock(side_effect=Exception)
         with patch('patroni.ha.logger.warning') as mock_logger:
-            self.ha.notify_citus_coordinator('before_promote')
+            self.ha.notify_formation_coordinator('before_promote')
             self.assertEqual(self.ha.patroni.request.call_args[1]['timeout'], 2)
             mock_logger.assert_called()
-            self.assertTrue(mock_logger.call_args[0][0].startswith('Request to Citus coordinator'))
+            self.assertTrue(mock_logger.call_args[0][0].startswith('Request to Formation coordinator'))

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -26,16 +26,16 @@ def mock_list_namespaced_config_map(*args, **kwargs):
     items.append(k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata)))
     metadata.update({'name': 'test-sync', 'annotations': {'leader': 'p-0'}})
     items.append(k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata)))
-    metadata.update({'name': 'test-0-leader', 'labels': {Kubernetes._CITUS_LABEL: '0'},
+    metadata.update({'name': 'test-0-leader', 'labels': {Kubernetes._CLUSTER_GROUP_LABEL: '0'},
                      'annotations': {'optime': '1234x', 'leader': 'p-0', 'ttl': '30s', 'slots': '{', 'failsafe': '{'}})
     items.append(k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata)))
-    metadata.update({'name': 'test-0-config', 'labels': {Kubernetes._CITUS_LABEL: '0'},
+    metadata.update({'name': 'test-0-config', 'labels': {Kubernetes._CLUSTER_GROUP_LABEL: '0'},
                      'annotations': {'initialize': '123', 'config': '{}'}})
     items.append(k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata)))
-    metadata.update({'name': 'test-1-leader', 'labels': {Kubernetes._CITUS_LABEL: '1'},
+    metadata.update({'name': 'test-1-leader', 'labels': {Kubernetes._CLUSTER_GROUP_LABEL: '1'},
                      'annotations': {'leader': 'p-3', 'ttl': '30s'}})
     items.append(k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata)))
-    metadata.update({'name': 'test-2-config', 'labels': {Kubernetes._CITUS_LABEL: '2'}, 'annotations': {}})
+    metadata.update({'name': 'test-2-config', 'labels': {Kubernetes._CLUSTER_GROUP_LABEL: '2'}, 'annotations': {}})
     items.append(k8s_client.V1ConfigMap(metadata=k8s_client.V1ObjectMeta(**metadata)))
 
     metadata = k8s_client.V1ObjectMeta(resource_version='1')
@@ -60,7 +60,7 @@ def mock_list_namespaced_endpoints(*args, **kwargs):
 
 
 def mock_list_namespaced_pod(*args, **kwargs):
-    metadata = k8s_client.V1ObjectMeta(resource_version='1', labels={'f': 'b', Kubernetes._CITUS_LABEL: '1'},
+    metadata = k8s_client.V1ObjectMeta(resource_version='1', labels={'f': 'b', Kubernetes._CLUSTER_GROUP_LABEL: '1'},
                                        name='p-0', annotations={'status': '{}'},
                                        uid='964dfeae-e79b-4476-8a5a-1920b5c2a69d')
     status = k8s_client.V1PodStatus(pod_ip='10.0.0.1')
@@ -229,7 +229,7 @@ class BaseTestKubernetes(unittest.TestCase):
         config.update(ttl=30, scope='test', name='p-0', loop_wait=10, group=0,
                       retry_timeout=10, labels={'f': 'b'}, bypass_api_service=True)
         self.k = Kubernetes(config)
-        self.k._citus_group = None
+        self.k._formation_group = None
         self.assertRaises(AttributeError, self.k._pods._build_cache)
         self.k._pods._is_ready = True
         self.assertRaises(TypeError, self.k._kinds._build_cache)
@@ -254,18 +254,19 @@ class TestKubernetesConfigMaps(BaseTestKubernetes):
             self.assertRaises(KubernetesError, self.k.get_cluster)
 
     def test__get_citus_cluster(self):
-        self.k._citus_group = '0'
+        self.k._formation_group = '0'
+        self.k._cluster_type = 'citus'
         cluster = self.k.get_cluster()
         self.assertIsInstance(cluster, Cluster)
         self.assertIsInstance(cluster.workers[1], Cluster)
 
     @patch('patroni.dcs.kubernetes.logger.error')
     def test_get_citus_coordinator(self, mock_logger):
-        self.assertIsInstance(self.k.get_citus_coordinator(), Cluster)
-        with patch.object(Kubernetes, '_cluster_loader', Mock(side_effect=Exception)):
-            self.assertIsNone(self.k.get_citus_coordinator())
+        self.assertIsInstance(self.k.get_formation_coordinator_cluster(), Cluster)
+        with patch.object(Kubernetes, '_postgresql_cluster_loader', Mock(side_effect=Exception)):
+            self.assertIsNone(self.k.get_formation_coordinator_cluster())
             mock_logger.assert_called()
-            self.assertTrue(mock_logger.call_args[0][0].startswith('Failed to load Citus coordinator'))
+            self.assertTrue(mock_logger.call_args[0][0].startswith('Failed to load formation coordinator cluster'))
 
     def test_attempt_to_acquire_leader(self):
         with patch.object(k8s_client.CoreV1Api, 'patch_namespaced_config_map', create=True) as mock_patch:
@@ -466,7 +467,7 @@ class TestCacheBuilder(BaseTestKubernetes):
     @patch('patroni.dcs.kubernetes.ObjectCache._watch', mock_watch)
     @patch.object(urllib3.HTTPResponse, 'read_chunked')
     def test__build_cache(self, mock_read_chunked):
-        self.k._citus_group = '0'
+        self.k._formation_group = '0'
         mock_read_chunked.return_value = [json.dumps(
             {'type': 'MODIFIED', 'object': {'metadata': {
                 'name': self.k.config_path, 'resourceVersion': '2', 'annotations': {self.k._CONFIG: 'foo'}}}}

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -130,7 +130,7 @@ class TestRaft(unittest.TestCase):
     def test_raft(self):
         raft = Raft({'ttl': 30, 'scope': 'test', 'name': 'pg', 'self_addr': '127.0.0.1:1234',
                      'retry_timeout': 10, 'data_dir': self._TMP,
-                     'database': 'citus', 'group': 0})
+                     'database': 'citus', 'group': 0, 'cluster_type': 'citus'})
         raft.reload_config({'retry_timeout': 20, 'ttl': 60, 'loop_wait': 10})
         self.assertTrue(raft._sync_obj.set(raft.members_path + 'legacy', '{"version":"2.0.0"}'))
         self.assertTrue(raft.touch_member(''))
@@ -139,9 +139,9 @@ class TestRaft(unittest.TestCase):
         self.assertTrue(raft.set_config_value('{}'))
         self.assertTrue(raft.write_sync_state('foo', 'bar'))
         self.assertFalse(raft.write_sync_state('foo', 'bar', 1))
-        raft._citus_group = '1'
+        raft._formation_group = '1'
         self.assertTrue(raft.manual_failover('foo', 'bar'))
-        raft._citus_group = '0'
+        raft._formation_group = '0'
         self.assertTrue(raft.take_leader())
         cluster = raft.get_cluster()
         self.assertIsInstance(cluster, Cluster)
@@ -153,13 +153,13 @@ class TestRaft(unittest.TestCase):
         self.assertTrue(raft.update_leader(leader, '1', failsafe={'foo': 'bat'}))
         self.assertTrue(raft._sync_obj.set(raft.failsafe_path, '{"foo"}'))
         self.assertTrue(raft._sync_obj.set(raft.status_path, '{'))
-        raft.get_citus_coordinator()
+        raft._get_formation_cluster()
         self.assertTrue(raft.delete_sync_state())
         self.assertTrue(raft.set_history_value(''))
         self.assertTrue(raft.delete_cluster())
-        raft._citus_group = '1'
+        raft._group = '1'
         self.assertTrue(raft.delete_cluster())
-        raft._citus_group = None
+        raft._group = None
         raft.get_cluster()
         raft.watch(None, 0.001)
         raft._sync_obj.destroy()

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -164,29 +164,30 @@ class TestZooKeeper(unittest.TestCase):
 
     def test__cluster_loader(self):
         self.zk._base_path = self.zk._base_path.replace('test', 'bla')
-        self.zk._cluster_loader(self.zk.client_path(''))
+        self.zk._postgresql_cluster_loader(self.zk.client_path(''))
         self.zk._base_path = self.zk._base_path = '/broken'
-        self.zk._cluster_loader(self.zk.client_path(''))
+        self.zk._postgresql_cluster_loader(self.zk.client_path(''))
         self.zk._base_path = self.zk._base_path = '/legacy'
-        self.zk._cluster_loader(self.zk.client_path(''))
+        self.zk._postgresql_cluster_loader(self.zk.client_path(''))
         self.zk._base_path = self.zk._base_path = '/no_node'
-        self.zk._cluster_loader(self.zk.client_path(''))
+        self.zk._postgresql_cluster_loader(self.zk.client_path(''))
 
     def test_get_cluster(self):
         cluster = self.zk.get_cluster()
         self.assertEqual(cluster.last_lsn, 500)
 
     def test__get_citus_cluster(self):
-        self.zk._citus_group = '0'
+        self.zk._formation_group = '0'
+        self.zk._cluster_type = 'citus'
         for _ in range(0, 2):
             cluster = self.zk.get_cluster()
             self.assertIsInstance(cluster, Cluster)
             self.assertIsInstance(cluster.workers[1], Cluster)
 
     @patch('patroni.dcs.zookeeper.logger.error')
-    @patch.object(ZooKeeper, '_cluster_loader', Mock(side_effect=Exception))
-    def test_get_citus_coordinator(self, mock_logger):
-        self.assertIsNone(self.zk.get_citus_coordinator())
+    @patch.object(ZooKeeper, '_postgresql_cluster_loader', Mock(side_effect=Exception))
+    def test_get_formation_coordinator_cluster(self, mock_logger):
+        self.assertIsNone(self.zk.get_formation_coordinator_cluster())
         mock_logger.assert_called_once()
 
     def test_delete_leader(self):


### PR DESCRIPTION
Citus is one successful mpp architecture, besides it, there are many
other mpp dbs which are based on postgresql, so it might be a good
idea to make Patroni extendable for other mpp dbs.

The two key points for Patroni to support Citus is:

1. a DCS hierarchy with an extra ''group'' level for citus
2. CitusHandler to update pg_dist_node when failover happens

To make Patroni extenable, I'd first like to clarify the 5 meanings
of *cluster* in Patroni.

1. Postgresql cluster: a cluster of postgresql instances which
   have the same system identifier.
2. Formation cluster: a cluster of Postgresql cluster which contains
   different data in each Postgresql cluster, usually one Postgresql
   cluster acts as coordinator, and other Postgresql clusters act as
   workers.
3. Coordinator cluster: a Postgresql cluster which has the role
   'coordinator' within a Formation cluster.
4. Worker cluster: a Postgresql cluster which has the role 'worker'
   within a Formation cluster.
5. Patroni cluster: all cluster managed by Patroni are called Patroni
   cluster, including Postgresql cluster and Formation cluster.

Then the two main efforts of this patch are:

1. dcs: get rid of Citus specific code(like the cluster loader) and
   instead introduce formation group, cluter type when initializing
   concrete dcs class.
2. create a AbstractHandler, define some hooks that module
   `Postgresql` and `HA` should call when things happens. Let
   CitusHandler inherit it, and implement the interfaces by defining
   what citus should do in each phase. Other mpp dbs can integrate
   themselves by implement another xxxHandler.

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>