### PR TITLE
Fix Docker entrypoint to handle multiple ZooKeeper nodes and provide sample docker-compose files for ZK DCS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN set -ex \
     && apt-cache depends patroni | sed -n -e 's/.*Depends: \(python3-.\+\)$/\1/p' \
             | grep -Ev '^python3-(sphinx|etcd|consul|kazoo|kubernetes)' \
             | xargs apt-get install -y vim curl less jq locales haproxy sudo \
-                            python3-etcd python3-kazoo python3-pip busybox \
+                            python3-etcd python3-kazoo python3-pip zookeeper busybox \
                             net-tools iputils-ping dumb-init --fix-missing \
 \
     # Cleanup all locales but en_US.UTF-8
@@ -68,7 +68,7 @@ RUN set -ex \
     fi \
 \
     # Clean up all useless packages and some files
-    && apt-get purge -y --allow-remove-essential python3-pip gzip bzip2 util-linux e2fsprogs \
+    && apt-get purge -y --allow-remove-essential python3-pip gzip bzip2 e2fsprogs \
                 libmagic1 bsdmainutils login ncurses-bin libmagic-mgc e2fslibs bsdutils \
                 exim4-config gnupg-agent dirmngr \
                 git make \

--- a/docker-compose-zk-patroni.yml
+++ b/docker-compose-zk-patroni.yml
@@ -1,0 +1,60 @@
+# docker compose file for running a 3-node PostgreSQL cluster
+# with an existing zookeeper cluster as the DCS and one haproxy node
+#
+# requires a patroni image build from the Dockerfile:
+# $ docker build -t patroni .
+# The cluster could be started as:
+# $ docker-compose up -d
+# You can read more about it in the:
+# https://github.com/zalando/patroni/blob/master/docker/README.md
+version: "2"
+
+networks:
+    patroni_zk-net:
+        external: true
+
+services:
+    haproxy:
+        image: ${PATRONI_TEST_IMAGE:-patroni}
+        networks: [ patroni_zk-net ]
+        env_file: docker/patroni.env
+        hostname: haproxy
+        container_name: demo-haproxy
+        ports:
+            - "5432:5000"
+            - "5433:5001"
+            - "7880:7000"
+        command: haproxy
+        environment: &haproxy_env
+            PATRONI_ZOOKEEPER_HOSTS: "'zk1:2181','zk2:2181','zk3:2181'"
+            PATRONI_SCOPE: demo
+
+    patroni1:
+        image: ${PATRONI_TEST_IMAGE:-patroni}
+        networks: [ patroni_zk-net ]
+        env_file: docker/patroni.env
+        hostname: patroni1
+        container_name: demo-patroni1
+        environment:
+            <<: *haproxy_env
+            PATRONI_NAME: patroni1
+
+    patroni2:
+        image: ${PATRONI_TEST_IMAGE:-patroni}
+        networks: [ patroni_zk-net ]
+        env_file: docker/patroni.env
+        hostname: patroni2
+        container_name: demo-patroni2
+        environment:
+            <<: *haproxy_env
+            PATRONI_NAME: patroni2
+
+    patroni3:
+        image: ${PATRONI_TEST_IMAGE:-patroni}
+        networks: [ patroni_zk-net ]
+        env_file: docker/patroni.env
+        hostname: patroni3
+        container_name: demo-patroni3
+        environment:
+            <<: *haproxy_env
+            PATRONI_NAME: patroni3

--- a/docker-compose-zk-quorum.yml
+++ b/docker-compose-zk-quorum.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+services:
+  zk1:
+    container_name: zk1
+    hostname: zk1
+    image: bitnami/zookeeper:latest
+    networks:
+      - zk-net
+    ports:
+      - 21811:2181
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOO_SERVER_ID=1
+      - ZOO_SERVERS=0.0.0.0:2888:3888,zk2:2888:3888,zk3:2888:3888
+  zk2:
+    container_name: zk2
+    hostname: zk2
+    image: bitnami/zookeeper:latest
+    networks:
+      - zk-net
+    ports:
+      - 21812:2181
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOO_SERVER_ID=2
+      - ZOO_SERVERS=zk1:2888:3888,0.0.0.0:2888:3888,zk3:2888:3888
+  zk3:
+    container_name: zk3
+    hostname: zk3
+    image: bitnami/zookeeper:latest
+    networks:
+      - zk-net
+    ports:
+      - 21813:2181
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOO_SERVER_ID=3
+      - ZOO_SERVERS=zk1:2888:3888,zk2:2888:3888,0.0.0.0:2888:3888
+  zoonavigator:
+    container_name: zoonavigator
+    image: elkozmon/zoonavigator
+    networks:
+      - zk-net
+    ports:
+      - 9000:9000
+networks:
+  zk-net:
+    driver: bridge

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,10 +20,13 @@ case "$1" in
         haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D
         set -- confd "-prefix=$PATRONI_NAMESPACE/$PATRONI_SCOPE" -interval=10 -backend
         if [ -n "$PATRONI_ZOOKEEPER_HOSTS" ]; then
-            while ! /usr/share/zookeeper/bin/zkCli.sh -server "$PATRONI_ZOOKEEPER_HOSTS" ls /; do
+            while ! /usr/share/zookeeper/bin/zkCli.sh -server `echo "$PATRONI_ZOOKEEPER_HOSTS" | tr -d "'"` ls /; do
                 sleep 1
             done
-            set -- "$@" zookeeper -node "$PATRONI_ZOOKEEPER_HOSTS"
+            set -- "$@" zookeeper
+            for z in `echo "$PATRONI_ZOOKEEPER_HOSTS" | tr -d "'" | tr "," " "`; do
+                set -- "$@" -node "$z"
+            done
         else
             while ! etcdctl member list 2> /dev/null; do
                 sleep 1


### PR DESCRIPTION
I've preserved the quoting convention in the existing documentation, though it seems unlikely that it ever worked:

docs/ENVIRONMENT.rst:-  **PATRONI\_ZOOKEEPER\_HOSTS**: Comma separated list of ZooKeeper cluster members: "'host1:port1','host2:port2','etc...'". It is important to quote every single entity!

I'm using this setup day-to-day with x86_64 Docker images on an aarch64 Mac running Sonoma (14.2), via docker-compose / Colima / VZ / Rosetta.  It's kinda amazing that it works at all; but in fact it seems to work reasonably well.

Here's what I do from a cold start (my needs do not presently include a persistent data volume):

* Start the Colima container hosting environment with `colima start --network-address`

* Watch the Colima logs in another terminal with `tail -F ~/.colima/_lima/colima/serial*.log`

* From a local clone of the patroni github repo: ** In another terminal, fire up the ZooKeeper quorum with `docker compose -f docker-compose-zk-quorum.yml up -d` ** Watch the ZK logs with `docker compose -f docker-compose-zk-quorum.yml logs -f` ** Wait for ZK to spin up (verify via ZooNavigator at http://localhost:9000/editor/data?path=%2Fzookeeper%2Fconfig) ** In another terminal, fire up the Patroni cluster with `docker compose -f docker-compose-zk-patroni.yml up -d` ** Watch the Patroni logs with `docker compose -f docker-compose-zk-patroni.yml logs -f` ** Wait for Patroni to spin up (verify via HAProxy stats at http://localhost:7880/)

* Create Postgres roles, databases, etc.; I habitually use Postico 2 pointed at localhost:5432
* Go to town (note that the Patroni HAProxy container also exposes port 5433 for access to the follower replicas)