### PR TITLE
Add pending restart reason information

### DIFF
--- a/patroni/api.py
+++ b/patroni/api.py
@@ -198,6 +198,13 @@ class RestApiHandler(BaseHTTPRequestHandler):
             response['database_system_identifier'] = patroni.postgresql.sysid
         if patroni.postgresql.pending_restart:
             response['pending_restart'] = True
+            response['pending_restart_reason'] = {
+                param: {
+                    'old_value': value[0],
+                    'new_value': value[1]
+                }
+                for param, value in patroni.postgresql.pending_restart_reason.items()
+            }
         response['patroni'] = {
             'version': patroni.version,
             'scope': patroni.postgresql.scope,

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -200,7 +200,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             response['database_system_identifier'] = patroni.postgresql.sysid
         if patroni.postgresql.pending_restart_reason:
             response['pending_restart'] = True
-            response['pending_restart_reason'] = patroni.postgresql.pending_restart_reason
+            response['pending_restart_reason'] = dict(patroni.postgresql.pending_restart_reason)
         response['patroni'] = {
             'version': patroni.version,
             'scope': patroni.postgresql.scope,

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -180,6 +180,8 @@ class RestApiHandler(BaseHTTPRequestHandler):
             * ``tags``: tags that were set through Patroni configuration merged with dynamically applied tags;
             * ``database_system_identifier``: ``Database system identifier`` from ``pg_controldata`` output;
             * ``pending_restart``: ``True`` if PostgreSQL is pending to be restarted;
+            * ``pending_restart_reason``: dictionary where each key is the parameter that caused "pending restart" flag
+                to be set and the value is a dictionary with the old and the new value.
             * ``scheduled_restart``: a dictionary with a single key ``schedule``, which is the timestamp for the
                 scheduled restart;
             * ``watchdog_failed``: ``True`` if watchdog device is unhealthy;
@@ -196,7 +198,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             response['tags'] = tags
         if patroni.postgresql.sysid:
             response['database_system_identifier'] = patroni.postgresql.sysid
-        if patroni.postgresql.pending_restart:
+        if patroni.postgresql.pending_restart_reason:
             response['pending_restart'] = True
             response['pending_restart_reason'] = {
                 param: {
@@ -641,7 +643,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
         metrics.append("# HELP patroni_pending_restart Value is 1 if the node needs a restart, 0 otherwise.")
         metrics.append("# TYPE patroni_pending_restart gauge")
         metrics.append("patroni_pending_restart{0} {1}"
-                       .format(labels, int(patroni.postgresql.pending_restart)))
+                       .format(labels, int(bool(patroni.postgresql.pending_restart_reason))))
 
         metrics.append("# HELP patroni_is_paused Value is 1 if auto failover is disabled, 0 otherwise.")
         metrics.append("# TYPE patroni_is_paused gauge")

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -200,13 +200,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
             response['database_system_identifier'] = patroni.postgresql.sysid
         if patroni.postgresql.pending_restart_reason:
             response['pending_restart'] = True
-            response['pending_restart_reason'] = {
-                param: {
-                    'old_value': value[0],
-                    'new_value': value[1]
-                }
-                for param, value in patroni.postgresql.pending_restart_reason.items()
-            }
+            response['pending_restart_reason'] = patroni.postgresql.pending_restart_reason
         response['patroni'] = {
             'version': patroni.version,
             'scope': patroni.postgresql.scope,

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1576,8 +1576,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
             def format_diff(param: str, values: Dict[str, str], hide_long: bool):
                 full_diff = param + ': ' + values['old_value'] + '->' + values['new_value']
                 return full_diff if not hide_long or len(full_diff) <= 50 else param + ': [hidden - too long]'
-            restart_reason = '\n'.join(
-                [format_diff(k, v, fmt == 'pretty') for k, v in member.get('pending_restart_reason', {}).items()]) or ''
+            restart_reason = '\n'.join([format_diff(k, v, fmt in ('pretty', 'topology'))
+                                        for k, v in member.get('pending_restart_reason', {}).items()]) or ''
 
             member.update(cluster=name, member=member['name'], group=g,
                           host=member.get('host', ''), tl=member.get('timeline', ''),

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1573,7 +1573,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
                 full_diff = param + ': ' + values[0] + '->' + values[1]
                 return full_diff if len(full_diff) <= 50 else param + ': [hidden - too long]'
             restart_reason = '\n'.join(
-                [format_diff(k,v) for k, v in member.get('pending_restart_reason', {}).items()]) or ''
+                [format_diff(k, v) for k, v in member.get('pending_restart_reason', {}).items()]) or ''
 
             member.update(cluster=name, member=member['name'], group=g,
                           host=member.get('host', ''), tl=member.get('timeline', ''),

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1569,8 +1569,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
 
             lag = member.get('lag', '')
 
-            def format_diff(param: str, values: Tuple[str, str], hide_long: bool):
-                full_diff = param + ': ' + values[0] + '->' + values[1]
+            def format_diff(param: str, values: Dict[str, str], hide_long: bool):
+                full_diff = param + ': ' + values['old_value'] + '->' + values['new_value']
                 return full_diff if not hide_long or len(full_diff) <= 50 else param + ': [hidden - too long]'
             restart_reason = '\n'.join(
                 [format_diff(k, v, fmt == 'pretty') for k, v in member.get('pending_restart_reason', {}).items()]) or ''

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1569,11 +1569,11 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
 
             lag = member.get('lag', '')
 
-            def format_diff(param: str, values: Tuple[str, str]):
+            def format_diff(param: str, values: Tuple[str, str], hide_long: bool):
                 full_diff = param + ': ' + values[0] + '->' + values[1]
-                return full_diff if len(full_diff) <= 50 else param + ': [hidden - too long]'
+                return full_diff if not hide_long or len(full_diff) <= 50 else param + ': [hidden - too long]'
             restart_reason = '\n'.join(
-                [format_diff(k, v) for k, v in member.get('pending_restart_reason', {}).items()]) or ''
+                [format_diff(k, v, fmt == 'pretty') for k, v in member.get('pending_restart_reason', {}).items()]) or ''
 
             member.update(cluster=name, member=member['name'], group=g,
                           host=member.get('host', ''), tl=member.get('timeline', ''),

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -50,6 +50,7 @@ from . import global_config
 from .config import Config
 from .dcs import get_dcs as _get_dcs, AbstractDCS, Cluster, Member
 from .exceptions import PatroniException
+from .postgresql.config import ParamDiff
 from .postgresql.misc import postgres_version_to_int
 from .utils import cluster_as_json, patch_config, polling_loop
 from .request import PatroniRequest
@@ -1569,11 +1570,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
 
             lag = member.get('lag', '')
 
-            def format_diff(param: str, values: Dict[str, str], hide_long: bool):
-                full_diff = param + ': ' + values['old_value'] + '->' + values['new_value']
-                return full_diff if not hide_long or len(full_diff) <= 50 else param + ': [hidden - too long]'
-            restart_reason = '\n'.join(
-                [format_diff(k, v, fmt == 'pretty') for k, v in member.get('pending_restart_reason', {}).items()]) or ''
+            restart_reason = '\n'.join([ParamDiff.as_string(k, v, fmt == 'pretty')
+                                        for k, v in member.get('pending_restart_reason', {}).items()]) or ''
 
             member.update(cluster=name, member=member['name'], group=g,
                           host=member.get('host', ''), tl=member.get('timeline', ''),

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -363,7 +363,7 @@ class Ha(object):
                 data['tags'] = tags
             if self.state_handler.pending_restart_reason:
                 data['pending_restart'] = True
-                data['pending_restart_reason'] = self.state_handler.pending_restart_reason
+                data['pending_restart_reason'] = dict(self.state_handler.pending_restart_reason)
             if self._async_executor.scheduled_action in (None, 'promote') \
                     and data['state'] in ['running', 'restarting', 'starting']:
                 try:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -363,6 +363,7 @@ class Ha(object):
                 data['tags'] = tags
             if self.state_handler.pending_restart:
                 data['pending_restart'] = True
+                data['pending_restart_reason'] = self.state_handler.pending_restart_reason
             if self._async_executor.scheduled_action in (None, 'promote') \
                     and data['state'] in ['running', 'restarting', 'starting']:
                 try:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -361,7 +361,7 @@ class Ha(object):
             tags = self.get_effective_tags()
             if tags:
                 data['tags'] = tags
-            if self.state_handler.pending_restart:
+            if self.state_handler.pending_restart_reason:
                 data['pending_restart'] = True
                 data['pending_restart_reason'] = self.state_handler.pending_restart_reason
             if self._async_executor.scheduled_action in (None, 'promote') \
@@ -1486,7 +1486,7 @@ class Ha(object):
         if postgres_version and postgres_version_to_int(postgres_version) <= int(self.state_handler.server_version):
             reason_to_cancel = "postgres version mismatch"
 
-        if pending_restart and not self.state_handler.pending_restart:
+        if pending_restart and not self.state_handler.pending_restart_reason:
             reason_to_cancel = "pending restart flag is not set"
 
         if not reason_to_cancel:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -325,21 +325,18 @@ class Postgresql(object):
         """Get :attr:`_pending_restart_reason` value.
 
         :attr:`_pending_restart_reason` is a :class:`CaseInsensitiveDict` object of the PG parameters that are
-        causing pending restart state. Every key is a parameter name, value - :class:`ParamDiff` object.
+        causing pending restart state. Every key is a parameter name, value - a dictionary containing the old
+        and the new value (see :func:`~patroni.postgresql.config.get_param_diff`).
         """
         return self._pending_restart_reason
 
-    def set_pending_restart_reason(self, diff_dict: CaseInsensitiveDict, update: bool = False) -> None:
+    def set_pending_restart_reason(self, diff_dict: CaseInsensitiveDict) -> None:
         """Set new or update current :attr:`_pending_restart_reason`.
 
         :param diff_dict: :class:``CaseInsensitiveDict`` object with the parameters that are causing pending restart
             state with the diff of their values. Used to reset/update the :attr:`_pending_restart_reason`.
-        :param update: bool, indicates if :attr:`_pending_restart_reason` should be updated or reset with *diff_dict*.
         """
-        if update:
-            self._pending_restart_reason.update(diff_dict)
-        else:
-            self._pending_restart_reason = diff_dict
+        self._pending_restart_reason = diff_dict
 
     @property
     def sysid(self) -> str:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -77,7 +77,7 @@ class Postgresql(object):
         self._state_lock = Lock()
         self.set_state('stopped')
 
-        self._pending_restart_reason: Dict[str, Tuple[str, str]] = {}
+        self._pending_restart_reason: Dict[str, Dict[str, str]] = {}
         self.connection_pool = ConnectionPool()
         self._connection = self.connection_pool.get('heartbeat')
         self.citus_handler = CitusHandler(self, config.get('citus'))
@@ -321,10 +321,10 @@ class Postgresql(object):
         self._is_leader_retry.deadline = self.retry.deadline = config['retry_timeout'] / 2.0
 
     @property
-    def pending_restart_reason(self) -> Dict[str, Tuple[str, str]]:
+    def pending_restart_reason(self) -> Dict[str, Dict[str, str]]:
         return self._pending_restart_reason
 
-    def set_pending_restart(self, diff_dict: Dict[str, Tuple[str, str]]) -> None:
+    def set_pending_restart(self, diff_dict: Dict[str, Dict[str, str]]) -> None:
         if not diff_dict:
             self._pending_restart_reason = {}
         else:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Union, Tuple, 
 from .bootstrap import Bootstrap
 from .callback_executor import CallbackAction, CallbackExecutor
 from .cancellable import CancellableSubprocess
-from .config import ConfigHandler, ParamDiff, mtime
+from .config import ConfigHandler, mtime
 from .connection import ConnectionPool, get_connection_cursor
 from .misc import parse_history, parse_lsn, postgres_major_version_to_int
 from .mpp import AbstractMPP
@@ -35,6 +35,7 @@ from ..tags import Tags
 if TYPE_CHECKING:  # pragma: no cover
     from psycopg import Connection as Connection3, Cursor
     from psycopg2 import connection as connection3, cursor
+    from .config import ParamDiff
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,7 @@ class Postgresql(object):
         self._state_lock = Lock()
         self.set_state('stopped')
 
-        self._pending_restart_reason: Dict[str, ParamDiff] = {}
+        self._pending_restart_reason: Dict[str, 'ParamDiff'] = {}
         self.connection_pool = ConnectionPool()
         self._connection = self.connection_pool.get('heartbeat')
         self.citus_handler = mpp.get_handler_impl(self)
@@ -321,10 +322,10 @@ class Postgresql(object):
         self._is_leader_retry.deadline = self.retry.deadline = config['retry_timeout'] / 2.0
 
     @property
-    def pending_restart_reason(self) -> Dict[str, ParamDiff]:
+    def pending_restart_reason(self) -> Dict[str, 'ParamDiff']:
         return self._pending_restart_reason
 
-    def set_pending_restart_reason(self, diff_dict: Dict[str, ParamDiff], update: bool = False) -> None:
+    def set_pending_restart_reason(self, diff_dict: Dict[str, 'ParamDiff'], update: bool = False) -> None:
         if update:
             self._pending_restart_reason.update(diff_dict)
         else:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Union, Tuple, 
 from .bootstrap import Bootstrap
 from .callback_executor import CallbackAction, CallbackExecutor
 from .cancellable import CancellableSubprocess
-from .config import ConfigHandler, mtime
+from .config import ConfigHandler, ParamDiff, mtime
 from .connection import ConnectionPool, get_connection_cursor
 from .citus import CitusHandler
 from .misc import parse_history, parse_lsn, postgres_major_version_to_int
@@ -77,7 +77,7 @@ class Postgresql(object):
         self._state_lock = Lock()
         self.set_state('stopped')
 
-        self._pending_restart_reason: Dict[str, Dict[str, str]] = {}
+        self._pending_restart_reason: Dict[str, ParamDiff] = {}
         self.connection_pool = ConnectionPool()
         self._connection = self.connection_pool.get('heartbeat')
         self.citus_handler = CitusHandler(self, config.get('citus'))
@@ -321,10 +321,10 @@ class Postgresql(object):
         self._is_leader_retry.deadline = self.retry.deadline = config['retry_timeout'] / 2.0
 
     @property
-    def pending_restart_reason(self) -> Dict[str, Dict[str, str]]:
+    def pending_restart_reason(self) -> Dict[str, ParamDiff]:
         return self._pending_restart_reason
 
-    def set_pending_restart_reason(self, diff_dict: Dict[str, Dict[str, str]], update: bool = False) -> None:
+    def set_pending_restart_reason(self, diff_dict: Dict[str, ParamDiff], update: bool = False) -> None:
         if update:
             self._pending_restart_reason.update(diff_dict)
         else:

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -324,11 +324,11 @@ class Postgresql(object):
     def pending_restart_reason(self) -> Dict[str, Tuple[str, str]]:
         return self._pending_restart_reason
 
-    def set_pending_restart(self, value: bool, diff_dict: Optional[Dict[str, Tuple[str, str]]] = None) -> None:
-        if not value:
+    def set_pending_restart(self, diff_dict: Dict[str, Tuple[str, str]]) -> None:
+        if not diff_dict:
             self._pending_restart_reason = {}
         else:
-            self._pending_restart_reason.update(diff_dict or {})
+            self._pending_restart_reason.update(diff_dict)
 
     @property
     def sysid(self) -> str:
@@ -730,7 +730,7 @@ class Postgresql(object):
         self.set_role(role or self.get_postgres_role_from_data_directory())
 
         self.set_state('starting')
-        self.set_pending_restart(False)
+        self.set_pending_restart({})
 
         try:
             if not self.ensure_major_version_is_known():

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -324,11 +324,11 @@ class Postgresql(object):
     def pending_restart_reason(self) -> Dict[str, Dict[str, str]]:
         return self._pending_restart_reason
 
-    def set_pending_restart(self, diff_dict: Dict[str, Dict[str, str]]) -> None:
-        if not diff_dict:
-            self._pending_restart_reason = {}
-        else:
+    def set_pending_restart_reason(self, diff_dict: Dict[str, Dict[str, str]], update: bool = False) -> None:
+        if update:
             self._pending_restart_reason.update(diff_dict)
+        else:
+            self._pending_restart_reason = diff_dict
 
     @property
     def sysid(self) -> str:
@@ -730,7 +730,7 @@ class Postgresql(object):
         self.set_role(role or self.get_postgres_role_from_data_directory())
 
         self.set_state('starting')
-        self.set_pending_restart({})
+        self.set_pending_restart_reason({})
 
         try:
             if not self.ensure_major_version_is_known():

--- a/patroni/postgresql/__init__.py
+++ b/patroni/postgresql/__init__.py
@@ -77,7 +77,6 @@ class Postgresql(object):
         self._state_lock = Lock()
         self.set_state('stopped')
 
-        self._pending_restart = False
         self._pending_restart_reason: Dict[str, Tuple[str, str]] = {}
         self.connection_pool = ConnectionPool()
         self._connection = self.connection_pool.get('heartbeat')
@@ -322,15 +321,10 @@ class Postgresql(object):
         self._is_leader_retry.deadline = self.retry.deadline = config['retry_timeout'] / 2.0
 
     @property
-    def pending_restart(self) -> bool:
-        return self._pending_restart
-
-    @property
     def pending_restart_reason(self) -> Dict[str, Tuple[str, str]]:
         return self._pending_restart_reason
 
     def set_pending_restart(self, value: bool, diff_dict: Optional[Dict[str, Tuple[str, str]]] = None) -> None:
-        self._pending_restart = value
         if not value:
             self._pending_restart_reason = {}
         else:

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -463,7 +463,7 @@ END;$$""".format(f, quote_ident(rewind['username'], postgresql.connection()))
                         postgresql.restart()
                     else:
                         postgresql.config.replace_pg_hba()
-                        if postgresql.pending_restart:
+                        if postgresql.pending_restart_reason:
                             postgresql.restart()
                         else:
                             postgresql.reload()

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1181,7 +1181,7 @@ class ConfigHandler(object):
         else:
             logger.info('No PostgreSQL configuration items changed, nothing to reload.')
 
-        self._postgresql.set_pending_restart(param_diff)
+        self._postgresql.set_pending_restart_reason(param_diff)
 
     def set_synchronous_standby_names(self, value: Optional[str]) -> Optional[bool]:
         """Updates synchronous_standby_names and reloads if necessary.
@@ -1236,7 +1236,7 @@ class ConfigHandler(object):
                 effective_configuration[name] = cvalue
                 logger.info("%s value in pg_controldata: %d, in the global configuration: %d."
                             " pg_controldata value will be used. Setting 'Pending restart' flag", name, cvalue, value)
-                self._postgresql.set_pending_restart({name: get_parameter_diff(cvalue, value)})
+                self._postgresql.set_pending_restart_reason({name: get_parameter_diff(cvalue, value)}, True)
 
         # If we are using custom bootstrap with PITR it could fail when values like max_connections
         # are increased, therefore we disable hot_standby if recovery_target_action == 'promote'.
@@ -1255,7 +1255,7 @@ class ConfigHandler(object):
                 effective_configuration['hot_standby'] = 'off'
                 logger.info("'hot_standby' parameter is set to 'off' during the custom bootstrap."
                             " Setting 'Pending restart' flag")
-                self._postgresql.set_pending_restart({'hot_standby': get_parameter_diff('on', 'off')})
+                self._postgresql.set_pending_restart_reason({'hot_standby': get_parameter_diff('on', 'off')}, True)
 
         return effective_configuration
 

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1156,9 +1156,9 @@ class ConfigHandler(object):
                 time.sleep(1)
                 try:
                     settings_diff = {
-                        p: param_diff.get(p, (v, (lambda x: '?' if x is None else x)(self._postgresql.get_guc_value(p))))
+                        p: (v, (lambda x: '?' if x is None else x)(self._postgresql.get_guc_value(p)))
                         for p, v in self._postgresql.query(
-                            'SELECT name, pg_catalog.current_setting(name) FROM pg_catalog.pg_settings'
+                            'SELECT name, setting FROM pg_catalog.pg_settings'
                             ' WHERE pg_catalog.lower(name) != ALL(%s) AND pending_restart',
                             [n.lower() for n in self._RECOVERY_PARAMETERS])
                         }

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1111,7 +1111,8 @@ class ConfigHandler(object):
                         # Check that user-defined-parameters have changed (parameters with period in name)
                         if value is None or param not in self._server_parameters \
                                 or str(value) != str(self._server_parameters[param]):
-                            logger.info("Changed %s from '%s' to '%s'", param, self._server_parameters.get(param), value)
+                            logger.info("Changed %s from '%s' to '%s'",
+                                        param, self._server_parameters.get(param), value)
                             conf_changed = True
                     elif param in server_parameters:
                         logger.warning('Removing invalid parameter `%s` from postgresql.parameters', param)
@@ -1161,7 +1162,7 @@ class ConfigHandler(object):
                             'SELECT name, setting FROM pg_catalog.pg_settings'
                             ' WHERE pg_catalog.lower(name) != ALL(%s) AND pending_restart',
                             [n.lower() for n in self._RECOVERY_PARAMETERS])
-                        }
+                    }
                     pending_restart = len(settings_diff) > 0
                     external_change = settings_diff.keys() - param_diff.keys()
                     if external_change:

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -17,7 +17,7 @@ from ..collections import CaseInsensitiveDict, CaseInsensitiveSet
 from ..dcs import Leader, Member, RemoteMember, slot_name_from_member_name
 from ..exceptions import PatroniFatalException, PostgresConnectionException
 from ..file_perm import pg_perm
-from ..utils import (compare_values, maybe_convert_base_unit, parse_bool, parse_int,
+from ..utils import (compare_values, maybe_convert_from_base_unit, parse_bool, parse_int,
                      split_host_port, uri, validate_directory, is_subpath)
 from ..validator import IntValidator, EnumValidator
 
@@ -1122,7 +1122,7 @@ class ConfigHandler(object):
                         new_value = changes.pop(r[0])
                         if new_value is None or not compare_values(r[3], r[2], r[1], new_value):
                             conf_changed = True
-                            old_value = maybe_convert_base_unit(r[1], r[3], r[2])
+                            old_value = maybe_convert_from_base_unit(r[1], r[3], r[2])
                             if r[4] == 'postmaster':
                                 param_diff[r[0]] = ParamDiff(old_value, new_value)
                                 logger.info("Changed %s from '%s' to '%s' (restart might be required)",
@@ -1136,7 +1136,7 @@ class ConfigHandler(object):
                                 and not compare_values(r[3], r[2], r[1], self._server_parameters[r[0]]):
                             # Check if any parameter was set back to the current pg_settings value
                             # We can use pg_settings value here, as it is proved to be equal to new_value
-                            logger.info('Changed %s from %s to %s', r[0], self._server_parameters[r[0]], r[1])
+                            logger.info("Changed %s from '%s' to '%s'", r[0], self._server_parameters[r[0]], new_value)
                             conf_changed = True
                 for param, value in changes.items():
                     if '.' in param:
@@ -1195,7 +1195,7 @@ class ConfigHandler(object):
                             [n.lower() for n in self._RECOVERY_PARAMETERS]):
                         new_value = (
                             lambda v: '?' if v is None
-                            else maybe_convert_base_unit(v, vartype, unit))(self._postgresql.get_guc_value(param))
+                            else maybe_convert_from_base_unit(v, vartype, unit))(self._postgresql.get_guc_value(param))
                         settings_diff[param] = ParamDiff(value, new_value)
                     external_change = {param: value for param, value in settings_diff.items()
                                        if param not in param_diff or value != param_diff[param]}

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -271,7 +271,7 @@ def _bool_is_true_validator(value: Any) -> bool:
     return parse_bool(value) is True
 
 
-class ParamDiff(dict[str, str]):
+class ParamDiff(Dict[str, str]):
 
     def __init__(self, old_value: Any, new_value: Any):
         super(ParamDiff, self).__init__()

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1093,7 +1093,7 @@ class ConfigHandler(object):
                             if r[4] == 'postmaster':
                                 pending_restart = True
                                 param_diff[r[0]] = (r[1], str(new_value))
-                                logger.info("Changed %s from '%s' to '%s'. Setting 'Pending restart' flag",
+                                logger.info("Changed %s from '%s' to '%s' (restart might be required)",
                                             r[0], r[1], new_value)
                                 if config.get('use_unix_socket') and r[0] == 'unix_socket_directories'\
                                         or r[0] in ('listen_addresses', 'port'):

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -271,6 +271,10 @@ def _bool_is_true_validator(value: Any) -> bool:
     return parse_bool(value) is True
 
 
+def get_parameter_diff(old_value: Any, new_value: Any) -> Dict[str, str]:
+    return {'old_value': str(old_value), 'new_value': str(new_value)}
+
+
 class ConfigHandler(object):
 
     # List of parameters which must be always passed to postmaster as command line options
@@ -1068,7 +1072,7 @@ class ConfigHandler(object):
         server_parameters = self.get_server_parameters(config)
 
         conf_changed = hba_changed = ident_changed = local_connection_address_changed = False
-        param_diff: Dict[str, Tuple[str, str]] = {}
+        param_diff: Dict[str, Dict[str, str]] = {}
         if self._postgresql.state == 'running':
             changes = CaseInsensitiveDict({p: v for p, v in server_parameters.items()
                                            if p.lower() not in self._RECOVERY_PARAMETERS})
@@ -1093,7 +1097,7 @@ class ConfigHandler(object):
                             conf_changed = True
                             if r[4] == 'postmaster':
                                 old_value = maybe_convert_int_base_unit(r[1], r[2])
-                                param_diff[r[0]] = (old_value, str(new_value))
+                                param_diff[r[0]] = get_parameter_diff(old_value, new_value)
                                 logger.info("Changed %s from '%s' to '%s' (restart might be required)",
                                             r[0], old_value, new_value)
                                 if config.get('use_unix_socket') and r[0] == 'unix_socket_directories'\
@@ -1157,15 +1161,16 @@ class ConfigHandler(object):
             if self._postgresql.major_version >= 90500:
                 time.sleep(1)
                 try:
-                    settings_diff: Dict[str, Tuple[str, str]] = {}
+                    settings_diff: Dict[str, Dict[str, str]] = {}
                     for param, value, unit in self._postgresql.query(
                             'SELECT name, pg_catalog.current_setting(name), unit FROM pg_catalog.pg_settings'
                             ' WHERE pg_catalog.lower(name) != ALL(%s) AND pending_restart',
                             [n.lower() for n in self._RECOVERY_PARAMETERS]):
                         new_value = (lambda v: '?' if v is None
                                      else maybe_convert_int_base_unit(v, unit))(self._postgresql.get_guc_value(param))
-                        settings_diff[param] = (value, new_value)
-                    external_change = set(map(lambda x: x[0], settings_diff.items() - param_diff.items()))
+                        settings_diff[param] = get_parameter_diff(value, new_value)
+                    external_change = {param: value for param, value in settings_diff.items()
+                                       if param not in param_diff or value != param_diff[param]}
                     if external_change:
                         logger.info("PostgreSQL configuration parameters requiring restart"
                                     " (%s) seem to be changed bypassing Patroni config."
@@ -1231,7 +1236,7 @@ class ConfigHandler(object):
                 effective_configuration[name] = cvalue
                 logger.info("%s value in pg_controldata: %d, in the global configuration: %d."
                             " pg_controldata value will be used. Setting 'Pending restart' flag", name, cvalue, value)
-                self._postgresql.set_pending_restart({name: (str(cvalue), str(value))})
+                self._postgresql.set_pending_restart({name: get_parameter_diff(cvalue, value)})
 
         # If we are using custom bootstrap with PITR it could fail when values like max_connections
         # are increased, therefore we disable hot_standby if recovery_target_action == 'promote'.
@@ -1250,7 +1255,7 @@ class ConfigHandler(object):
                 effective_configuration['hot_standby'] = 'off'
                 logger.info("'hot_standby' parameter is set to 'off' during the custom bootstrap."
                             " Setting 'Pending restart' flag")
-                self._postgresql.set_pending_restart({'hot_standby': ('on', 'off')})
+                self._postgresql.set_pending_restart({'hot_standby': get_parameter_diff('on', 'off')})
 
         return effective_configuration
 

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1164,7 +1164,7 @@ class ConfigHandler(object):
                             [n.lower() for n in self._RECOVERY_PARAMETERS])
                     }
                     pending_restart = len(settings_diff) > 0
-                    external_change = settings_diff.keys() - param_diff.keys()
+                    external_change = set(map(lambda x: x[0], settings_diff.items() - param_diff.items()))
                     if external_change:
                         logger.info("PostgreSQL configuration parameters requiring restart"
                                     " (%s) seem to be changed bypassing Patroni config."

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -271,8 +271,17 @@ def _bool_is_true_validator(value: Any) -> bool:
     return parse_bool(value) is True
 
 
-def get_parameter_diff(old_value: Any, new_value: Any) -> Dict[str, str]:
-    return {'old_value': str(old_value), 'new_value': str(new_value)}
+class ParamDiff(dict[str, str]):
+
+    def __init__(self, old_value: Any, new_value: Any):
+        super(ParamDiff, self).__init__()
+        self['old_value'] = str(old_value)
+        self['new_value'] = str(new_value)
+
+    @staticmethod
+    def as_string(param: str, diff_dict: Dict[str, str], hide_long: bool) -> str:
+        full_diff = param + ': ' + diff_dict['old_value'] + '->' + diff_dict['new_value']
+        return full_diff if not hide_long or len(full_diff) <= 50 else param + ': [hidden - too long]'
 
 
 class ConfigHandler(object):
@@ -1072,7 +1081,7 @@ class ConfigHandler(object):
         server_parameters = self.get_server_parameters(config)
 
         conf_changed = hba_changed = ident_changed = local_connection_address_changed = False
-        param_diff: Dict[str, Dict[str, str]] = {}
+        param_diff: Dict[str, ParamDiff] = {}
         if self._postgresql.state == 'running':
             changes = CaseInsensitiveDict({p: v for p, v in server_parameters.items()
                                            if p.lower() not in self._RECOVERY_PARAMETERS})
@@ -1097,7 +1106,7 @@ class ConfigHandler(object):
                             conf_changed = True
                             if r[4] == 'postmaster':
                                 old_value = maybe_convert_int_base_unit(r[1], r[2])
-                                param_diff[r[0]] = get_parameter_diff(old_value, new_value)
+                                param_diff[r[0]] = ParamDiff(old_value, new_value)
                                 logger.info("Changed %s from '%s' to '%s' (restart might be required)",
                                             r[0], old_value, new_value)
                                 if config.get('use_unix_socket') and r[0] == 'unix_socket_directories'\
@@ -1161,14 +1170,14 @@ class ConfigHandler(object):
             if self._postgresql.major_version >= 90500:
                 time.sleep(1)
                 try:
-                    settings_diff: Dict[str, Dict[str, str]] = {}
+                    settings_diff: Dict[str, ParamDiff] = {}
                     for param, value, unit in self._postgresql.query(
                             'SELECT name, pg_catalog.current_setting(name), unit FROM pg_catalog.pg_settings'
                             ' WHERE pg_catalog.lower(name) != ALL(%s) AND pending_restart',
                             [n.lower() for n in self._RECOVERY_PARAMETERS]):
                         new_value = (lambda v: '?' if v is None
                                      else maybe_convert_int_base_unit(v, unit))(self._postgresql.get_guc_value(param))
-                        settings_diff[param] = get_parameter_diff(value, new_value)
+                        settings_diff[param] = ParamDiff(value, new_value)
                     external_change = {param: value for param, value in settings_diff.items()
                                        if param not in param_diff or value != param_diff[param]}
                     if external_change:
@@ -1236,7 +1245,7 @@ class ConfigHandler(object):
                 effective_configuration[name] = cvalue
                 logger.info("%s value in pg_controldata: %d, in the global configuration: %d."
                             " pg_controldata value will be used. Setting 'Pending restart' flag", name, cvalue, value)
-                self._postgresql.set_pending_restart_reason({name: get_parameter_diff(cvalue, value)}, True)
+                self._postgresql.set_pending_restart_reason({name: ParamDiff(cvalue, value)}, True)
 
         # If we are using custom bootstrap with PITR it could fail when values like max_connections
         # are increased, therefore we disable hot_standby if recovery_target_action == 'promote'.
@@ -1255,7 +1264,7 @@ class ConfigHandler(object):
                 effective_configuration['hot_standby'] = 'off'
                 logger.info("'hot_standby' parameter is set to 'off' during the custom bootstrap."
                             " Setting 'Pending restart' flag")
-                self._postgresql.set_pending_restart_reason({'hot_standby': get_parameter_diff('on', 'off')}, True)
+                self._postgresql.set_pending_restart_reason({'hot_standby': ParamDiff('on', 'off')}, True)
 
         return effective_configuration
 

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1230,7 +1230,7 @@ class ConfigHandler(object):
                 effective_configuration[name] = cvalue
                 logger.info("%s value in pg_controldata: %d, in the global configuration: %d."
                             " pg_controldata value will be used. Setting 'Pending restart' flag", name, cvalue, value)
-                self._postgresql.set_pending_restart(True, {cname: (str(cvalue), str(value))})
+                self._postgresql.set_pending_restart(True, {name: (str(cvalue), str(value))})
 
         # If we are using custom bootstrap with PITR it could fail when values like max_connections
         # are increased, therefore we disable hot_standby if recovery_target_action == 'promote'.

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -35,14 +35,14 @@ from .version import __version__
 if TYPE_CHECKING:  # pragma: no cover
     from .dcs import Cluster
 
-memory_unit_conversion_table: OrderedDict[str, Dict[str, Union[int, float]]] = OrderedDict([
+memory_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
     ('TB', {'B': 1024**4, 'kB': 1024**3, 'MB': 1024**2}),
     ('GB', {'B': 1024**3, 'kB': 1024**2, 'MB': 1024}),
     ('MB', {'B': 1024**2, 'kB': 1024, 'MB': 1}),
     ('kB', {'B': 1024, 'kB': 1, 'MB': 1024**-1}),
     ('B', {'B': 1, 'kB': 1024**-1, 'MB': 1024**-2})
 ])
-time_unit_conversion_table: OrderedDict[str, Dict[str, Union[int, float]]] = OrderedDict([
+time_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
     ('d', {'ms': 1000 * 60**2 * 24, 's': 60**2 * 24, 'min': 60 * 24}),
     ('h', {'ms': 1000 * 60**2, 's': 60**2, 'min': 60}),
     ('min', {'ms': 1000 * 60, 's': 60, 'min': 1}),
@@ -63,7 +63,7 @@ DBL_RE = re.compile(r'^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?')
 WHITESPACE_RE = re.compile(r'[ \t\n\r]*', re.VERBOSE | re.MULTILINE | re.DOTALL)
 
 
-def get_conversion_table(base_unit: str) -> OrderedDict[str, Dict[str, Union[int, float]]]:
+def get_conversion_table(base_unit: str) -> Dict[str, Dict[str, Union[int, float]]]:
     """Get convertion table for the specified base unit.
 
     If no convertion table exists for the passed unit, return an empty :class:`OrderedDict`.

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -813,7 +813,7 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             member['host'] = conn_kwargs['host']
             if conn_kwargs.get('port'):
                 member['port'] = int(conn_kwargs['port'])
-        optional_attributes = ('timeline', 'pending_restart', 'scheduled_restart', 'tags')
+        optional_attributes = ('timeline', 'pending_restart', 'pending_restart_reason', 'scheduled_restart', 'tags')
         member.update({n: m.data[n] for n in optional_attributes if n in m.data})
 
         if m.name != leader_name:

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -10,6 +10,7 @@
 :var WHITESPACE_RE: regular expression to match whitespace characters
 """
 import errno
+import itertools
 import logging
 import os
 import platform
@@ -305,15 +306,12 @@ def convert_to_base_unit(value: Union[int, float], unit: str, base_unit: Optiona
         >>> convert_to_base_unit(1, 'GB', '512 MB') is None
         True
     """
-    round_order = {
-        'TB': 'GB', 'GB': 'MB', 'MB': 'kB', 'kB': 'B',
-        'd': 'h', 'h': 'min', 'min': 's', 's': 'ms', 'ms': 'us'
-    }
     base_value, base_unit = strtol(base_unit, False)
     if TYPE_CHECKING:  # pragma: no cover
         assert isinstance(base_value, int)
 
     convert_tbl = get_conversion_table(base_unit)
+    round_order = dict(zip(convert_tbl, itertools.islice(convert_tbl, 1, None)))
     if unit in convert_tbl and base_unit in convert_tbl[unit]:
         value *= convert_tbl[unit][base_unit] / float(base_value)
         if unit in round_order:
@@ -411,7 +409,7 @@ def convert_real_from_base_unit(base_value: float, base_unit: Optional[str]) -> 
     return result
 
 
-def maybe_convert_base_unit(base_value: str, vartype: str, base_unit: Optional[str]) -> str:
+def maybe_convert_from_base_unit(base_value: str, vartype: str, base_unit: Optional[str]) -> str:
     """Try to convert integer or real value in a base unit to a human-readable unit.
 
     Value is passed as a string. If parsing or subsequent convertion fails, the original

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -150,6 +150,8 @@ class MockCursor(object):
             self.results = [(False, 2)]
         elif sql.startswith('SELECT pg_catalog.pg_postmaster_start_time'):
             self.results = [(datetime.datetime.now(tzutc),)]
+        elif sql.endswith('AND pending_restart'):
+            self.results = []
         elif sql.startswith('SELECT name, pg_catalog.current_setting(name) FROM pg_catalog.pg_settings'):
             self.results = [('data_directory', 'data'),
                             ('hba_file', os.path.join('data', 'pg_hba.conf')),
@@ -167,8 +169,6 @@ class MockCursor(object):
                             ('cluster_name', 'my_cluster')]
         elif sql.startswith('SELECT name, setting'):
             self.results = GET_PG_SETTINGS_RESULT
-        elif sql.startswith('SELECT COUNT(*) FROM pg_catalog.pg_settings'):
-            self.results = [(0,)]
         elif sql.startswith('IDENTIFY_SYSTEM'):
             self.results = [('1', 3, '0/402EEC0', '')]
         elif sql.startswith('TIMELINE_HISTORY '):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,7 @@ class MockPostgresql:
     sysid = 'dummysysid'
     scope = 'dummy'
     pending_restart = True
+    pending_restart_reason = {}
     wal_name = 'wal'
     lsn_name = 'lsn'
     wal_flush = '_flush'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from patroni.api import RestApiHandler, RestApiServer
 from patroni.dcs import ClusterConfig, Member
 from patroni.exceptions import PostgresConnectionException
 from patroni.ha import _MemberStatus
-from patroni.postgresql.config import ParamDiff
+from patroni.postgresql.config import get_param_diff
 from patroni.psycopg import OperationalError
 from patroni.utils import RetryFailedError, tzutc
 
@@ -203,7 +203,7 @@ class TestRestApiHandler(unittest.TestCase):
     _authorization = '\nAuthorization: Basic dGVzdDp0ZXN0'
 
     def test_do_GET(self):
-        MockPostgresql.pending_restart_reason = {'max_connections': ParamDiff('200', '100')}
+        MockPostgresql.pending_restart_reason = {'max_connections': get_param_diff('200', '100')}
         MockPatroni.dcs.cluster.last_lsn = 20
         MockPatroni.dcs.cluster.sync.members = [MockPostgresql.name]
         with patch.object(global_config.__class__, 'is_synchronous_mode', PropertyMock(return_value=True)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from patroni.api import RestApiHandler, RestApiServer
 from patroni.dcs import ClusterConfig, Member
 from patroni.exceptions import PostgresConnectionException
 from patroni.ha import _MemberStatus
-from patroni.postgresql.config import get_parameter_diff
+from patroni.postgresql.config import ParamDiff
 from patroni.psycopg import OperationalError
 from patroni.utils import RetryFailedError, tzutc
 
@@ -203,7 +203,7 @@ class TestRestApiHandler(unittest.TestCase):
     _authorization = '\nAuthorization: Basic dGVzdDp0ZXN0'
 
     def test_do_GET(self):
-        MockPostgresql.pending_restart_reason = {'max_connections': get_parameter_diff('200', '100')}
+        MockPostgresql.pending_restart_reason = {'max_connections': ParamDiff('200', '100')}
         MockPatroni.dcs.cluster.last_lsn = 20
         MockPatroni.dcs.cluster.sync.members = [MockPostgresql.name]
         with patch.object(global_config.__class__, 'is_synchronous_mode', PropertyMock(return_value=True)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from patroni.api import RestApiHandler, RestApiServer
 from patroni.dcs import ClusterConfig, Member
 from patroni.exceptions import PostgresConnectionException
 from patroni.ha import _MemberStatus
+from patroni.postgresql.config import get_parameter_diff
 from patroni.psycopg import OperationalError
 from patroni.utils import RetryFailedError, tzutc
 
@@ -202,7 +203,7 @@ class TestRestApiHandler(unittest.TestCase):
     _authorization = '\nAuthorization: Basic dGVzdDp0ZXN0'
 
     def test_do_GET(self):
-        MockPostgresql.pending_restart_reason = {'max_connections': ('200', '100')}
+        MockPostgresql.pending_restart_reason = {'max_connections': get_parameter_diff('200', '100')}
         MockPatroni.dcs.cluster.last_lsn = 20
         MockPatroni.dcs.cluster.sync.members = [MockPostgresql.name]
         with patch.object(global_config.__class__, 'is_synchronous_mode', PropertyMock(return_value=True)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,7 +54,6 @@ class MockPostgresql:
     major_version = 90600
     sysid = 'dummysysid'
     scope = 'dummy'
-    pending_restart = True
     pending_restart_reason = {}
     wal_name = 'wal'
     lsn_name = 'lsn'
@@ -203,6 +202,7 @@ class TestRestApiHandler(unittest.TestCase):
     _authorization = '\nAuthorization: Basic dGVzdDp0ZXN0'
 
     def test_do_GET(self):
+        MockPostgresql.pending_restart_reason = {'max_connections': ('200', '100')}
         MockPatroni.dcs.cluster.last_lsn = 20
         MockPatroni.dcs.cluster.sync.members = [MockPostgresql.name]
         with patch.object(global_config.__class__, 'is_synchronous_mode', PropertyMock(return_value=True)):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,10 +4,11 @@ import sys
 from mock import Mock, PropertyMock, patch
 
 from patroni.async_executor import CriticalTask
+from patroni.collections import CaseInsensitiveDict
 from patroni.postgresql import Postgresql
 from patroni.postgresql.bootstrap import Bootstrap
 from patroni.postgresql.cancellable import CancellableSubprocess
-from patroni.postgresql.config import ConfigHandler
+from patroni.postgresql.config import ConfigHandler, ParamDiff
 
 from . import psycopg_connect, BaseTestPostgresql, mock_available_gucs
 
@@ -235,8 +236,9 @@ class TestBootstrap(BaseTestPostgresql):
         self.assertTrue(task.result)
 
         self.b.bootstrap(config)
-        with patch.object(Postgresql, 'pending_restart_reason', PropertyMock({'max_connections': ('200', '100')})), \
-                patch.object(Postgresql, 'restart', Mock()) as mock_restart:
+        with patch.object(Postgresql, 'pending_restart_reason',
+                          PropertyMock(CaseInsensitiveDict({'max_connections': ParamDiff('200', '100')}))), \
+             patch.object(Postgresql, 'restart', Mock()) as mock_restart:
             self.b.post_bootstrap({}, task)
             mock_restart.assert_called_once()
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -8,7 +8,7 @@ from patroni.collections import CaseInsensitiveDict
 from patroni.postgresql import Postgresql
 from patroni.postgresql.bootstrap import Bootstrap
 from patroni.postgresql.cancellable import CancellableSubprocess
-from patroni.postgresql.config import ConfigHandler, ParamDiff
+from patroni.postgresql.config import ConfigHandler, get_param_diff
 
 from . import psycopg_connect, BaseTestPostgresql, mock_available_gucs
 
@@ -237,7 +237,7 @@ class TestBootstrap(BaseTestPostgresql):
 
         self.b.bootstrap(config)
         with patch.object(Postgresql, 'pending_restart_reason',
-                          PropertyMock(CaseInsensitiveDict({'max_connections': ParamDiff('200', '100')}))), \
+                          PropertyMock(CaseInsensitiveDict({'max_connections': get_param_diff('200', '100')}))), \
              patch.object(Postgresql, 'restart', Mock()) as mock_restart:
             self.b.post_bootstrap({}, task)
             mock_restart.assert_called_once()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -235,7 +235,7 @@ class TestBootstrap(BaseTestPostgresql):
         self.assertTrue(task.result)
 
         self.b.bootstrap(config)
-        with patch.object(Postgresql, 'pending_restart', PropertyMock(return_value=True)), \
+        with patch.object(Postgresql, 'pending_restart_reason', PropertyMock({'max_connections': ('200', '100')})), \
                 patch.object(Postgresql, 'restart', Mock()) as mock_restart:
             self.b.post_bootstrap({}, task)
             mock_restart.assert_called_once()

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -487,8 +487,9 @@ class TestCtl(unittest.TestCase):
         cluster.members[1].data['pending_restart'] = True
         cluster.members[1].data['pending_restart_reason'] = {'param': get_param_diff('', 'very l' + 'o' * 34 + 'ng')}
         with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=cluster)):
-            result = self.runner.invoke(ctl, ['list', 'dummy'])
-            self.assertIn('param: [hidden - too long]', result.output)
+            for cmd in ('list', 'topology'):
+                result = self.runner.invoke(ctl, [cmd, 'dummy'])
+                self.assertIn('param: [hidden - too long]', result.output)
 
             result = self.runner.invoke(ctl, ['list', 'dummy', '-f', 'tsv'])
             self.assertIn('param: ->very l' + 'o' * 34 + 'ng', result.output)

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -12,7 +12,7 @@ from patroni.ctl import ctl, load_config, output_members, get_dcs, parse_dcs, \
     get_all_members, get_any_member, get_cursor, query_member, PatroniCtlException, apply_config_changes, \
     format_config_for_editing, show_diff, invoke_editor, format_pg_version, CONFIG_FILE_PATH, PatronictlPrettyTable
 from patroni.dcs import Cluster, Failover
-from patroni.postgresql.config import ParamDiff
+from patroni.postgresql.config import get_param_diff
 from patroni.postgresql.mpp import get_mpp
 from patroni.psycopg import OperationalError
 from patroni.utils import tzutc
@@ -485,7 +485,7 @@ class TestCtl(unittest.TestCase):
 
         cluster = get_cluster_initialized_with_leader()
         cluster.members[1].data['pending_restart'] = True
-        cluster.members[1].data['pending_restart_reason'] = {'param': ParamDiff('', 'very l' + 'o' * 34 + 'ng')}
+        cluster.members[1].data['pending_restart_reason'] = {'param': get_param_diff('', 'very l' + 'o' * 34 + 'ng')}
         with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=cluster)):
             result = self.runner.invoke(ctl, ['list', 'dummy'])
             self.assertIn('param: [hidden - too long]', result.output)
@@ -493,7 +493,7 @@ class TestCtl(unittest.TestCase):
             result = self.runner.invoke(ctl, ['list', 'dummy', '-f', 'tsv'])
             self.assertIn('param: ->very l' + 'o' * 34 + 'ng', result.output)
 
-            cluster.members[1].data['pending_restart_reason'] = {'param': ParamDiff('', 'new')}
+            cluster.members[1].data['pending_restart_reason'] = {'param': get_param_diff('', 'new')}
             result = self.runner.invoke(ctl, ['list', 'dummy'])
             self.assertIn('param: ->new', result.output)
 

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -12,7 +12,7 @@ from patroni.ctl import ctl, load_config, output_members, get_dcs, parse_dcs, \
     get_all_members, get_any_member, get_cursor, query_member, PatroniCtlException, apply_config_changes, \
     format_config_for_editing, show_diff, invoke_editor, format_pg_version, CONFIG_FILE_PATH, PatronictlPrettyTable
 from patroni.dcs import Cluster, Failover
-from patroni.postgresql.config import get_parameter_diff
+from patroni.postgresql.config import ParamDiff
 from patroni.psycopg import OperationalError
 from patroni.utils import tzutc
 from prettytable import PrettyTable, ALL
@@ -476,8 +476,7 @@ class TestCtl(unittest.TestCase):
 
         cluster = get_cluster_initialized_with_leader()
         cluster.members[1].data['pending_restart'] = True
-        cluster.members[1].data['pending_restart_reason'] = {
-            'param': get_parameter_diff('', 'very l' + 'o' * 34 + 'ng')}
+        cluster.members[1].data['pending_restart_reason'] = {'param': ParamDiff('', 'very l' + 'o' * 34 + 'ng')}
         with patch('patroni.dcs.AbstractDCS.get_cluster', Mock(return_value=cluster)):
             result = self.runner.invoke(ctl, ['list', 'dummy'])
             self.assertIn('param: [hidden - too long]', result.output)
@@ -485,7 +484,7 @@ class TestCtl(unittest.TestCase):
             result = self.runner.invoke(ctl, ['list', 'dummy', '-f', 'tsv'])
             self.assertIn('param: ->very l' + 'o' * 34 + 'ng', result.output)
 
-            cluster.members[1].data['pending_restart_reason'] = {'param': get_parameter_diff('', 'new')}
+            cluster.members[1].data['pending_restart_reason'] = {'param': ParamDiff('', 'new')}
             result = self.runner.invoke(ctl, ['list', 'dummy'])
             self.assertIn('param: ->new', result.output)
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -597,8 +597,9 @@ class TestPostgresql(BaseTestPostgresql):
         config['parameters']['max_worker_processes'] *= 2
         new_max_worker_processes = config['parameters']['max_worker_processes']
 
-        with patch('patroni.postgresql.Postgresql._query', Mock(side_effect=[
-            GET_PG_SETTINGS_RESULT, [('max_worker_processes', config['parameters']['max_worker_processes'])]])):
+        with patch.object(Postgresql, 'get_guc_value', Mock(return_value=str(new_max_worker_processes))), \
+             patch('patroni.postgresql.Postgresql._query', Mock(side_effect=[
+            GET_PG_SETTINGS_RESULT, [('max_worker_processes', str(init_max_worker_processes))]])):
             self.p.reload_config(config)
             self.assertEqual(mock_info.call_args_list[0][0],
                              ("Changed %s from '%s' to '%s' (restart might be required)",

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -599,7 +599,7 @@ class TestPostgresql(BaseTestPostgresql):
 
         with patch.object(Postgresql, 'get_guc_value', Mock(return_value=str(new_max_worker_processes))), \
              patch('patroni.postgresql.Postgresql._query', Mock(side_effect=[
-            GET_PG_SETTINGS_RESULT, [('max_worker_processes', str(init_max_worker_processes))]])):
+                 GET_PG_SETTINGS_RESULT, [('max_worker_processes', str(init_max_worker_processes))]])):
             self.p.reload_config(config)
             self.assertEqual(mock_info.call_args_list[0][0],
                              ("Changed %s from '%s' to '%s' (restart might be required)",

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -617,9 +617,9 @@ class TestPostgresql(BaseTestPostgresql):
         # Reset to the initial value without restart
         config['parameters']['max_worker_processes'] = init_max_worker_processes
         self.p.reload_config(config)
-        self.assertEqual(mock_info.call_args_list[0][0], ('Changed %s from %s to %s', 'max_worker_processes',
+        self.assertEqual(mock_info.call_args_list[0][0], ("Changed %s from '%s' to '%s'", 'max_worker_processes',
                                                           init_max_worker_processes * 2,
-                                                          str(config['parameters']['max_worker_processes'])))
+                                                          config['parameters']['max_worker_processes']))
         self.assertEqual(mock_info.call_args_list[1][0], ('Reloading PostgreSQL configuration.',))
         self.assertEqual(self.p.pending_restart_reason, CaseInsensitiveDict())
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -601,7 +601,7 @@ class TestPostgresql(BaseTestPostgresql):
             GET_PG_SETTINGS_RESULT, [('max_worker_processes', config['parameters']['max_worker_processes'])]])):
             self.p.reload_config(config)
             self.assertEqual(mock_info.call_args_list[0][0],
-                             ("Changed %s from '%s' to '%s'. Setting 'Pending restart' flag",
+                             ("Changed %s from '%s' to '%s' (restart might be required)",
                               'max_worker_processes', str(init_max_worker_processes), new_max_worker_processes))
             self.assertEqual(mock_info.call_args_list[1][0], ('Reloading PostgreSQL configuration.',))
             self.assertEqual(self.p.pending_restart, True)


### PR DESCRIPTION
Show info about the PG parameters that caused "pending restart"
flag to be set in both `patronictl list` and `/patroni` REST API endpoint response