### PR TITLE
Fixes around pending_restart flag

### DIFF
--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, Tuple, TYPE_CHECK
 from ..async_executor import CriticalTask
 from ..dcs import Leader, Member, RemoteMember
 from ..psycopg import quote_ident, quote_literal
-from ..utils import deep_compare, parse_bool, unquote
+from ..utils import deep_compare, unquote
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import Postgresql
@@ -463,7 +463,7 @@ END;$$""".format(f, quote_ident(rewind['username'], postgresql.connection()))
                         postgresql.restart()
                     else:
                         postgresql.config.replace_pg_hba()
-                        if postgresql.pending_restart or not parse_bool(postgresql.config.hot_standby):
+                        if postgresql.pending_restart:
                             postgresql.restart()
                         else:
                             postgresql.reload()

--- a/patroni/postgresql/bootstrap.py
+++ b/patroni/postgresql/bootstrap.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, Tuple, TYPE_CHECK
 from ..async_executor import CriticalTask
 from ..dcs import Leader, Member, RemoteMember
 from ..psycopg import quote_ident, quote_literal
-from ..utils import deep_compare, unquote
+from ..utils import deep_compare, parse_bool, unquote
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import Postgresql
@@ -463,7 +463,7 @@ END;$$""".format(f, quote_ident(rewind['username'], postgresql.connection()))
                         postgresql.restart()
                     else:
                         postgresql.config.replace_pg_hba()
-                        if postgresql.pending_restart:
+                        if postgresql.pending_restart or not parse_bool(postgresql.config.hot_standby):
                             postgresql.restart()
                         else:
                             postgresql.reload()

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -647,7 +647,8 @@ class ConfigHandler(object):
 
     @property
     def _parameters_skip_changes(self) -> Tuple[str, ...]:
-        return tuple(self._RECOVERY_PARAMETERS) + ('hot_standby',)
+        additional_params = ('hot_standby',) if self._postgresql.is_primary() else ()
+        return tuple(self._RECOVERY_PARAMETERS) + additional_params
 
     def _read_recovery_params(self) -> Tuple[Optional[CaseInsensitiveDict], bool]:
         """Read current recovery parameters values.

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1244,13 +1244,16 @@ class ConfigHandler(object):
 
             if disable_hot_standby:
                 effective_configuration['hot_standby'] = 'off'
-                self._postgresql.set_pending_restart(True)
 
         return effective_configuration
 
     @property
     def replication(self) -> Dict[str, Any]:
         return self._config['authentication']['replication']
+
+    @property
+    def hot_standby(self) -> str:
+        return self._config['parameters']['hot_standby']
 
     @property
     def superuser(self) -> Dict[str, Any]:

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -646,9 +646,8 @@ class ConfigHandler(object):
         return CaseInsensitiveSet(self._RECOVERY_PARAMETERS - skip_params)
 
     @property
-    def _parameters_skip_changes(self) -> Tuple[str, ...]:
-        additional_params = ('hot_standby',) if self._postgresql.is_primary() else ()
-        return tuple(self._RECOVERY_PARAMETERS) + additional_params
+    def _parameters_skip_changes(self) -> CaseInsensitiveSet:
+        return CaseInsensitiveSet((*self._RECOVERY_PARAMETERS, 'hot_standby', 'wal_log_hints'))
 
     def _read_recovery_params(self) -> Tuple[Optional[CaseInsensitiveDict], bool]:
         """Read current recovery parameters values.

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1170,7 +1170,7 @@ class ConfigHandler(object):
                     pending_restart = self._postgresql.query(
                         'SELECT COUNT(*) FROM pg_catalog.pg_settings'
                         ' WHERE pg_catalog.lower(name) != ALL(%s) AND pending_restart',
-                        [n for n in params_skip_changes])[0][0] > 0
+                        [n.lower() for n in params_skip_changes])[0][0] > 0
                     self._postgresql.set_pending_restart(pending_restart)
                 except Exception as e:
                     logger.warning('Exception %r when running query', e)

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1085,9 +1085,9 @@ class ConfigHandler(object):
         conf_changed = hba_changed = ident_changed = local_connection_address_changed = pending_restart = False
         if self._postgresql.state == 'running':
             changes = CaseInsensitiveDict({p: v for p, v in server_parameters.items()
-                                           if p.lower() not in self._parameters_skip_changes})
+                                           if p not in self._parameters_skip_changes})
             changes.update({p: None for p in self._server_parameters.keys()
-                            if not (p in changes or p.lower() in self._parameters_skip_changes)})
+                            if not (p in changes or p in self._parameters_skip_changes)})
             if changes:
                 undef = []
                 if 'wal_buffers' in changes:  # we need to calculate the default value of wal_buffers
