### PR TITLE
Update README.md to reflect changes in etcd v3

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -78,7 +78,7 @@ Example session:
     |   demo  | patroni3 | 172.22.0.4 |        | running |  1 |         0 |
     +---------+----------+------------+--------+---------+----+-----------+
 
-    postgres@patroni1:~$ etcdctl ls --recursive --sort -p /service/demo
+    postgres@patroni1:~$ etcdctl get --keys-only --prefix /service/demo
     /service/demo/config
     /service/demo/initialize
     /service/demo/leader


### PR DESCRIPTION
In etcdctl v3 the ls command isn't present anymore, it has to be changed to etcdctl get --keys-only --prefix (as already used in the citus paragraph)