### PR TITLE
get rid of stale comment of get_cluster

### DIFF
--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1597,7 +1597,7 @@ class AbstractDCS(abc.ABC):
         return cluster
 
     def get_cluster(self) -> Cluster:
-        """Retrieve an appropriate cached or fresh view of DCS.
+        """Retrieve a fresh view of DCS.
 
         .. note::
             Stores copy of time, status and failsafe values for comparison in DCS update decisions.


### PR DESCRIPTION
PR #2909 remove the cache in Zookeeper implementation of DCS, so the comment of get_cluster should be changed to 'Retrieve a fresh view of DCS' since every implementation does so.