### PR TITLE
call freeze_support in main module to solve pyinstaller frozen issue

### DIFF
--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -229,11 +229,6 @@ def patroni_main(configfile: str) -> None:
 
     :param configfile: path to Patroni configuration file.
     """
-    from multiprocessing import freeze_support
-
-    # Windows executables created by PyInstaller are frozen, thus we need to enable frozen support for
-    # :mod:`multiprocessing` to avoid :class:`RuntimeError` exceptions.
-    freeze_support()
     abstract_main(Patroni, configfile)
 
 
@@ -391,4 +386,9 @@ def main() -> None:
 
 
 if __name__ == '__main__':
+    from multiprocessing import freeze_support
+
+    # Executables created by PyInstaller are frozen, thus we need to enable frozen support for
+    # :mod:`multiprocessing` to avoid :class:`RuntimeError` exceptions.
+    freeze_support()
     main()

--- a/patroni/__main__.py
+++ b/patroni/__main__.py
@@ -330,6 +330,12 @@ def main() -> None:
         ``patroni`` daemon as another process. In that case relevant signals received by the main process and forwarded
         to ``patroni`` daemon process.
     """
+    from multiprocessing import freeze_support
+
+    # Executables created by PyInstaller are frozen, thus we need to enable frozen support for
+    # :mod:`multiprocessing` to avoid :class:`RuntimeError` exceptions.
+    freeze_support()
+
     check_psycopg()
 
     args = process_arguments()
@@ -386,9 +392,4 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    from multiprocessing import freeze_support
-
-    # Executables created by PyInstaller are frozen, thus we need to enable frozen support for
-    # :mod:`multiprocessing` to avoid :class:`RuntimeError` exceptions.
-    freeze_support()
     main()


### PR DESCRIPTION
To solve issue #2995, we need to call multiprocessing.freeze_support() straight after the if __name__ == __main__ line of the main module. Refer to https://docs.python.org/3/library/multiprocessing.html#multiprocessing.freeze_support

In the fix for issue #1441, freeze_support was added to patroni_main() but it doesn't work now since v3.1.0. I moved this part of code to follow the if __name__ == __main__ line and verified OK. Besides, as this issue also occured on linux I removed 'Windows' from the comment. 