### PR TITLE
fix inefficient validate_host_port

### DIFF
--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -51,6 +51,31 @@ def validate_connect_address(address: str) -> bool:
     return True
 
 
+def is_valid_host(host: str):
+    # Check if the host is a valid IPv4 address
+    try:
+        socket.inet_aton(host)
+        return True
+    except socket.error:
+        pass
+
+    # Check if the host is a valid IPv6 address
+    try:
+        socket.inet_pton(socket.AF_INET6, host)
+        return True
+    except socket.error:
+        pass
+
+    # Check if the host is a valid domain name
+    try:
+        socket.gethostbyname(host)
+        return True
+    except socket.error:
+        pass
+
+    return False
+
+
 def validate_host_port(host_port: str, listen: bool = False, multiple_hosts: bool = False) -> bool:
     """Check if host(s) and port are valid and available for usage.
 
@@ -91,6 +116,8 @@ def validate_host_port(host_port: str, listen: bool = False, multiple_hosts: boo
         for host in hosts:
             # Check if "socket.IF_INET" or "socket.IF_INET6" is being used and instantiate a socket with the identified
             # protocol
+            if not is_valid_host(host):
+                raise ConfigParseError("{} is not a valid host address".format(host))
             proto = socket.getaddrinfo(host, "", 0, socket.SOCK_STREAM, 0, socket.AI_PASSIVE)
             s = socket.socket(proto[0][0], socket.SOCK_STREAM)
             try:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -175,11 +175,12 @@ class TestValidator(unittest.TestCase):
         c = copy.deepcopy(config)
         c["restapi"]["connect_address"] = 'False:blabla'
         c["postgresql"]["listen"] = '*:543'
-        c["etcd"]["hosts"] = ["127.0.0.1:2379", "1244.0.0.1:2379", "127.0.0.1:invalidport"]
+        c["etcd"]["hosts"] = ["127.0.0.1:2379", "1244.0.0.1:2379", "127.0.0.1:invalidport",
+                              "[2001:0db8:85a3:::8a2e:0370:7334]:8080", "example.com:2379"]
         c["kubernetes"]["pod_ip"] = "127.0.0.1111"
         errors = schema(c)
         output = "\n".join(errors)
-        self.assertEqual(['etcd.hosts.1', 'etcd.hosts.2', 'kubernetes.pod_ip', 'postgresql.bin_dir',
+        self.assertEqual(['etcd.hosts.1', 'etcd.hosts.2', 'etcd.hosts.3', 'kubernetes.pod_ip', 'postgresql.bin_dir',
                           'postgresql.data_dir', 'raft.bind_addr', 'raft.self_addr',
                           'restapi.connect_address'], parse_output(output))
 


### PR DESCRIPTION
The check in validate_host_port is not sufficient to tell 1244.0.0.1 is an illegal ip address. 
Case `test_bin_dir_is_file` blames as described in #2915.