### PR TITLE
Authenticate and retry when etcd returns "revision of auth store is old" error

### DIFF
--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -138,6 +138,10 @@ class InvalidAuthToken(Etcd3ClientError):
     error = "etcdserver: invalid auth token"
 
 
+class RevisionOfAuthStoreIsOld(InvalidArgument):
+    error = "etcdserver: revision of auth store is old"
+
+
 errStringToClientError = {getattr(s, 'error'): s for s in Etcd3ClientError.get_subclasses() if hasattr(s, 'error')}
 errCodeToClientError = {getattr(s, 'code'): s for s in Etcd3ClientError.__subclasses__()}
 
@@ -320,6 +324,9 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
                 raise UnsupportedEtcdVersion('Authentication is required by Etcd cluster but not '
                                              'supported on version lower than 3.3.0. Cluster version: '
                                              '{0}'.format('.'.join(map(str, self._cluster_version))))
+            return retry(e)
+        except RevisionOfAuthStoreIsOld as e:
+            logger.error('Auth token is for old revision of auth store')
             return retry(e)
         except InvalidAuthToken as e:
             logger.error('Invalid auth token: %s', self._token)


### PR DESCRIPTION
From https://etcd.io/docs/v3.5/learning/design-auth-v3/#notes-on-the-implementation-of-authenticate-rpc, when etcd creates an auth token, it has an associated auth store revision number. If the auth store changes (ex: a new user is added), then the auth store revision is updated. Attempts to use auth tokens with old auth store revisions return an error (https://github.com/etcd-io/etcd/blob/6d68ab092d30e539308e6c6d9e286b3cd81a8f04/server/auth/store.go#L874).

# Current behavior

Currently, the etcd client does not re-authenticate if it gets an error about the auth revision being old.

To replicate:
1. Start an etcd server:
```bash
echo "my private key" > priv_key.txt
etcd \
  --log-level debug \
  --auth-token 'jwt,sign-method=HS512,priv-key=priv_key.txt' \
  --auth-token-ttl 999999999
```
2. Enable auth:
```bash
etcdctl role add root
etcdctl user add root --new-user-password="rootpw"
etcdctl user grant-role root root

etcdctl role add role1
etcdctl role grant-permission role1 readwrite --prefix=true /
etcdctl user add user1 --new-user-password "user1pw"
etcdctl user grant-role user1 role1

etcdctl auth enable
```
3. Create an `Etcd3Client` and verify it can `put`:
```bash
$ venv/bin/python
Python 3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 15.0.0 (clang-1500.0.40.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from patroni.dcs import etcd3
>>> from patroni.dcs.etcd import DnsCachingResolver
>>> client = etcd3.Etcd3Client({
...   'host': '127.0.0.1',
...   'port': 2379,
...   'username': 'user1',
...   'password': 'user1pw',
...   'retry_timeout': 5,
...   'version_prefix': '/v3',
... }, DnsCachingResolver())
>>> client.put('/patronikey', 'patronivalue')
{'header': {'cluster_id': '14841639068965178418', 'member_id': '10276657743932975437', 'revision': '2', 'raft_term': '2'}}
```
4. Add a new etcd user
```bash
etcdctl user --user root --password rootpw add user2 --new-user-password "user2pw"
```
5. Attempting to `put` again throws an error:
```python
>>> client.put('/patronikey', 'patronivalue')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kedo/Workspace/kennydo/patroni/patroni/dcs/etcd3.py", line 198, in wrapper
    return self.handle_auth_errors(func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kedo/Workspace/kennydo/patroni/patroni/dcs/etcd3.py", line 315, in handle_auth_errors
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kedo/Workspace/kennydo/patroni/patroni/dcs/etcd3.py", line 364, in put
    return self.call_rpc('/kv/put', fields, retry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kedo/Workspace/kennydo/patroni/patroni/dcs/etcd3.py", line 283, in call_rpc
    return self.api_execute(self.version_prefix + method, self._MPOST, fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kedo/Workspace/kennydo/patroni/patroni/dcs/etcd.py", line 283, in api_execute
    return self._handle_server_response(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kedo/Workspace/kennydo/patroni/patroni/dcs/etcd3.py", line 241, in _handle_server_response
    raise _raise_for_data(ret or data, response.status)
patroni.dcs.etcd3.InvalidArgument: <InvalidArgument error: 'etcdserver: revision of auth store is old', code: 3>
```

I expected the etcd3 client to re-authenticate and retry.

# This change

This change makes it so that the etcd client re-authenticates and retries if it receives the old auth store revision error.

Between these two `put`s, I added a new user. It logs about the old auth store revision and then retries:
```
>>> client.put('/patronikey', 'patronivalue')
{'header': {'cluster_id': '14841639068965178418', 'member_id': '10276657743932975437', 'revision': '2', 'raft_term': '2'}}

>>> client.put('/patronikey', 'patronivalue')
Auth token is for old revision of auth store
{'header': {'cluster_id': '14841639068965178418', 'member_id': '10276657743932975437', 'revision': '3', 'raft_term': '2'}}
```