### PR TITLE
Fix Citus transaction rollback condition check

### DIFF
--- a/features/steps/citus.py
+++ b/features/steps/citus.py
@@ -131,5 +131,5 @@ def check_transaction(context, name, time_limit):
 
 @step("a transaction finishes in {timeout:d} seconds")
 def check_transaction_timeout(context, timeout):
-    assert (datetime.now(tzutc) - context.xact_start).seconds > timeout, \
+    assert (datetime.now(tzutc) - context.xact_start).seconds >= timeout, \
         "a transaction finished earlier than in {0} seconds".format(timeout)


### PR DESCRIPTION
It seems that sometimes we get an exact match, what makes behave tests to fail.