@@ -1173,7 +1173,7 @@ class ConfigHandler(object):
                     pending_restart = self._postgresql.query(
                         'SELECT COUNT(*) FROM pg_catalog.pg_settings'
                         ' WHERE pg_catalog.lower(name) != ALL(%s) AND pending_restart',
-                        [n.lower() for n in self._parameters_skip_changes])[0][0] > 0
+                        [n for n in self._parameters_skip_changes])[0][0] > 0
                     self._postgresql.set_pending_restart(pending_restart)
                 except Exception as e:
                     logger.warning('Exception %r when running query', e)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -55,10 +55,10 @@ GET_PG_SETTINGS_RESULT = [
     ('zero_damaged_pages', 'off', None, 'bool', 'superuser'),
     ('stats_temp_directory', '/tmp', None, 'string', 'sighup'),
     ('track_commit_timestamp', 'off', None, 'bool', 'postmaster'),
-    ('wal_log_hints', 'on', None, 'bool', 'superuser'),
+    ('wal_log_hints', 'on', None, 'bool', 'postmaster'),
     ('hot_standby', 'on', None, 'bool', 'postmaster'),
-    ('max_replication_slots', '5', None, 'integer', 'superuser'),
-    ('wal_level', 'logical', None, 'enum', 'superuser'),
+    ('max_replication_slots', '5', None, 'integer', 'postmaster'),
+    ('wal_level', 'logical', None, 'enum', 'postmaster'),
 ]
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,7 +56,7 @@ GET_PG_SETTINGS_RESULT = [
     ('stats_temp_directory', '/tmp', None, 'string', 'sighup'),
     ('track_commit_timestamp', 'off', None, 'bool', 'postmaster'),
     ('wal_log_hints', 'on', None, 'bool', 'superuser'),
-    ('hot_standby', 'on', None, 'bool', 'superuser'),
+    ('hot_standby', 'on', None, 'bool', 'postmaster'),
     ('max_replication_slots', '5', None, 'integer', 'superuser'),
     ('wal_level', 'logical', None, 'enum', 'superuser'),
 ]

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -576,17 +576,6 @@ class TestPostgresql(BaseTestPostgresql):
         mock_info.reset_mock()
 
         # Ignored params changed
-        with patch.object(Postgresql, 'is_primary', Mock(return_value=False)), \
-             patch('patroni.postgresql.Postgresql._query', Mock(side_effect=[GET_PG_SETTINGS_RESULT, [(1,)]])):
-            config['parameters']['hot_standby'] = 'off'
-            self.p.reload_config(config)
-            self.assertEqual(mock_info.call_args_list[0][0], ('Changed %s from %s to %s (restart might be required)',
-                                                              'hot_standby', 'on', 'off'))
-            self.assertEqual(mock_info.call_args_list[1][0], ('Reloading PostgreSQL configuration.',))
-            self.assertEqual(self.p.pending_restart, True)
-
-        mock_info.reset_mock()
-
         config['parameters']['archive_cleanup_command'] = 'blabla'
         self.p.reload_config(config)
         mock_info.assert_called_once_with('No PostgreSQL configuration items changed, nothing to reload.')

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -575,6 +575,15 @@ class TestPostgresql(BaseTestPostgresql):
 
         mock_info.reset_mock()
 
+        # Ignored params changed
+        self.p.config._config['parameters']['hot_standby'] = 'off'
+        self.p.config._config['parameters']['archive_cleanup_command'] = 'blabla'
+        self.p.reload_config(config)
+        mock_info.assert_called_once_with('No PostgreSQL configuration items changed, nothing to reload.')
+        self.assertEqual(self.p.pending_restart, False)
+
+        mock_info.reset_mock()
+
         # Handle wal_buffers
         self.p.config._config['parameters']['wal_buffers'] = '512'
         self.p.reload_config(config)
