### PR TITLE
Prevent HA nap_time longer than loop_wait

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -172,7 +172,7 @@ class Patroni(AbstractPatroniDaemon, Tags):
         """
         self.next_run += self.dcs.loop_wait
         current_time = time.time()
-        nap_time = self.next_run - current_time
+        nap_time = min(self.next_run - current_time, self.dcs.loop_wait)
         if nap_time <= 0:
             self.next_run = current_time
             # Release the GIL so we don't starve anyone waiting on async_executor lock


### PR DESCRIPTION
General there is time synchronization mechanism on each server node. 
In extreme scenarios, the system time may be rolled back several ten seconds, then master will sleep for more than the TTL  period in a loop, causing leader lock expiration and triggering a failover:
<img width="826" alt="image" src="https://github.com/zalando/patroni/assets/39515546/64e2b43f-73f0-491d-9b1f-837974da90fd">


This issue is unrelated to Patroni, but I think limiting `nap_time` to not exceed `loop_wait` may make HA loop mechanism more robust.