### PR TITLE
Update: etcd flags in command in docker-compose.yml and docker-compose-citus.yml

### DIFF
--- a/docker-compose-citus.yml
+++ b/docker-compose-citus.yml
@@ -27,19 +27,19 @@ services:
             ETCD_UNSUPPORTED_ARCH: arm64
         container_name: demo-etcd1
         hostname: etcd1
-        command: etcd -name etcd1 -initial-advertise-peer-urls http://etcd1:2380
+        command: etcd --name etcd1 --initial-advertise-peer-urls http://etcd1:2380
 
     etcd2:
         <<: *etcd
         container_name: demo-etcd2
         hostname: etcd2
-        command: etcd -name etcd2 -initial-advertise-peer-urls http://etcd2:2380
+        command: etcd --name etcd2 --initial-advertise-peer-urls http://etcd2:2380
 
     etcd3:
         <<: *etcd
         container_name: demo-etcd3
         hostname: etcd3
-        command: etcd -name etcd3 -initial-advertise-peer-urls http://etcd3:2380
+        command: etcd --name etcd3 --initial-advertise-peer-urls http://etcd3:2380
 
     haproxy:
         image: ${PATRONI_TEST_IMAGE:-patroni-citus}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,19 +25,19 @@ services:
             ETCD_UNSUPPORTED_ARCH: arm64
         container_name: demo-etcd1
         hostname: etcd1
-        command: etcd -name etcd1 -initial-advertise-peer-urls http://etcd1:2380
+        command: etcd --name etcd1 --initial-advertise-peer-urls http://etcd1:2380
 
     etcd2:
         <<: *etcd
         container_name: demo-etcd2
         hostname: etcd2
-        command: etcd -name etcd2 -initial-advertise-peer-urls http://etcd2:2380
+        command: etcd --name etcd2 --initial-advertise-peer-urls http://etcd2:2380
 
     etcd3:
         <<: *etcd
         container_name: demo-etcd3
         hostname: etcd3
-        command: etcd -name etcd3 -initial-advertise-peer-urls http://etcd3:2380
+        command: etcd --name etcd3 --initial-advertise-peer-urls http://etcd3:2380
 
     haproxy:
         image: ${PATRONI_TEST_IMAGE:-patroni}


### PR DESCRIPTION
According to `etcd --help` there is no flags with one dash `-` like `-name` that is used in `command` in docker compose file. 

so updated flags for `etcd` in `command` in both `docker-compose.yml` and `docker-compose-citus.yml` for up and running etcd services in those files.

`etcd -name etcd1 -initial-advertise-peer-urls http://etcd1:2380` changed to `etcd --name etcd1 --initial-advertise-peer-urls http://etcd1:2380`

changes:
- in `docker-compose.yml` are in lines 28, 34, 40
- in `docker-compose-citus.yml` are in lines 30, 36, 42


All Testing commands in `docker/README.md` are passed and all is good.
