### PR TITLE
Fix the issue that REST API returns unknown after postgres restart

### DIFF
--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -147,7 +147,7 @@ class ConnectionPool:
     def close(self) -> None:
         """Close all named connections from Patroni to PostgreSQL registered in the pool."""
         with self._lock:
-            if all(conn.close(True) for conn in self._connections.values()):
+            if all(conn.close(False) for conn in self._connections.values()):
                 logger.info("closed patroni connections to postgres")
 
 

--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -147,7 +147,8 @@ class ConnectionPool:
     def close(self) -> None:
         """Close all named connections from Patroni to PostgreSQL registered in the pool."""
         with self._lock:
-            if all(conn.close(False) for conn in self._connections.values()):
+            closed_connections = [conn.close(True) for conn in self._connections.values()]
+            if any(closed_connections):
                 logger.info("closed patroni connections to postgres")
 
 

--- a/patroni/postgresql/connection.py
+++ b/patroni/postgresql/connection.py
@@ -147,7 +147,7 @@ class ConnectionPool:
     def close(self) -> None:
         """Close all named connections from Patroni to PostgreSQL registered in the pool."""
         with self._lock:
-            if any(conn.close(True) for conn in self._connections.values()):
+            if all(conn.close(True) for conn in self._connections.values()):
                 logger.info("closed patroni connections to postgres")
 
 


### PR DESCRIPTION
**Problem:**
Currenctly REST API could establish connection to postgres at the first time and return correct query result. But after postgres node restarted, restapi connection returned exception as the previous restapi connection was not closed properly. 
**Solution:**
For the close function in ConnectionPool, we need to close all named connections including heartbeat and restapi connections. So in this pull request, I change function any() to all() to close all connections in the pool. This will fix issue #2955 