### PR TITLE
Fix pg_rewind behavior with Postgres v16+

### DIFF
--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -184,12 +184,11 @@ class TestRewind(BaseTestPostgresql):
             mock_popen.return_value.communicate.return_value = (
                 b'0, lsn: 0/040159C1, prev 0/\n',
                 b'pg_waldump: fatal: error in WAL record at 0/40159C1: invalid record '
-                b'length at /: expected at least 24, got 0\n'
+                b'length at 0/402DD98: expected at least 24, got 0\n'
             )
             self.r.reset_state()
             self.r.trigger_check_diverged_lsn()
-            mock_get_local_timeline_lsn.return_value = (False, 2, 67197377)
-            self.assertTrue(self.r.rewind_or_reinitialize_needed_and_possible(self.leader))
+            self.assertFalse(self.r.rewind_or_reinitialize_needed_and_possible(self.leader))
 
             self.r.reset_state()
             self.r.trigger_check_diverged_lsn()

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -180,6 +180,17 @@ class TestRewind(BaseTestPostgresql):
             self.r.trigger_check_diverged_lsn()
             mock_get_local_timeline_lsn.return_value = (False, 2, 67197377)
             self.assertTrue(self.r.rewind_or_reinitialize_needed_and_possible(self.leader))
+
+            mock_popen.return_value.communicate.return_value = (
+                b'0, lsn: 0/040159C1, prev 0/\n',
+                b'pg_waldump: fatal: error in WAL record at 0/40159C1: invalid record '
+                b'length at /: expected at least 24, got 0\n'
+            )
+            self.r.reset_state()
+            self.r.trigger_check_diverged_lsn()
+            mock_get_local_timeline_lsn.return_value = (False, 2, 67197377)
+            self.assertTrue(self.r.rewind_or_reinitialize_needed_and_possible(self.leader))
+
             self.r.reset_state()
             self.r.trigger_check_diverged_lsn()
             mock_popen.side_effect = Exception


### PR DESCRIPTION
The error message format was changed in
https://github.com/postgres/postgres/commit/4ac30ba4f29d4b586b131404b0d514f16501272a, what caused `pg_rewind` being called by Patroni even when it was not necessary.