### PR TITLE
Add a contrib script for remote Barman recovery

### DIFF
--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -86,7 +86,7 @@ As an example, you are able to bootstrap a fresh Patroni cluster from a Barman b
 
 .. note::
     ``patroni_barman_recover`` requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
-    The above example used a subset of the available parameters. You can get more information running ``patroni_barman_recover --help``.
+    The above example uses a subset of the available parameters. You can get more information running ``patroni_barman_recover --help``.
 
 .. _custom_replica_creation:
 
@@ -159,7 +159,7 @@ example: Barman
 
 .. note::
     ``patroni_barman_recover`` requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
-    The above example used a subset of the available parameters. You can get more information running ``patroni_barman_recover --help``.
+    The above example uses a subset of the available parameters. You can get more information running ``patroni_barman_recover --help``.
 
 The ``create_replica_methods`` defines available replica creation methods and the order of executing them. Patroni will
 stop on the first one that returns 0. Each method should define a separate section in the configuration file, listing the command

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -87,6 +87,7 @@ As an example, you are able to bootstrap a fresh Patroni cluster from a Barman b
 .. note::
     The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
     That script requires that you have both Barman and ``pg-backup-api`` configure in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
+    The above example used a subset of the available parameters. After downloading the script you can execute you can execute it with ``--help`` to get the full list of parameters.
 
 .. _custom_replica_creation:
 
@@ -160,6 +161,7 @@ example: Barman
 .. note::
     The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
     That script requires that you have both Barman and ``pg-backup-api`` configure in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
+    The above example used a subset of the available parameters. After downloading the script you can execute you can execute it with ``--help`` to get the full list of parameters.
 
 The ``create_replica_methods`` defines available replica creation methods and the order of executing them. Patroni will
 stop on the first one that returns 0. Each method should define a separate section in the configuration file, listing the command

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -71,6 +71,22 @@ Makes the configured ``command`` to be called additionally with ``--arg1=value1 
 
  .. note:: Bootstrap methods are neither chained, nor fallen-back to the default one in case the primary one fails
 
+As an example, you are able to bootstrap a fresh Patroni cluster from a Barman backup with a configuration like this:
+
+.. code:: YAML
+
+    bootstrap:
+        method: barman
+        barman:
+            keep_existing_recovery_conf: true
+            command: /path/to/barman_recover.py
+            api-url: https://barman-host:7480
+            barman-server: my_server
+            ssh-command: ssh postgres@patroni-host
+
+.. note::
+    The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
+    That script requires that you have both Barman and ``pg-backup-api`` configure in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
 
 .. _custom_replica_creation:
 
@@ -125,6 +141,25 @@ example: pgbackrest
         basebackup:
             max-rate: '100M'
 
+example: Barman
+
+.. code:: YAML
+
+    postgresql:
+        create_replica_methods:
+            - barman
+            - basebackup
+        barman:
+            command: /path/to/barman_recover.py
+            api-url: https://barman-host:7480
+            barman-server: my_server
+            ssh-command: ssh postgres@patroni-host
+        basebackup:
+            max-rate: '100M'
+
+.. note::
+    The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
+    That script requires that you have both Barman and ``pg-backup-api`` configure in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
 
 The ``create_replica_methods`` defines available replica creation methods and the order of executing them. Patroni will
 stop on the first one that returns 0. Each method should define a separate section in the configuration file, listing the command

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -86,7 +86,7 @@ As an example, you are able to bootstrap a fresh Patroni cluster from a Barman b
 
 .. note::
     The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
-    That script requires that you have both Barman and ``pg-backup-api`` configure in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
+    That script requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
     The above example used a subset of the available parameters. After downloading the script you can execute you can execute it with ``--help`` to get the full list of parameters.
 
 .. _custom_replica_creation:
@@ -160,7 +160,7 @@ example: Barman
 
 .. note::
     The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
-    That script requires that you have both Barman and ``pg-backup-api`` configure in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
+    That script requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
     The above example used a subset of the available parameters. After downloading the script you can execute you can execute it with ``--help`` to get the full list of parameters.
 
 The ``create_replica_methods`` defines available replica creation methods and the order of executing them. Patroni will

--- a/docs/replica_bootstrap.rst
+++ b/docs/replica_bootstrap.rst
@@ -79,15 +79,14 @@ As an example, you are able to bootstrap a fresh Patroni cluster from a Barman b
         method: barman
         barman:
             keep_existing_recovery_conf: true
-            command: /path/to/barman_recover.py
+            command: patroni_barman_recover
             api-url: https://barman-host:7480
             barman-server: my_server
             ssh-command: ssh postgres@patroni-host
 
 .. note::
-    The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
-    That script requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
-    The above example used a subset of the available parameters. After downloading the script you can execute you can execute it with ``--help`` to get the full list of parameters.
+    ``patroni_barman_recover`` requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
+    The above example used a subset of the available parameters. You can get more information running ``patroni_barman_recover --help``.
 
 .. _custom_replica_creation:
 
@@ -151,7 +150,7 @@ example: Barman
             - barman
             - basebackup
         barman:
-            command: /path/to/barman_recover.py
+            command: patroni_barman_recover
             api-url: https://barman-host:7480
             barman-server: my_server
             ssh-command: ssh postgres@patroni-host
@@ -159,9 +158,8 @@ example: Barman
             max-rate: '100M'
 
 .. note::
-    The above Barman method is based on the sample script `barman_recover.py <https://github.com/zalando/patroni/blob/master/patroni/scripts/barman_recover.py>`_.
-    That script requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
-    The above example used a subset of the available parameters. After downloading the script you can execute you can execute it with ``--help`` to get the full list of parameters.
+    ``patroni_barman_recover`` requires that you have both Barman and ``pg-backup-api`` configured in the Barman host, so it can execute a remote ``barman recover`` through the backup API.
+    The above example used a subset of the available parameters. You can get more information running ``patroni_barman_recover --help``.
 
 The ``create_replica_methods`` defines available replica creation methods and the order of executing them. Patroni will
 stop on the first one that returns 0. Each method should define a separate section in the configuration file, listing the command

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -85,8 +85,9 @@ def retry(times_attr: str, retry_wait_attr: str,
                 try:
                     return func(instance, *args, **kwargs)
                 except exceptions as exc:
-                    logging.warning(f"Attempt {attempt} of {times} on method "
-                                    f"{method_name} failed with {repr(exc)}.")
+                    logging.warning("Attempt %d of %d on method %s failed "
+                                    "with %r.",
+                                    attempt, times, method_name, exc)
                     attempt += 1
 
                 time.sleep(retry_wait)
@@ -238,7 +239,7 @@ class BarmanRecover:
                                context=self._create_ssl_context())
         except (HTTPError, URLError) as exc:
             logging.critical("An error occurred while performing an HTTP GET "
-                             f"request: {repr(exc)}")
+                             "request: %r", exc)
             sys.exit(ExitCode.HTTP_REQUEST_ERROR)
 
         return self._deserialize_response(response)
