### PR TITLE
Fix bugs introduced in the jsonlog implementation

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -378,31 +378,23 @@ class TestValidator(unittest.TestCase):
         c["log"]["type"] = "json"
         c["log"]["format"] = {"levelname": "level"}
         errors = schema(c)
-        self.assertIn(
-            'log.format {\'levelname\': \'level\'} didn\'t pass validation: Should be a string or a list',
-            errors
-        )
+        self.assertIn("log.format {'levelname': 'level'} didn't pass validation: Should be a string or a list", errors)
 
-        c = copy.deepcopy(config)
-        c["log"]["type"] = "json"
+        c["log"]["format"] = []
+        errors = schema(c)
+        self.assertIn("log.format [] didn't pass validation: should contains at least one item", errors)
+
         c["log"]["format"] = [{"levelname": []}]
         errors = schema(c)
-        self.assertIn(
-            ' '.join([
-                'log.format [{\'levelname\': []}] didn\'t pass validation:',
-                'Each item should be a string or a dictionary with string values'
-            ]),
-            errors
-        )
+        self.assertIn("log.format [{'levelname': []}] didn't pass validation: "
+                      "Each item should be a string or a dictionary with string values", errors)
 
-        c = copy.deepcopy(config)
-        c["log"]["type"] = "json"
         c["log"]["format"] = [[]]
         errors = schema(c)
-        self.assertIn(
-            ' '.join([
-                'log.format [[]] didn\'t pass validation:',
-                'Each item should be a string or a dictionary with string values'
-            ]),
-            errors
-        )
+        self.assertIn("log.format [[]] didn't pass validation: "
+                      "Each item should be a string or a dictionary with string values", errors)
+
+        c["log"]["format"] = ['foo']
+        errors = schema(c)
+        output = "\n".join(errors)
+        self.assertEqual(['postgresql.bin_dir', 'raft.bind_addr', 'raft.self_addr'], parse_output(output))


### PR DESCRIPTION
1. RotatingFileHandler is a child of StreamHandler, therefore we can't rely on `not isinstance(handler, logging.StreamHandler)`.
2. If the legacy version of `python-json-logger` is installed (that doesn't support rename_fields or static_fields), we want do what is possible rather than fail with the exception.

Besides that:
1. improve code coverage
2. make unit tests pass without python-json-logger installed or if only some old version is installed.