@@ -801,21 +810,28 @@ class TestPostgresql(BaseTestPostgresql):
     @patch.object(Postgresql, 'get_postgres_role_from_data_directory', Mock(return_value='replica'))
     @patch.object(Postgresql, 'is_running', Mock(return_value=False))
     @patch.object(Bootstrap, 'running_custom_bootstrap', PropertyMock(return_value=True))
-    @patch.object(Postgresql, 'controldata', Mock(return_value={'max_connections setting': '200',
-                                                                'max_worker_processes setting': '20',
-                                                                'max_locks_per_xact setting': '100',
-                                                                'max_wal_senders setting': 10}))
-    @patch('patroni.postgresql.config.logger.warning')
+    @patch('patroni.postgresql.config.logger')
     def test_effective_configuration(self, mock_logger):
-        self.p.cancellable.cancel()
-        self.p.config.write_recovery_conf({'pause_at_recovery_target': 'false'})
-        self.assertFalse(self.p.start())
-        mock_logger.assert_called_once()
-        self.assertTrue('is missing from pg_controldata output' in mock_logger.call_args[0][0])
+        controldata = {'max_connections setting': '100', 'max_worker_processes setting': '8',
+                       'max_locks_per_xact setting': '64', 'max_wal_senders setting': 5}
 
-        self.assertTrue(self.p.pending_restart)
-        with patch.object(Bootstrap, 'keep_existing_recovery_conf', PropertyMock(return_value=True)):
+        with patch.object(Postgresql, 'controldata', Mock(return_value=controldata)), \
+             patch.object(Bootstrap, 'keep_existing_recovery_conf', PropertyMock(return_value=True)):
+            self.p.cancellable.cancel()
             self.assertFalse(self.p.start())
+            self.assertFalse(self.p.pending_restart)
+            mock_logger.warning.assert_called_once()
+            self.assertEqual(mock_logger.warning.call_args[0],
+                             ('%s is missing from pg_controldata output', 'max_prepared_xacts setting'))
+
+        mock_logger.reset_mock()
+        controldata['max_prepared_xacts setting'] = 0
+        controldata['max_wal_senders setting'] *= 2
+
+        with patch.object(Postgresql, 'controldata', Mock(return_value=controldata)):
+            self.p.config.write_recovery_conf({'pause_at_recovery_target': 'false'})
+            self.assertFalse(self.p.start())
+            mock_logger.warning.assert_not_called()
             self.assertTrue(self.p.pending_restart)
 
     @patch('os.path.exists', Mock(return_value=True))

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -576,8 +576,18 @@ class TestPostgresql(BaseTestPostgresql):
         mock_info.reset_mock()
 
         # Ignored params changed
-        self.p.config._config['parameters']['hot_standby'] = 'off'
-        self.p.config._config['parameters']['archive_cleanup_command'] = 'blabla'
+        with patch.object(Postgresql, 'is_primary', Mock(return_value=False)), \
+             patch('patroni.postgresql.Postgresql._query', Mock(side_effect=[GET_PG_SETTINGS_RESULT, [(1,)]])):
+            config['parameters']['hot_standby'] = 'off'
+            self.p.reload_config(config)
+            self.assertEqual(mock_info.call_args_list[0][0], ('Changed %s from %s to %s (restart might be required)',
+                                                              'hot_standby', 'on', 'off'))
+            self.assertEqual(mock_info.call_args_list[1][0], ('Reloading PostgreSQL configuration.',))
+            self.assertEqual(self.p.pending_restart, True)
+
+        mock_info.reset_mock()
+
+        config['parameters']['archive_cleanup_command'] = 'blabla'
         self.p.reload_config(config)
         mock_info.assert_called_once_with('No PostgreSQL configuration items changed, nothing to reload.')
         self.assertEqual(self.p.pending_restart, False)


### PR DESCRIPTION
* Do not set `pending_restart` flag if `hot_standby` is set to 'off' during a custom bootstrap (even though we will have this flag actually set in PG, this configuration parameter is irrelevant on primary and there is no actual need for restart)
* Skip `hot_standby` and `wal_log_hints` when querying parameters pending restart on config reload. They actually can be changed manually (e.g. via `ALTER SYSTEM`) and it will cause the pending_restart state in PG but Patroni anyway always passes those params to postmaster as command line options. And there they only can have one value - 'on' (except on primary when performing custom bootstrap)