### PR TITLE
Optimize priority failover behave tests

### DIFF
--- a/features/priority_failover.feature
+++ b/features/priority_failover.feature
@@ -6,10 +6,9 @@ Feature: priority replication
     And I configure and start postgres1 with a tag failover_priority 0
     Then replication works from postgres0 to postgres1 after 20 seconds
     When I shut down postgres0
-    And I sleep for 5 seconds
-    Then postgres1 role is the secondary after 10 seconds
     And there is one of ["following a different leader because I am not allowed to promote"] INFO in the postgres1 patroni log after 5 seconds
-    Given I start postgres0
+    Then postgres1 role is the secondary after 10 seconds
+    When I start postgres0
     Then postgres0 role is the primary after 10 seconds
 
   Scenario: check higher failover priority is respected
@@ -18,7 +17,6 @@ Feature: priority replication
     Then replication works from postgres0 to postgres2 after 20 seconds
     And replication works from postgres0 to postgres3 after 20 seconds
     When I shut down postgres0
-    And I sleep for 5 seconds
     Then postgres3 role is the primary after 10 seconds
     And there is one of ["postgres3 has equally tolerable WAL position and priority 2, while this node has priority 1","Wal position of postgres3 is ahead of my wal position"] INFO in the postgres2 patroni log after 5 seconds
 
@@ -29,13 +27,13 @@ Feature: priority replication
     And there is one of ["Conflicting configuration between nofailover: True and failover_priority: 1. Defaulting to nofailover: True"] WARNING in the postgres2 patroni log after 5 seconds
     And "members/postgres2" key in DCS has tags={'failover_priority': '1', 'nofailover': True} after 10 seconds
     When I issue a POST request to http://127.0.0.1:8010/failover with {"candidate": "postgres2"}
-	  Then I receive a response code 412
+    Then I receive a response code 412
     And I receive a response text "failover is not possible: no good candidates have been found"
     When I reset nofailover tag in postgres1 config
     And I issue an empty POST request to http://127.0.0.1:8009/reload
     Then I receive a response code 202
     And there is one of ["Conflicting configuration between nofailover: False and failover_priority: 0. Defaulting to nofailover: False"] WARNING in the postgres1 patroni log after 5 seconds
     And "members/postgres1" key in DCS has tags={'failover_priority': '0', 'nofailover': False} after 10 seconds
-    And I issue a POST request to http://127.0.0.1:8010/failover with {"candidate": "postgres1"}
+    And I issue a POST request to http://127.0.0.1:8009/failover with {"candidate": "postgres1"}
     Then I receive a response code 200
     And postgres1 role is the primary after 10 seconds

--- a/features/steps/basic_replication.py
+++ b/features/steps/basic_replication.py
@@ -114,7 +114,7 @@ def replication_works(context, primary, replica, time_limit):
     """.format(str(time()).replace('.', '_').replace(',', '_'), primary, replica, time_limit))
 
 
-@then('there is one of {message_list} {level:w} in the {node} patroni log after {timeout:d} seconds')
+@step('there is one of {message_list} {level:w} in the {node} patroni log after {timeout:d} seconds')
 def check_patroni_log(context, message_list, level, node, timeout):
     timeout *= context.timeout_multiplier
     message_list = json.loads(message_list)


### PR DESCRIPTION
1. get rid of useless sleep calls
2. call `POST /failover` on the node where we want to failover to