### PR TITLE
Remove contradictory failover tag from config

### DIFF
--- a/features/priority_failover.feature
+++ b/features/priority_failover.feature
@@ -21,3 +21,14 @@ Feature: priority replication
     And I sleep for 5 seconds
     Then postgres3 role is the primary after 10 seconds
     And there is one of ["postgres3 has equally tolerable WAL position and priority 2, while this node has priority 1","Wal position of postgres3 is ahead of my wal position"] INFO in the postgres2 patroni log after 5 seconds
+
+  Scenario: check conflicting configuration handling
+    When I set nofailover tag in postgres2 config
+    And I issue an empty POST request to http://127.0.0.1:8010/reload
+    Then I receive a response code 202
+    And there is one of ["Conflicting configuration between nofailover: True and failover_priority: 1. Defaulting to nofailover: True"] WARNING in the postgres2 patroni log after 5 seconds
+    When I issue a GET request to http://127.0.0.1:8010/patroni
+    Then I receive a response tags {'nofailover': True}
+    When I issue a POST request to http://127.0.0.1:8010/failover with {"candidate": "postgres2"}
+	  Then I receive a response code 412
+    And I receive a response text "failover is not possible: no good candidates have been found"

--- a/features/steps/basic_replication.py
+++ b/features/steps/basic_replication.py
@@ -123,6 +123,6 @@ def check_patroni_log(context, message_list, level, node, timeout):
         messsages_of_level = context.pctl.read_patroni_log(node, level)
         if any(any(message in line for line in messsages_of_level) for message in message_list):
             break
-        time.sleep(1)
+        sleep(1)
     else:
         assert False, f"There were none of {message_list} {level} in the {node} patroni log after {timeout} seconds"

--- a/features/steps/patroni_api.py
+++ b/features/steps/patroni_api.py
@@ -128,6 +128,11 @@ def scheduled_restart(context, url, in_seconds, data):
     context.execute_steps(u"""Given I issue a POST request to {0}/restart with {1}""".format(url, json.dumps(data)))
 
 
+@step('I set {tag:w} tag in {pg_name:w} config')
+def add_bool_tag_to_config(context, tag, pg_name):
+    context.pctl.add_tag_to_config(pg_name, tag, True)
+
+
 @step('I add tag {tag:w} {value:w} to {pg_name:w} config')
 def add_tag_to_config(context, tag, value, pg_name):
     context.pctl.add_tag_to_config(pg_name, tag, value)

--- a/postgres0.yml
+++ b/postgres0.yml
@@ -132,7 +132,7 @@ postgresql:
 #  safety_margin: 5
 
 tags:
-    nofailover: false
+    # failover_priority: 1
     noloadbalance: false
     clonefrom: false
     nosync: false

--- a/postgres1.yml
+++ b/postgres1.yml
@@ -124,6 +124,6 @@ postgresql:
   #pre_promote: /path/to/pre_promote.sh
 
 tags:
-    nofailover: false
+    # failover_priority: 1
     noloadbalance: false
     clonefrom: false

--- a/postgres2.yml
+++ b/postgres2.yml
@@ -114,7 +114,7 @@ postgresql:
 #    krb_server_keyfile: /var/spool/keytabs/postgres
     unix_socket_directories: '..'  # parent directory of data_dir
 tags:
-    nofailover: false
+    # failover_priority: 1
     noloadbalance: false
     clonefrom: false
 #    replicatefrom: postgresql1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -155,34 +155,36 @@ class TestConfig(unittest.TestCase):
     def test_invalid_path(self):
         self.assertRaises(ConfigParseError, Config, 'postgres0')
 
-    @patch.object(Config, 'get')
     @patch('patroni.config.logger')
-    def test__validate_failover_tags(self, mock_logger, mock_get):
+    def test__validate_failover_tags(self, mock_logger):
         """Ensures that only one of `nofailover` or `failover_priority` can be provided"""
-        mock_logger.warning.reset_mock()
-        config = Config("postgres0.yml")
         # Providing one of `nofailover` or `failover_priority` is fine
-        just_nofailover = {"nofailover": True}
-        mock_get.side_effect = [just_nofailover] * 2
-        self.assertIsNone(config._validate_failover_tags())
+        config = {"nofailover": True}
+        self.assertIsNone(Config._validate_failover_tags(config))
         mock_logger.warning.assert_not_called()
-        just_failover_priority = {"failover_priority": 1}
-        mock_get.side_effect = [just_failover_priority] * 2
-        self.assertIsNone(config._validate_failover_tags())
+
+        config = {"failover_priority": 1}
+        self.assertIsNone(Config._validate_failover_tags(config))
         mock_logger.warning.assert_not_called()
+
         # Providing both `nofailover` and `failover_priority` is fine if consistent
-        consistent_false = {"nofailover": False, "failover_priority": 1}
-        mock_get.side_effect = [consistent_false] * 2
-        self.assertIsNone(config._validate_failover_tags())
+        config = {"nofailover": False, "failover_priority": 1}
+        self.assertIsNone(Config._validate_failover_tags(config))
+        self.assertIn('nofailover', config)
+        self.assertIn('failover_priority', config)
         mock_logger.warning.assert_not_called()
-        consistent_true = {"nofailover": True, "failover_priority": 0}
-        mock_get.side_effect = [consistent_true] * 2
-        self.assertIsNone(config._validate_failover_tags())
+
+        config = {"nofailover": True, "failover_priority": 0}
+        self.assertIsNone(Config._validate_failover_tags(config))
+        self.assertIn('nofailover', config)
+        self.assertIn('failover_priority', config)
         mock_logger.warning.assert_not_called()
+
         # Providing both inconsistently should log a warning
-        inconsistent_false = {"nofailover": False, "failover_priority": 0}
-        mock_get.side_effect = [inconsistent_false] * 2
-        self.assertIsNone(config._validate_failover_tags())
+        config = {"nofailover": False, "failover_priority": 0}
+        self.assertIsNone(Config._validate_failover_tags(config))
+        self.assertIn('nofailover', config)
+        self.assertNotIn('failover_priority', config)
         mock_logger.warning.assert_called_once_with(
             'Conflicting configuration between nofailover: %s and failover_priority: %s.'
             + ' Defaulting to nofailover: %s',
@@ -191,9 +193,11 @@ class TestConfig(unittest.TestCase):
             False
         )
         mock_logger.warning.reset_mock()
-        inconsistent_true = {"nofailover": True, "failover_priority": 1}
-        mock_get.side_effect = [inconsistent_true] * 2
-        self.assertIsNone(config._validate_failover_tags())
+
+        config = {"nofailover": True, "failover_priority": 1}
+        self.assertIsNone(Config._validate_failover_tags(config))
+        self.assertIn('nofailover', config)
+        self.assertNotIn('failover_priority', config)
         mock_logger.warning.assert_called_once_with(
             'Conflicting configuration between nofailover: %s and failover_priority: %s.'
             + ' Defaulting to nofailover: %s',


### PR DESCRIPTION
Closes #2981 

Also includes a small refactoring of `_build_effective_configuration()` to make the logic there a bit more clear