@@ -267,7 +268,7 @@ class BarmanRecover:
                                context=self._create_ssl_context())
         except (HTTPError, URLError) as exc:
             logging.critical("An error occurred while performing an HTTP POST "
-                             f"request: {repr(exc)}")
+                             "request: %r", exc)
             sys.exit(ExitCode.HTTP_REQUEST_ERROR)
 
         return self._deserialize_response(response)
@@ -282,7 +283,7 @@ class BarmanRecover:
         response = self._get_request("status")
 
         if response != "OK":
-            logging.critical(f"pg-backup-api is not working: {response}")
+            logging.critical("pg-backup-api is not working: %s", response)
             sys.exit(ExitCode.API_NOT_OK)
 
     @retry("max_retries", "retry_wait", KeyError)
@@ -335,7 +336,7 @@ class BarmanRecover:
             logging.critical("Maximum number of retries exceeded, exiting.")
             sys.exit(ExitCode.HTTP_RESPONSE_MALFORMED)
 
-        logging.info(f"Created the recovery operation with ID {operation_id}")
+        logging.info("Created the recovery operation with ID %s", operation_id)
 
         status = None
 
@@ -350,8 +351,8 @@ class BarmanRecover:
             if status != "IN_PROGRESS":
                 break
 
-            logging.info(f"Recovery operation {operation_id} is still in "
-                         "progress")
+            logging.info("Recovery operation %s is still in progress",
+                         operation_id)
             time.sleep(self.loop_wait)
 
         return status == "DONE"

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -67,7 +67,7 @@ def retry(times_attr: str, retry_wait_attr: str,
     :param times_attr: name of the instance attribute which contains the
         maximum number of retries upon exceptions.
     :param retry_wait_attr: name of the instance attribute which contains how
-        long to wait before retrying a failed request to the ``pg-backup-api`.
+        long to wait before retrying a failed request to the ``pg-backup-api``.
     :param exceptions: exceptions that could trigger a retry attempt.
 
     :raises:

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -21,6 +21,7 @@ import sys
 import time
 from typing import Any, Optional, TYPE_CHECKING
 from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
 from urllib.request import Request, urlopen
 
 
@@ -109,7 +110,7 @@ class BarmanRecover:
 
         :returns: the full URL after concatenating.
         """
-        return f"{self.api_url}/{url_path}"
+        return urljoin(self.api_url, url_path)
 
     def _create_ssl_context(self) -> Optional[ssl.SSLContext]:
         """Create an SSL context, if required.
@@ -214,7 +215,7 @@ class BarmanRecover:
         """Restore the configured Barman backup through ``pg-backup-api``.
 
         .. note::
-            If recover API request returns a malformed response, then exit with
+            If recovery API request returns a malformed response, then exit with
             :attr:`ExitCode.HTTP_RESPONSE_MALFORMED`.
 
         :returns: ``True`` if it was successfully recovered, ``False``
@@ -226,7 +227,7 @@ class BarmanRecover:
             response = self._post_request(
                 f"servers/{self.barman_server}/operations",
                 {
-                    "operation_type": "recover",
+                    "operation_type": "recovery",
                     "backup_id": self.backup_id,
                     "remote_ssh_command": self.ssh_command,
                     "destination_directory": self.data_directory,

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -1,0 +1,366 @@
+#!/usr/bin/python3
+
+"""Restore a Barman backup to the local node through ``pg-backup-api``.
+
+This script can be used both as a custom bootstrap method, and as a custom
+create replica method. Check the output of ``--help`` to understand the
+parameters supported by the script. ``--datadir`` is a special parameter and it
+is automatically filled by Patroni in both cases.
+
+It requires that you have previously configured a Barman server, and that you
+have ``pg-backup-api`` configured and running in the same host as Barman.
+
+Refer to :class:`ExitCode` for possible exit codes of this script.
+"""
+from argparse import ArgumentParser
+from enum import IntEnum
+import json
+import logging
+import ssl
+import sys
+import time
+from typing import Any, Optional, TYPE_CHECKING
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+if TYPE_CHECKING:
+    from http.client import HTTPResponse
+
+
+class ExitCode(IntEnum):
+    """Possible exit codes of this script.
+
+    :cvar RECOVERY_DONE: backup was successfully restored.
+    :cvar RECOVERY_FAILED: recovery of the backup faced an issue.
+    :cvar API_NOT_OK: ``pg-backup-api`` status is not ``OK``.
+    :cvar BARMAN_SERVER_DOES_NOT_EXIST: there is no such Barman server
+        configured in the Barman host.
+    :cvar HTTP_REQUEST_ERROR: an error has occurred during a request to the
+        ``pg-backup-api``.
+    :cvar HTTP_RESPONSE_MALFORMED: ``pg-backup-api`` returned a bogus response.
+    """
+
+    RECOVERY_DONE = 0
+    RECOVERY_FAILED = 1
+    API_NOT_OK = 2
+    BARMAN_SERVER_DOES_NOT_EXIST = 3
+    HTTP_REQUEST_ERROR = 4
+    HTTP_RESPONSE_MALFORMED = 5
+
+
+class BarmanRecover:
+    """_summary_.
+
+    :ivar api_url: base URL to reach the ``pg-backup-api``.
+    :ivar cert_file: certificate to authenticate against the
+        ``pg-backup-api``, if required.
+    :ivar key_file: certificate key to authenticate against the
+        ``pg-backup-api``, if required.
+    :ivar barman_server: name of the Barman server which backup is to be
+        restored.
+    :ivar backup_id: ID of the backup from the Barman server.
+    :ivar ssh_command: SSH command to connect from the Barman host to the
+        local host.
+    :ivar data_directory: path to the Postgres data directory where to
+        restore the backup at.
+    """
+
+    def __init__(self, api_url: str, barman_server: str, backup_id: str,
+                 ssh_command: str, data_directory: str,
+                 cert_file: Optional[str] = None,
+                 key_file: Optional[str] = None) -> None:
+        """Create a new instance of :class:`BarmanRecover`.
+
+        Make sure the ``pg-backup-api`` is reachable and running fine.
+
+        :param api_url: base URL to reach the ``pg-backup-api``.
+        :param barman_server: name of the Barman server which backup is to be
+            restored.
+        :param backup_id: ID of the backup from the Barman server.
+        :param ssh_command: SSH command to connect from the Barman host to the
+            local host.
+        :param data_directory: path to the Postgres data directory where to
+            restore the backup at.
+        :param cert_file: certificate to authenticate against the
+            ``pg-backup-api``, if required.
+        :param key_file: certificate key to authenticate against the
+            ``pg-backup-api``, if required.
+        """
+        self.api_url = api_url
+        self.cert_file = cert_file
+        self.key_file = key_file
+        self.barman_server = barman_server
+        self.backup_id = backup_id
+        self.ssh_command = ssh_command
+        self.data_directory = data_directory
+        self._ensure_api_ok()
+
+    def _build_full_url(self, url_path: str) -> str:
+        """Build the full URL by concatenating *url_path* with the base URL.
+
+        :param url_path: path to be accessed in the ``pg-backup-api``.
+
+        :returns: the full URL after concatenating.
+        """
+        return f"{self.api_url}/{url_path}"
+
+    def _create_ssl_context(self) -> Optional[ssl.SSLContext]:
+        """Create an SSL context, if required.
+
+        :returns: the SSL context, if we have a client certificate file,
+            otherwise ``None``.
+        """
+        if self.cert_file is None:
+            return None
+
+        ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ctx.load_cert_chain(self.cert_file, self.key_file)
+
+        return ctx
+
+    @staticmethod
+    def _deserialize_response(response: 'HTTPResponse') -> Any:
+        """Retrieve body from *response* as a deserialized JSON object.
+
+        :param response: response from which JSON body will be deserialized.
+
+        :returns: the deserialized JSON body.
+        """
+        return json.loads(response.read().decode("utf-8"))
+
+    @staticmethod
+    def _serialize_request(body: Any) -> Any:
+        """Serialize a request body.
+
+        :param body: content of the request body to be serialized.
+
+        :returns: the serialized request body.
+        """
+        return json.dumps(body).encode("utf-8")
+
+    def _get_request(self, url_path: str) -> Any:
+        """Perform a ``GET`` request to *url_path*.
+
+        .. note::
+            If a :exc:`HTTPError` or :exc:`URLError` is faced while performing
+            the request, then exit with :attr:`ExitCode.HTTP_REQUEST_ERROR`
+
+        :param url_path: URL to perform the ``GET`` request against.
+
+        :returns: the deserialized response body.
+        """
+        response = None
+
+        try:
+            response = urlopen(self._build_full_url(url_path),
+                               context=self._create_ssl_context())
+        except (HTTPError, URLError) as exc:
+            logging.critical("An error ocurred while performing an HTTP GET "
+                             f"request: {str(exc)}")
+            sys.exit(ExitCode.HTTP_REQUEST_ERROR)
+
+        return self._deserialize_response(response)
+
+    def _post_request(self, url_path: str, body: Any) -> Any:
+        """Perform a ``POST`` request to *url_path* serializing *body* as JSON.
+
+        .. note::
+            If a :exc:`HTTPError` or :exc:`URLError` is faced while performing
+            the request, then exit with :attr:`ExitCode.HTTP_REQUEST_ERROR`
+
+        :param url_path: URL to perform the ``POST`` request against.
+        :param body: the body to be serialized as JSON and sent in the request.
+
+        :returns: the deserialized response body.
+        """
+        body = self._serialize_request(body)
+        request = Request(self._build_full_url(url_path))
+        request.add_header("Content-Type", "application/json")
+        request.add_header("Content-Length", str(len(body)))
+
+        response = None
+
+        try:
+            response = urlopen(request, body,
+                               context=self._create_ssl_context())
+        except (HTTPError, URLError) as exc:
+            logging.critical("An error occurred while performing an HTTP POST "
+                             f"request: {str(exc)}")
+            sys.exit(ExitCode.HTTP_REQUEST_ERROR)
+
+        return self._deserialize_response(response)
+
+    def _ensure_api_ok(self):
+        """Ensure ``pg-backup-api`` is reachable and ``OK``.
+
+        .. note::
+            If ``pg-backup-api`` status is not ``OK``, then exit with
+            :attr:`ExitCode.API_NOT_OK`.
+        """
+        response = self._get_request("status")
+
+        if response != "OK":
+            logging.critical(f"pg-backup-api is not working: {response}")
+            sys.exit(ExitCode.API_NOT_OK)
+
+    def restore_backup(self) -> bool:
+        """Restore the configured Barman backup through ``pg-backup-api``.
+
+        .. note::
+            If recover API request returns a malformed response, then exit with
+            :attr:`ExitCode.HTTP_RESPONSE_MALFORMED`.
+
+        :returns: ``True`` if it was successfully recovered, ``False``
+            otherwise.
+        """
+        response = None
+
+        try:
+            response = self._post_request(
+                f"servers/{self.barman_server}/operations",
+                {
+                    "operation_type": "recover",
+                    "backup_id": self.backup_id,
+                    "remote_ssh_command": self.ssh_command,
+                    "destination_directory": self.data_directory,
+                },
+            )
+            
+            operation_id = response["operation_id"]
+        except KeyError:
+            logging.critical("Recived a malformed response from the API: "
+                             f"{response}")
+            sys.exit(ExitCode.HTTP_RESPONSE_MALFORMED)
+
+        logging.info(f"Created the recovery operation with ID {operation_id}")
+
+        status = None
+
+        while True:
+            try:
+                response = self._get_request(
+                    f"servers/{self.barman_server}/operations/{operation_id}",
+                )
+                
+                status = response["status"]
+            except KeyError:
+                logging.critical("Recived a malformed response from the API: "
+                                 f"{response}")
+                sys.exit(ExitCode.HTTP_RESPONSE_MALFORMED)
+
+            if status != "IN_PROGRESS":
+                break
+
+            logging.info(f"Recovery operation still in progress")
+            time.sleep(10)
+
+        return status == "DONE"
+
+
+def set_up_logging(log_file: Optional[str] = None) -> None:
+    """Set up logging to file, if *log_file* is given, otherwise to console.
+
+    :param log_file: file where to log messages, if any.
+    """
+    logging.basicConfig(filename=log_file, level=logging.INFO,
+                        format="%(asctime)s %(levelname)s: %(message)s")
+
+
+def main() -> None:
+    """Entry point of this script.
+
+    Parse the command-line arguments and recover a Barman backup through
+    ``pg-backup-api`` to the local host.
+    """
+    parser = ArgumentParser(
+        epilog=(
+            "Wrapper script for ``pg-backup-api``. Communicate with the API "
+            "running  at ``--api-url`` to restore a ``--backup-id`` Barman "
+            "backup of the server ``--barman-server``."
+        ),
+    )
+    parser.add_argument(
+        "--api-url",
+        type=str,
+        required=True,
+        help="URL to reach the ``pg-backup-api``, e.g. "
+             "``http://localhost:7480``",
+        dest="api_url",
+    )
+    parser.add_argument(
+        "--cert-file",
+        type=str,
+        required=False,
+        help="Certificate to authenticate against the API, if required.",
+        dest="cert_file",
+    )
+    parser.add_argument(
+        "--key-file",
+        type=str,
+        required=False,
+        help="Certificate key to authenticate against the API, if required.",
+        dest="key_file",
+    )
+    parser.add_argument(
+        "--barman-server",
+        type=str,
+        required=True,
+        help="Name of the Barman server from which to restore the backup.",
+        dest="barman_server",
+    )
+    parser.add_argument(
+        "--backup-id",
+        type=str,
+        required=False,
+        default="latest",
+        help="ID of the Barman backup to be restored. You can use any value "
+             "supported by ``barman recover`` command "
+             "(default: ``%(default)s``)",
+        dest="backup_id",
+    )
+    parser.add_argument(
+        "--ssh-command",
+        type=str,
+        required=True,
+        help="Value to be passed as ``--remote-ssh-command`` to "
+             "``barman recover``.",
+        dest="ssh_command",
+    )
+    parser.add_argument(
+        "--data-directory",
+        "--datadir",
+        type=str,
+        required=True,
+        help="Destination path where to restore the barman backup in the "
+             "local host.",
+        dest="data_directory",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        required=False,
+        help="File where to log messages produced by this script, if any.",
+        dest="log_file",
+    )
+    args, _ = parser.parse_known_args()
+
+    set_up_logging(args.log_file)
+
+    barman_recover = BarmanRecover(args.api_url, args.barman_server,
+                                   args.backup_id, args.ssh_command,
+                                   args.data_directory, args.cert_file,
+                                   args.key_file)
+
+    successful = barman_recover.restore_backup()
+
+    if successful:
+        logging.info("Recovery operation finished successfully.")
+        sys.exit(ExitCode.RECOVERY_DONE)
+    else:
+        logging.critical("Recovery operation failed.")
+        sys.exit(ExitCode.RECOVERY_FAILED)
+
+
+if __name__ == "__main__":
+    main()

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -76,8 +76,8 @@ def retry(exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]]) \
     """
     def decorator(func: Callable[..., Any]) -> Any:
         def inner_func(instance: object, *args: Any, **kwargs: Any) -> Any:
-            times: int = instance.max_retries
-            retry_wait: int = instance.retry_wait
+            times: int = getattr(instance, "max_retries")
+            retry_wait: int = getattr(instance, "retry_wait")
             method_name = f"{instance.__class__.__name__}.{func.__name__}"
 
             attempt = 1

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -50,7 +50,13 @@ class ExitCode(IntEnum):
 
 
 class BarmanRecover:
-    """_summary_.
+    """Facilities for performing a remote ``barman recover`` operation.
+
+    You should instantiate this class, which will take care of configuring the
+    operation accordingly. When you want to start the operation, you should
+    call :meth:`restore_backup`. At any point of interaction with this class,
+    you may face a :func:`sys.exit` call. Refer to :class:`ExitCode` for a view
+    on the possible exit codes.
 
     :ivar api_url: base URL to reach the ``pg-backup-api``.
     :ivar cert_file: certificate to authenticate against the

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -52,7 +52,6 @@ class ExitCode(IntEnum):
 
 class RetriesExceeded(Exception):
     """Maximum number of retries exceeded."""
-    pass
 
 
 def retry(times_attr: str, retry_wait_attr: str,
@@ -175,8 +174,17 @@ class BarmanRecover:
         :param url_path: path to be accessed in the ``pg-backup-api``.
 
         :returns: the full URL after concatenating.
+
+        :raises:
+            :exc:`ValueError`: if the URL is not using HTTP nor HTTPS scheme.
         """
-        return urljoin(self.api_url, url_path)
+        full_url = urljoin(self.api_url, url_path)
+
+        if not full_url.startswith(("http://", "https://")):
+            raise ValueError("URL is not using HTTP nor HTTPS scheme: "
+                             f"{full_url}")
+
+        return full_url
 
     def _create_ssl_context(self) -> Optional[ssl.SSLContext]:
         """Create an SSL context, if required.

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -31,8 +31,6 @@ class ExitCode(IntEnum):
     :cvar RECOVERY_DONE: backup was successfully restored.
     :cvar RECOVERY_FAILED: recovery of the backup faced an issue.
     :cvar API_NOT_OK: ``pg-backup-api`` status is not ``OK``.
-    :cvar BARMAN_SERVER_DOES_NOT_EXIST: there is no such Barman server
-        configured in the Barman host.
     :cvar HTTP_REQUEST_ERROR: an error has occurred during a request to the
         ``pg-backup-api``.
     :cvar HTTP_RESPONSE_MALFORMED: ``pg-backup-api`` returned a bogus response.
@@ -41,9 +39,8 @@ class ExitCode(IntEnum):
     RECOVERY_DONE = 0
     RECOVERY_FAILED = 1
     API_NOT_OK = 2
-    BARMAN_SERVER_DOES_NOT_EXIST = 3
-    HTTP_REQUEST_ERROR = 4
-    HTTP_RESPONSE_MALFORMED = 5
+    HTTP_REQUEST_ERROR = 3
+    HTTP_RESPONSE_MALFORMED = 4
 
 
 class RetriesExceeded(Exception):

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 """Restore a Barman backup to the local node through ``pg-backup-api``.
 
@@ -58,7 +58,7 @@ def retry(exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]]) \
         Should be used as a decorator of a class' method as it expects the
         first argument to be a class instance.
 
-        The class which method is going to decorated should contain a couple
+        The class which method is going to be decorated should contain a couple
         attributes:
 
         * ``max_retries``: maximum retry attempts before failing;

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -234,7 +234,7 @@ class BarmanRecover:
             response = self._post_request(
                 f"servers/{self.barman_server}/operations",
                 {
-                    "operation_type": "recovery",
+                    "type": "recovery",
                     "backup_id": self.backup_id,
                     "remote_ssh_command": self.ssh_command,
                     "destination_directory": self.data_directory,

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -18,14 +18,11 @@ import json
 import logging
 import sys
 import time
-from typing import Any, Callable, Optional, Tuple, Type, Union, TYPE_CHECKING
+from typing import Any, Callable, Optional, Tuple, Type, Union
 from urllib.parse import urljoin
 from urllib3 import PoolManager
 from urllib3.exceptions import MaxRetryError
-
-
-if TYPE_CHECKING:  # pragma: no cover
-    from urllib3.response import HTTPResponse
+from urllib3.response import HTTPResponse
 
 
 class ExitCode(IntEnum):
@@ -181,16 +178,10 @@ class BarmanRecover:
         :raises:
             :exc:`ValueError`: if the URL is not using HTTP nor HTTPS scheme.
         """
-        full_url = urljoin(self.api_url, url_path)
-
-        if not full_url.startswith(("http://", "https://")):
-            raise ValueError("URL is not using HTTP nor HTTPS scheme: "
-                             f"{full_url}")
-
-        return full_url
+        return urljoin(self.api_url, url_path)
 
     @staticmethod
-    def _deserialize_response(response: 'HTTPResponse') -> Any:
+    def _deserialize_response(response: HTTPResponse) -> Any:
         """Retrieve body from *response* as a deserialized JSON object.
 
         :param response: response from which JSON body will be deserialized.

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -78,6 +78,7 @@ def retry(times_attr: str, retry_wait_attr: str,
         def inner_func(instance: object, *args: Any, **kwargs: Any) -> Any:
             times: int = getattr(instance, times_attr)
             retry_wait: int = getattr(instance, retry_wait_attr)
+            method_name = f"{instance.__class__.__name__}.{func.__name__}"
 
             attempt = 1
 
@@ -85,14 +86,14 @@ def retry(times_attr: str, retry_wait_attr: str,
                 try:
                     return func(instance, *args, **kwargs)
                 except exceptions as exc:
-                    logging.warning(f"Attempt {attempt} of {times} on func "
-                                    f"{func} failed with {repr(exc)}.")
+                    logging.warning(f"Attempt {attempt} of {times} on method "
+                                    f"{method_name} failed with {repr(exc)}.")
                     attempt += 1
 
                 time.sleep(retry_wait)
 
             raise RetriesExceeded("Maximum number of retries exceeded for "
-                                  f"function {func}.")
+                                  f"method {method_name}.")
         return inner_func
     return decorator
 
@@ -228,7 +229,7 @@ class BarmanRecover:
             response = urlopen(self._build_full_url(url_path),
                                context=self._create_ssl_context())
         except (HTTPError, URLError) as exc:
-            logging.critical("An error ocurred while performing an HTTP GET "
+            logging.critical("An error occurred while performing an HTTP GET "
                              f"request: {repr(exc)}")
             sys.exit(ExitCode.HTTP_REQUEST_ERROR)
 
@@ -263,7 +264,7 @@ class BarmanRecover:
 
         return self._deserialize_response(response)
 
-    def _ensure_api_ok(self):
+    def _ensure_api_ok(self) -> None:
         """Ensure ``pg-backup-api`` is reachable and ``OK``.
 
         .. note::

--- a/patroni/scripts/barman_recover.py
+++ b/patroni/scripts/barman_recover.py
@@ -174,9 +174,6 @@ class BarmanRecover:
         :param url_path: path to be accessed in the ``pg-backup-api``.
 
         :returns: the full URL after concatenating.
-
-        :raises:
-            :exc:`ValueError`: if the URL is not using HTTP nor HTTPS scheme.
         """
         return urljoin(self.api_url, url_path)
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ CONSOLE_SCRIPTS = ['patroni = patroni.__main__:main',
                    'patronictl = patroni.ctl:ctl',
                    'patroni_raft_controller = patroni.raft_controller:main',
                    "patroni_wale_restore = patroni.scripts.wale_restore:main",
-                   "patroni_aws = patroni.scripts.aws:main"]
+                   "patroni_aws = patroni.scripts.aws:main",
+                   "patroni_barman_recover = patroni.scripts.barman_recover:main"]
 
 
 class _Command(Command):

--- a/tests/test_barman_recover.py
+++ b/tests/test_barman_recover.py
@@ -1,0 +1,396 @@
+import logging
+from mock import MagicMock, Mock, call, patch
+import ssl
+import unittest
+from urllib.error import HTTPError, URLError
+
+from patroni.scripts.barman_recover import BarmanRecover, RetriesExceeded, main, set_up_logging
+
+
+API_URL = "http://localhost:7480"
+BARMAN_SERVER = "my_server"
+BACKUP_ID = "backup_id"
+SSH_COMMAND = "ssh postgres@localhost"
+DATA_DIRECTORY = "/path/to/pgdata"
+LOOP_WAIT = 10
+RETRY_WAIT = 2
+MAX_RETRIES = 5
+
+
+class TestBarmanRecover(unittest.TestCase):
+
+    def setUp(self):
+        with patch.object(BarmanRecover, "_ensure_api_ok") as _:
+            self.br = BarmanRecover(API_URL, BARMAN_SERVER, BACKUP_ID, SSH_COMMAND, DATA_DIRECTORY, LOOP_WAIT,
+                                    RETRY_WAIT, MAX_RETRIES)
+
+    def test__build_full_url(self):
+        self.assertEqual(self.br._build_full_url("/some/path"), f"{API_URL}/some/path")
+
+    @patch.object(ssl, "create_default_context")
+    def test__create_ssl_context(self, mock_create_ctx):
+        # without certs
+        self.assertIsNone(self.br._create_ssl_context())
+        mock_create_ctx.assert_not_called()
+
+        # with certs
+        self.br.cert_file = "/path/to/certificate.crt"
+        self.br.key_file = "/path/to/certificate.key"
+        ret = self.br._create_ssl_context()
+        self.assertIsNotNone(ret)
+        mock_create_ctx.assert_called_once_with(ssl.Purpose.SERVER_AUTH)
+        ret.load_cert_chain.assert_called_once_with(self.br.cert_file, self.br.key_file)
+
+    @patch("json.loads")
+    def test__deserialize_response(self, mock_json_loads):
+        mock_response = MagicMock()
+        self.assertIsNotNone(self.br._deserialize_response(mock_response))
+        mock_response.read.assert_called_once()
+        mock_response.read.return_value.decode.assert_called_once_with("utf-8")
+        mock_json_loads.assert_called_once_with(mock_response.read.return_value.decode.return_value)
+
+    @patch("json.dumps")
+    def test__serialize_request(self, mock_json_dumps):
+        body = "some_body"
+        ret = self.br._serialize_request(body)
+        self.assertIsNotNone(ret)
+        mock_json_dumps.assert_called_once_with(body)
+        mock_json_dumps.return_value.encode.assert_called_once_with("utf-8")
+
+    @patch.object(BarmanRecover, "_deserialize_response", Mock(return_value="test"))
+    @patch("logging.critical")
+    @patch.object(BarmanRecover, "_create_ssl_context")
+    @patch("patroni.scripts.barman_recover.urlopen")
+    def test__get_request(self, mock_urlopen, mock_create_ctx, mock_logging):
+        # with no error
+        mock_create_ctx.return_value = None
+        self.assertEqual(self.br._get_request("/some/path"), "test")
+        mock_urlopen.assert_called_once_with(f"{API_URL}/some/path", context=None)
+        mock_create_ctx.assert_called_once()
+
+        # with HTTPError
+        http_error = HTTPError("url", 403, "Some error.", [], None)
+        mock_urlopen.side_effect = http_error
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br._get_request("/some/path"))
+
+        mock_logging.assert_called_once_with("An error occurred while performing an HTTP GET request: "
+                                             f"{repr(http_error)}")
+        self.assertEqual(exc.exception.code, 4)
+
+        # with URLError
+        mock_logging.reset_mock()
+        url_error = URLError("Some error.")
+        mock_urlopen.side_effect = url_error
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br._get_request("/some/path"))
+
+        mock_logging.assert_called_once_with("An error occurred while performing an HTTP GET request: "
+                                             f"{repr(url_error)}")
+        self.assertEqual(exc.exception.code, 4)
+
+        # with Exception
+        mock_logging.reset_mock()
+        mock_urlopen.side_effect = Exception("Some error.")
+
+        with patch("sys.exit") as mock_sys:
+            with self.assertRaises(Exception):
+                self.assertIsNone(self.br._get_request("/some/path"))
+
+            mock_logging.assert_not_called()
+            mock_sys.assert_not_called()
+
+    @patch.object(BarmanRecover, "_deserialize_response", Mock(return_value="test"))
+    @patch("logging.critical")
+    @patch.object(BarmanRecover, "_create_ssl_context")
+    @patch("patroni.scripts.barman_recover.urlopen")
+    @patch("patroni.scripts.barman_recover.Request")
+    @patch.object(BarmanRecover, "_serialize_request")
+    def test__post_request(self, mock_serialize, mock_request, mock_urlopen, mock_create_ctx, mock_logging):
+        # with no error
+        mock_create_ctx.return_value = None
+        self.assertEqual(self.br._post_request("/some/path", "some body"), "test")
+        mock_serialize.assert_called_once_with("some body")
+        mock_request.assert_called_once_with(f"{API_URL}/some/path")
+        mock_urlopen.assert_called_once_with(mock_request.return_value, mock_serialize.return_value,
+                                             context=mock_create_ctx.return_value)
+
+        # with HTTPError
+        http_error = HTTPError("url", 403, "Some error.", [], None)
+        mock_urlopen.side_effect = http_error
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br._post_request("/some/path", "some body"))
+
+        mock_logging.assert_called_once_with("An error occurred while performing an HTTP POST request: "
+                                             f"{repr(http_error)}")
+        self.assertEqual(exc.exception.code, 4)
+
+        # with URLError
+        mock_logging.reset_mock()
+        url_error = URLError("Some error.")
+        mock_urlopen.side_effect = url_error
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br._post_request("/some/path", "some body"))
+
+        mock_logging.assert_called_once_with("An error occurred while performing an HTTP POST request: "
+                                             f"{repr(url_error)}")
+        self.assertEqual(exc.exception.code, 4)
+
+        # with Exception
+        mock_logging.reset_mock()
+        mock_urlopen.side_effect = Exception("Some error.")
+
+        with patch("sys.exit") as mock_sys:
+            with self.assertRaises(Exception):
+                self.br._post_request("/some/path", "some body")
+
+            mock_logging.assert_not_called()
+            mock_sys.assert_not_called()
+
+    @patch("logging.critical")
+    @patch.object(BarmanRecover, "_get_request")
+    def test__ensure_api_ok(self, mock_get_request, mock_logging):
+        # API ok
+        mock_get_request.return_value = "OK"
+
+        with patch("sys.exit") as mock_sys:
+            self.assertIsNone(self.br._ensure_api_ok())
+            mock_logging.assert_not_called()
+            mock_sys.assert_not_called()
+
+        # API not ok
+        mock_get_request.return_value = "random"
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br._ensure_api_ok())
+
+        mock_logging.assert_called_once_with("pg-backup-api is not working: random")
+        self.assertEqual(exc.exception.code, 2)
+
+    @patch("logging.warning")
+    @patch("time.sleep")
+    @patch.object(BarmanRecover, "_post_request")
+    def test__create_recovery_operation(self, mock_post_request, mock_sleep, mock_logging):
+        # well formed response
+        mock_post_request.return_value = {"operation_id": "some_id"}
+        self.assertEqual(self.br._create_recovery_operation(), "some_id")
+        mock_sleep.assert_not_called()
+        mock_logging.assert_not_called()
+        mock_post_request.assert_called_once_with(
+            f"servers/{BARMAN_SERVER}/operations",
+            {
+                "type": "recovery",
+                "backup_id": BACKUP_ID,
+                "remote_ssh_command": SSH_COMMAND,
+                "destination_directory": DATA_DIRECTORY,
+            }
+        )
+
+        # malformed response
+        mock_post_request.return_value = {"operation_idd": "some_id"}
+
+        with self.assertRaises(RetriesExceeded) as exc:
+            self.br._create_recovery_operation()
+
+        self.assertEqual(str(exc.exception),
+                         "Maximum number of retries exceeded for method BarmanRecover._create_recovery_operation.")
+
+        self.assertEqual(mock_sleep.call_count, self.br.max_retries)
+        mock_sleep.assert_has_calls([call(self.br.retry_wait)] * self.br.max_retries)
+
+        self.assertEqual(mock_logging.call_count, self.br.max_retries)
+        mock_logging.assert_has_calls([call(f"Attempt {i+1} of {self.br.max_retries} on method BarmanRecover."
+                                            "_create_recovery_operation failed with KeyError('operation_id').")
+                                       for i in range(self.br.max_retries)])
+
+    @patch("logging.warning")
+    @patch("time.sleep")
+    @patch.object(BarmanRecover, "_get_request")
+    def test__get_recovery_operation_status(self, mock_get_request, mock_sleep, mock_logging):
+        # well formed response
+        mock_get_request.return_value = {"status": "some status"}
+        self.assertEqual(self.br._get_recovery_operation_status("some_id"), "some status")
+        mock_get_request.assert_called_once_with(f"servers/{BARMAN_SERVER}/operations/some_id")
+        mock_sleep.assert_not_called()
+        mock_logging.assert_not_called()
+
+        # malformed response
+        mock_get_request.return_value = {"statuss": "some status"}
+
+        with self.assertRaises(RetriesExceeded) as exc:
+            self.br._get_recovery_operation_status("some_id")
+
+        self.assertEqual(str(exc.exception),
+                         "Maximum number of retries exceeded for method BarmanRecover._get_recovery_operation_status.")
+
+        self.assertEqual(mock_sleep.call_count, self.br.max_retries)
+        mock_sleep.assert_has_calls([call(self.br.retry_wait)] * self.br.max_retries)
+
+        self.assertEqual(mock_logging.call_count, self.br.max_retries)
+        mock_logging.assert_has_calls([call(f"Attempt {i+1} of {self.br.max_retries} on method BarmanRecover."
+                                            "_get_recovery_operation_status failed with KeyError('status').")
+                                       for i in range(self.br.max_retries)])
+
+    @patch.object(BarmanRecover, "_get_recovery_operation_status")
+    @patch("time.sleep")
+    @patch("logging.info")
+    @patch("logging.critical")
+    @patch.object(BarmanRecover, "_create_recovery_operation")
+    def test_restore_backup(self, mock_create_op, mock_log_critical, mock_log_info, mock_sleep, mock_get_status):
+        # successful fast restore
+        mock_create_op.return_value = "some_id"
+        mock_get_status.return_value = "DONE"
+
+        self.assertTrue(self.br.restore_backup())
+
+        mock_create_op.assert_called_once()
+        mock_get_status.assert_called_once_with("some_id")
+        mock_log_info.assert_called_once_with("Created the recovery operation with ID some_id")
+        mock_log_critical.assert_not_called()
+        mock_sleep.assert_not_called()
+
+        # successful slow restore
+        mock_create_op.reset_mock()
+        mock_get_status.reset_mock()
+        mock_log_info.reset_mock()
+        mock_get_status.side_effect = ["IN_PROGRESS"] * 20 + ["DONE"]
+
+        self.assertTrue(self.br.restore_backup())
+
+        mock_create_op.assert_called_once()
+
+        self.assertEqual(mock_get_status.call_count, 21)
+        mock_get_status.assert_has_calls([call("some_id")] * 21)
+
+        self.assertEqual(mock_log_info.call_count, 21)
+        mock_log_info.assert_has_calls([call("Created the recovery operation with ID some_id")]
+                                       + [call("Recovery operation some_id is still in progress")] * 20)
+
+        mock_log_critical.assert_not_called()
+
+        self.assertEqual(mock_sleep.call_count, 20)
+        mock_sleep.assert_has_calls([call(LOOP_WAIT)] * 20)
+
+        # failed fast restore
+        mock_create_op.reset_mock()
+        mock_get_status.reset_mock()
+        mock_log_info.reset_mock()
+        mock_sleep.reset_mock()
+        mock_get_status.side_effect = None
+        mock_get_status.return_value = "FAILED"
+
+        self.assertFalse(self.br.restore_backup())
+
+        mock_create_op.assert_called_once()
+        mock_get_status.assert_called_once_with("some_id")
+        mock_log_info.assert_called_once_with("Created the recovery operation with ID some_id")
+        mock_log_critical.assert_not_called()
+        mock_sleep.assert_not_called()
+
+        # failed slow restore
+        mock_create_op.reset_mock()
+        mock_get_status.reset_mock()
+        mock_log_info.reset_mock()
+        mock_sleep.reset_mock()
+        mock_get_status.side_effect = ["IN_PROGRESS"] * 20 + ["FAILED"]
+
+        self.assertFalse(self.br.restore_backup())
+
+        mock_create_op.assert_called_once()
+
+        self.assertEqual(mock_get_status.call_count, 21)
+        mock_get_status.assert_has_calls([call("some_id")] * 21)
+
+        self.assertEqual(mock_log_info.call_count, 21)
+        mock_log_info.assert_has_calls([call("Created the recovery operation with ID some_id")]
+                                       + [call("Recovery operation some_id is still in progress")] * 20)
+
+        mock_log_critical.assert_not_called()
+
+        self.assertEqual(mock_sleep.call_count, 20)
+        mock_sleep.assert_has_calls([call(LOOP_WAIT)] * 20)
+
+        # create retries exceeded
+        mock_log_info.reset_mock()
+        mock_sleep.reset_mock()
+        mock_create_op.side_effect = RetriesExceeded
+        mock_get_status.side_effect = None
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br.restore_backup())
+
+        self.assertEqual(exc.exception.code, 5)
+        mock_log_info.assert_not_called()
+        mock_log_critical.assert_called_once_with("Maximum number of retries exceeded, exiting.")
+        mock_sleep.assert_not_called()
+
+        # get status retries exceeded
+        mock_create_op.reset_mock()
+        mock_create_op.side_effect = None
+        mock_log_critical.reset_mock()
+        mock_log_info.reset_mock()
+        mock_get_status.side_effect = RetriesExceeded
+
+        with self.assertRaises(SystemExit) as exc:
+            self.assertIsNone(self.br.restore_backup())
+
+        self.assertEqual(exc.exception.code, 5)
+        mock_log_info.assert_called_once_with("Created the recovery operation with ID some_id")
+        mock_log_critical.assert_called_once_with("Maximum number of retries exceeded, exiting.")
+        mock_sleep.assert_not_called()
+
+
+class TestMain(unittest.TestCase):
+
+    @patch("logging.basicConfig")
+    def test_set_up_logging(self, mock_log_config):
+        log_file = "/path/to/some/file.log"
+        set_up_logging(log_file)
+        mock_log_config.assert_called_once_with(filename=log_file, level=logging.INFO,
+                                                format="%(asctime)s %(levelname)s: %(message)s")
+
+    @patch("logging.critical")
+    @patch("logging.info")
+    @patch("patroni.scripts.barman_recover.set_up_logging")
+    @patch("patroni.scripts.barman_recover.BarmanRecover")
+    @patch("patroni.scripts.barman_recover.ArgumentParser")
+    def test_main(self, mock_arg_parse, mock_br, mock_set_up_log, mock_log_info, mock_log_critical):
+        # successful restore
+        args = MagicMock()
+        mock_arg_parse.return_value.parse_known_args.return_value = (args, None)
+        mock_br.return_value.restore_backup.return_value = True
+
+        with self.assertRaises(SystemExit) as exc:
+            main()
+
+        mock_arg_parse.assert_called_once()
+        mock_set_up_log.assert_called_once_with(args.log_file)
+        mock_br.assert_called_once_with(args.api_url, args.barman_server, args.backup_id, args.ssh_command,
+                                        args.data_directory, args.loop_wait, args.retry_wait, args.max_retries,
+                                        args.cert_file, args.key_file)
+        mock_log_info.assert_called_once_with("Recovery operation finished successfully.")
+        mock_log_critical.assert_not_called()
+        self.assertEqual(exc.exception.code, 0)
+
+        # failed restore
+        mock_arg_parse.reset_mock()
+        mock_set_up_log.reset_mock()
+        mock_br.reset_mock()
+        mock_log_info.reset_mock()
+        mock_br.return_value.restore_backup.return_value = False
+
+        with self.assertRaises(SystemExit) as exc:
+            main()
+
+        mock_arg_parse.assert_called_once()
+        mock_set_up_log.assert_called_once_with(args.log_file)
+        mock_br.assert_called_once_with(args.api_url, args.barman_server, args.backup_id, args.ssh_command,
+                                        args.data_directory, args.loop_wait, args.retry_wait, args.max_retries,
+                                        args.cert_file, args.key_file)
+        mock_log_info.assert_not_called()
+        mock_log_critical.assert_called_once_with("Recovery operation failed.")
+        self.assertEqual(exc.exception.code, 1)

--- a/tests/test_barman_recover.py
+++ b/tests/test_barman_recover.py
@@ -28,16 +28,7 @@ class TestBarmanRecover(unittest.TestCase):
         self.br.http.request.side_effect = None
 
     def test__build_full_url(self):
-        # valid scheme
         self.assertEqual(self.br._build_full_url("/some/path"), f"{API_URL}/some/path")
-
-        # invalid scheme
-        self.br.api_url = "file://base"
-
-        with self.assertRaises(ValueError) as exc:
-            self.assertIsNone(self.br._build_full_url("/some/path"))
-
-        self.assertEqual(str(exc.exception), "URL is not using HTTP nor HTTPS scheme: file://base/some/path")
 
     @patch("json.loads")
     def test__deserialize_response(self, mock_json_loads):

--- a/tests/test_barman_recover.py
+++ b/tests/test_barman_recover.py
@@ -25,7 +25,16 @@ class TestBarmanRecover(unittest.TestCase):
                                     RETRY_WAIT, MAX_RETRIES)
 
     def test__build_full_url(self):
+        # valid scheme
         self.assertEqual(self.br._build_full_url("/some/path"), f"{API_URL}/some/path")
+
+        # invalid scheme
+        self.br.api_url = "file://base"
+
+        with self.assertRaises(ValueError) as exc:
+            self.assertIsNone(self.br._build_full_url("/some/path"))
+
+        self.assertEqual(str(exc.exception), "URL is not using HTTP nor HTTPS scheme: file://base/some/path")
 
     @patch.object(ssl, "create_default_context")
     def test__create_ssl_context(self, mock_create_ctx):

--- a/tests/test_barman_recover.py
+++ b/tests/test_barman_recover.py
@@ -159,7 +159,6 @@ class TestBarmanRecover(unittest.TestCase):
         mock_sleep.assert_has_calls([call(self.br.retry_wait)] * self.br.max_retries)
 
         self.assertEqual(mock_logging.call_count, self.br.max_retries)
-        self.assertEqual(mock_logging.call_count, self.br.max_retries)
         for i in range(mock_logging.call_count):
             call_args = mock_logging.mock_calls[i].args
             self.assertEqual(len(call_args), 5)


### PR DESCRIPTION
This PR adds a contrib script, which can be used as a custom bootstrap method, or as a custom create replica method.

The script communicates with the pg-backup-api on the Barman node so Patroni is able to restore a Barman backup remotely.

The `--help` option of the script, along with the script docstring, should provide some context on how to use fill its parameters.

Patroni docs were updated accordingly to share examples about how to configure the script as a custom bootstrap method, or as a custom create replica method.

References: PAT-216.