### PR TITLE
Fix bug with custom bootstrap

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -188,10 +188,9 @@ class Bootstrap(object):
         params = [] if config.get('no_params') else ['--scope=' + self._postgresql.scope,
                                                      '--datadir=' + self._postgresql.data_dir]
         # Add custom parameters specified by the user
-        reserved_args = {'no_params', 'keep_existing_recovery_conf', 'recovery_conf', 'scope', 'datadir'}
-        for arg, val in config.items():
-            if arg not in reserved_args:
-                params.append(f"--{arg}={val}")
+        reserved_args = {'command', 'no_params', 'keep_existing_recovery_conf', 'recovery_conf', 'scope', 'datadir'}
+        params += [f"--{arg}={val}" for arg, val in config.items() if arg not in reserved_args]
+
         try:
             logger.info('Running custom bootstrap script: %s', config['command'])
             if self._postgresql.cancellable.call(shlex.split(config['command']) + params) != 0:


### PR DESCRIPTION
Patroni was falsely applying `--command` argument.

Close https://github.com/zalando/patroni/issues/2947