### PR TITLE
Update: specifying ETCDCTL_API=3 in docker/README.md for getting keys via etcdctl

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -78,7 +78,7 @@ Example session:
     |   demo  | patroni3 | 172.22.0.4 |        | running |  1 |         0 |
     +---------+----------+------------+--------+---------+----+-----------+
 
-    postgres@patroni1:~$ etcdctl get --keys-only --prefix /service/demo
+    postgres@patroni1:~$ ETCDCTL_API=3 etcdctl get --keys-only --prefix /service/demo
     /service/demo/config
     /service/demo/initialize
     /service/demo/leader


### PR DESCRIPTION
tired to run `etcdctl get --keys-only --prefix /service/demo` with no specifying the version of `ETCDCTL_API` and ran into `Incorrect Usage.` 

```
Incorrect Usage.

NAME:
   etcdctl get - retrieve the value of a key

USAGE:
   etcdctl get [command options] <key>

OPTIONS:
   --sort        returns result in sorted order
   --quorum, -q  require quorum for get request
   
flag provided but not defined: -keys-only
```

So, it needs to specify the version of `ETCDCTL_API` , the command would be like the below: 
`ETCDCTL_API=3 etcdctl get --keys-only --prefix /service/demo`