### PR TITLE
Add capability of specifying namespace through `--dcs` argument

### DIFF
--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -52,9 +52,9 @@ Before jumping into each of the sub-commands of ``patronictl``, be aware that ``
 ``-d`` / ``--dcs-url`` / ``--dcs``
     Provide a connection string to the DCS used by Patroni.
 
-    This argument can be used either to override the DCS settings from the ``patronictl`` configuration, or to define it if it's missing in the configuration.
+    This argument can be used either to override the DCS and ``namespace`` settings from the ``patronictl`` configuration, or to define it if it's missing in the configuration.
 
-    The value should be in the format ``DCS://HOST:PORT``, e.g. ``etcd3://localhost:2379`` to connect to etcd v3 running on ``localhost``.
+    The value should be in the format ``DCS://HOST:PORT/NAMESPACE``, e.g. ``etcd3://localhost:2379/service`` to connect to etcd v3 running on ``localhost`` with Patroni cluster stored under ``service`` namespace. Any part that is missing in the argument value will be replaced with the value present in the configuration or with its default.
 
 ``-k`` / ``--insecure``
     Flag to bypass validation of REST API server SSL certificate.


### PR DESCRIPTION
This commit changes the `patronictl` application in such a way its `--dcs` argument is now able to receive a namespace.

Previous to this commit this was the format of that argument's value: `DCS://HOST:PORT`.

From now on it accepts this format: `DCS://HORT:PORT/NAMESPACE`. As all previous parts of the argument value, `NAMESPACE` is optional, and if not given `patronictl` will fallback to the value from the configuration file, if any, or to `service`.

This change is specifically useful when you are running a cluster in a custom namespace, and from a machine where you don't have a configuration file for Patroni or `patronictl`. It can avoid that you would have to create a configuration file only with `namespace` filed in that case.

References: PAT-219.

Issue reported by: Shaun Thomas <shaun@bonesmoses.org>