### PR TITLE
Improve logging for Pg param change

### DIFF
--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -404,7 +404,7 @@ def convert_real_from_base_unit(base_value: float, base_unit: Optional[str]) -> 
     convert_tbl = get_conversion_table(base_unit)
     for unit in convert_tbl:
         value = base_value / convert_tbl[unit][base_unit]
-        result = '%g' % value + unit
+        result = f'{value:g}{unit}'
         if value > 0 and abs((round(value) / value) - 1.0) <= 1e-8:
             break
     return result

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -36,22 +36,6 @@ from .version import __version__
 if TYPE_CHECKING:  # pragma: no cover
     from .dcs import Cluster
 
-memory_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
-    ('TB', {'B': 1024**4, 'kB': 1024**3, 'MB': 1024**2}),
-    ('GB', {'B': 1024**3, 'kB': 1024**2, 'MB': 1024}),
-    ('MB', {'B': 1024**2, 'kB': 1024, 'MB': 1}),
-    ('kB', {'B': 1024, 'kB': 1, 'MB': 1024**-1}),
-    ('B', {'B': 1, 'kB': 1024**-1, 'MB': 1024**-2})
-])
-time_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
-    ('d', {'ms': 1000 * 60**2 * 24, 's': 60**2 * 24, 'min': 60 * 24}),
-    ('h', {'ms': 1000 * 60**2, 's': 60**2, 'min': 60}),
-    ('min', {'ms': 1000 * 60, 's': 60, 'min': 1}),
-    ('s', {'ms': 1000, 's': 1, 'min': 60**-1}),
-    ('ms', {'ms': 1, 's': 1000**-1, 'min': 1 / (1000 * 60)}),
-    ('us', {'ms': 1000**-1, 's': 1000**-2, 'min': 1 / (1000**2 * 60)})
-])
-
 tzutc = tz.tzutc()
 
 logger = logging.getLogger(__name__)
@@ -65,14 +49,29 @@ WHITESPACE_RE = re.compile(r'[ \t\n\r]*', re.VERBOSE | re.MULTILINE | re.DOTALL)
 
 
 def get_conversion_table(base_unit: str) -> Dict[str, Dict[str, Union[int, float]]]:
-    """Get convertion table for the specified base unit.
+    """Get conversion table for the specified base unit.
 
-    If no convertion table exists for the passed unit, return an empty :class:`OrderedDict`.
+    If no conversion table exists for the passed unit, return an empty :class:`OrderedDict`.
 
-    :param base_unit: unit to choose the convertion table for.
+    :param base_unit: unit to choose the conversion table for.
 
     :returns: :class:`OrderedDict` object.
     """
+    memory_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
+        ('TB', {'B': 1024**4, 'kB': 1024**3, 'MB': 1024**2}),
+        ('GB', {'B': 1024**3, 'kB': 1024**2, 'MB': 1024}),
+        ('MB', {'B': 1024**2, 'kB': 1024, 'MB': 1}),
+        ('kB', {'B': 1024, 'kB': 1, 'MB': 1024**-1}),
+        ('B', {'B': 1, 'kB': 1024**-1, 'MB': 1024**-2})
+    ])
+    time_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
+        ('d', {'ms': 1000 * 60**2 * 24, 's': 60**2 * 24, 'min': 60 * 24}),
+        ('h', {'ms': 1000 * 60**2, 's': 60**2, 'min': 60}),
+        ('min', {'ms': 1000 * 60, 's': 60, 'min': 1}),
+        ('s', {'ms': 1000, 's': 1, 'min': 60**-1}),
+        ('ms', {'ms': 1, 's': 1000**-1, 'min': 1 / (1000 * 60)}),
+        ('us', {'ms': 1000**-1, 's': 1000**-2, 'min': 1 / (1000**2 * 60)})
+    ])
     if base_unit in ('B', 'kB', 'MB'):
         return memory_unit_conversion_table
     elif base_unit in ('ms', 's', 'min'):
@@ -334,7 +333,7 @@ def convert_int_from_base_unit(base_value: int, base_unit: Optional[str]) -> Opt
             * For time: ``ms``, ``s``, ``min``.
 
     :returns: :class:`str` value representing *base_value* converted from *base_unit* to the greatest
-        possible human-friendly unit, or ``None`` if convertion failed.
+        possible human-friendly unit, or ``None`` if conversion failed.
 
     :Example:
 
@@ -378,7 +377,7 @@ def convert_real_from_base_unit(base_value: float, base_unit: Optional[str]) -> 
             * For time: ``ms``, ``s``, ``min``.
 
     :returns: :class:`str` value representing *base_value* converted from *base_unit* to the greatest
-        possible human-friendly unit, or ``None`` if convertion failed.
+        possible human-friendly unit, or ``None`` if conversion failed.
 
     :Example:
 
@@ -393,7 +392,6 @@ def convert_real_from_base_unit(base_value: float, base_unit: Optional[str]) -> 
 
         >>> convert_real_from_base_unit(4.0, '256 MB') is None
         True
-
     """
     base_value_mult, base_unit = strtol(base_unit, False)
     if TYPE_CHECKING:  # pragma: no cover
@@ -413,7 +411,7 @@ def convert_real_from_base_unit(base_value: float, base_unit: Optional[str]) -> 
 def maybe_convert_from_base_unit(base_value: str, vartype: str, base_unit: Optional[str]) -> str:
     """Try to convert integer or real value in a base unit to a human-readable unit.
 
-    Value is passed as a string. If parsing or subsequent convertion fails, the original
+    Value is passed as a string. If parsing or subsequent conversion fails, the original
     value is returned.
 
     :param base_value: value to be converted from a base unit.
@@ -426,7 +424,21 @@ def maybe_convert_from_base_unit(base_value: str, vartype: str, base_unit: Optio
             * For time: ``ms``, ``s``, ``min``.
 
     :returns: :class:`str` value representing *base_value* converted from *base_unit* to the greatest
-        possible human-friendly unit, or *base_value* string if convertion failed.
+        possible human-friendly unit, or *base_value* string if conversion failed.
+
+    :Example:
+
+        >>> maybe_convert_from_base_unit('5', 'integer', 'ms')
+        '5ms'
+
+        >>> maybe_convert_from_base_unit('4.2', 'real', 'ms')
+        '4200us'
+
+        >>> maybe_convert_from_base_unit('on', 'bool', None)
+        'on'
+
+        >>> maybe_convert_from_base_unit('', 'integer', '256MB')
+        ''
     """
     converters: Dict[str, Tuple[Callable[[str, Optional[str]], Union[int, float, str, None]],
                                 Callable[[Any, Optional[str]], Optional[str]]]] = {

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -10,6 +10,7 @@
 :var WHITESPACE_RE: regular expression to match whitespace characters
 """
 import errno
+import itertools
 import logging
 import os
 import platform
@@ -24,6 +25,7 @@ from shlex import split
 
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union, Tuple, Type, TYPE_CHECKING
 
+from collections import OrderedDict
 from dateutil import tz
 from json import JSONDecoder
 from urllib3.response import HTTPResponse
@@ -33,6 +35,22 @@ from .version import __version__
 
 if TYPE_CHECKING:  # pragma: no cover
     from .dcs import Cluster
+
+memory_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
+    ('TB', {'B': 1024**4, 'kB': 1024**3, 'MB': 1024**2}),
+    ('GB', {'B': 1024**3, 'kB': 1024**2, 'MB': 1024}),
+    ('MB', {'B': 1024**2, 'kB': 1024, 'MB': 1}),
+    ('kB', {'B': 1024, 'kB': 1, 'MB': 1024**-1}),
+    ('B', {'B': 1, 'kB': 1024**-1, 'MB': 1024**-2})
+])
+time_unit_conversion_table: Dict[str, Dict[str, Union[int, float]]] = OrderedDict([
+    ('d', {'ms': 1000 * 60**2 * 24, 's': 60**2 * 24, 'min': 60 * 24}),
+    ('h', {'ms': 1000 * 60**2, 's': 60**2, 'min': 60}),
+    ('min', {'ms': 1000 * 60, 's': 60, 'min': 1}),
+    ('s', {'ms': 1000, 's': 1, 'min': 60**-1}),
+    ('ms', {'ms': 1, 's': 1000**-1, 'min': 1 / (1000 * 60)}),
+    ('us', {'ms': 1000**-1, 's': 1000**-2, 'min': 1 / (1000**2 * 60)})
+])
 
 tzutc = tz.tzutc()
 
@@ -44,6 +62,22 @@ DEC_RE = re.compile(r'^[-+]?(0|[1-9][0-9]*)')
 HEX_RE = re.compile(r'^[-+]?0x[0-9a-fA-F]+')
 DBL_RE = re.compile(r'^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?')
 WHITESPACE_RE = re.compile(r'[ \t\n\r]*', re.VERBOSE | re.MULTILINE | re.DOTALL)
+
+
+def get_conversion_table(base_unit: str) -> Dict[str, Dict[str, Union[int, float]]]:
+    """Get convertion table for the specified base unit.
+
+    If no convertion table exists for the passed unit, return an empty :class:`OrderedDict`.
+
+    :param base_unit: unit to choose the convertion table for.
+
+    :returns: :class:`OrderedDict` object.
+    """
+    if base_unit in ('B', 'kB', 'MB'):
+        return memory_unit_conversion_table
+    elif base_unit in ('ms', 's', 'min'):
+        return time_unit_conversion_table
+    return OrderedDict()
 
 
 def deep_compare(obj1: Dict[Any, Union[Any, Dict[Any, Any]]], obj2: Dict[Any, Union[Any, Dict[Any, Any]]]) -> bool:
@@ -272,33 +306,139 @@ def convert_to_base_unit(value: Union[int, float], unit: str, base_unit: Optiona
         >>> convert_to_base_unit(1, 'GB', '512 MB') is None
         True
     """
-    convert: Dict[str, Dict[str, Union[int, float]]] = {
-        'B': {'B': 1, 'kB': 1024, 'MB': 1024 * 1024, 'GB': 1024 * 1024 * 1024, 'TB': 1024 * 1024 * 1024 * 1024},
-        'kB': {'B': 1.0 / 1024, 'kB': 1, 'MB': 1024, 'GB': 1024 * 1024, 'TB': 1024 * 1024 * 1024},
-        'MB': {'B': 1.0 / (1024 * 1024), 'kB': 1.0 / 1024, 'MB': 1, 'GB': 1024, 'TB': 1024 * 1024},
-        'ms': {'us': 1.0 / 1000, 'ms': 1, 's': 1000, 'min': 1000 * 60, 'h': 1000 * 60 * 60, 'd': 1000 * 60 * 60 * 24},
-        's': {'us': 1.0 / (1000 * 1000), 'ms': 1.0 / 1000, 's': 1, 'min': 60, 'h': 60 * 60, 'd': 60 * 60 * 24},
-        'min': {'us': 1.0 / (1000 * 1000 * 60), 'ms': 1.0 / (1000 * 60), 's': 1.0 / 60, 'min': 1, 'h': 60, 'd': 60 * 24}
-    }
+    base_value, base_unit = strtol(base_unit, False)
+    if TYPE_CHECKING:  # pragma: no cover
+        assert isinstance(base_value, int)
 
-    round_order = {
-        'TB': 'GB', 'GB': 'MB', 'MB': 'kB', 'kB': 'B',
-        'd': 'h', 'h': 'min', 'min': 's', 's': 'ms', 'ms': 'us'
-    }
-
-    if base_unit and base_unit not in convert:
-        base_value, base_unit = strtol(base_unit, False)
-    else:
-        base_value = 1
-
-    if base_value is not None and base_unit in convert and unit in convert[base_unit]:
-        value *= convert[base_unit][unit] / float(base_value)
-
+    convert_tbl = get_conversion_table(base_unit)
+    # {'TB': 'GB', 'GB': 'MB', ...}
+    round_order = dict(zip(convert_tbl, itertools.islice(convert_tbl, 1, None)))
+    if unit in convert_tbl and base_unit in convert_tbl[unit]:
+        value *= convert_tbl[unit][base_unit] / float(base_value)
         if unit in round_order:
-            multiplier = convert[base_unit][round_order[unit]]
+            multiplier = convert_tbl[round_order[unit]][base_unit]
             value = round(value / float(multiplier)) * multiplier
-
         return value
+
+
+def convert_int_from_base_unit(base_value: int, base_unit: Optional[str]) -> Optional[str]:
+    """Convert an integer value in some base unit to a human-friendly unit.
+
+    The output unit is chosen so that it's the greatest unit that can represent
+    the value without loss.
+
+    :param base_value: value to be converted from a base unit
+    :param base_unit: unit of *value*. Should be one of the base units (case sensitive):
+
+            * For space: ``B``, ``kB``, ``MB``;
+            * For time: ``ms``, ``s``, ``min``.
+
+    :returns: :class:`str` value representing *base_value* converted from *base_unit* to the greatest
+        possible human-friendly unit, or ``None`` if convertion failed.
+
+    :Example:
+
+        >>> convert_int_from_base_unit(1024, 'kB')
+        '1MB'
+
+        >>> convert_int_from_base_unit(1025, 'kB')
+        '1025kB'
+
+        >>> convert_int_from_base_unit(4, '256MB')
+        '1GB'
+
+        >>> convert_int_from_base_unit(4, '256 MB') is None
+        True
+
+        >>> convert_int_from_base_unit(1024, 'KB') is None
+        True
+    """
+    base_value_mult, base_unit = strtol(base_unit, False)
+    if TYPE_CHECKING:  # pragma: no cover
+        assert isinstance(base_value_mult, int)
+    base_value *= base_value_mult
+
+    convert_tbl = get_conversion_table(base_unit)
+    for unit in convert_tbl:
+        multiplier = convert_tbl[unit][base_unit]
+        if multiplier <= 1.0 or base_value % multiplier == 0:
+            return str(round(base_value / multiplier)) + unit
+
+
+def convert_real_from_base_unit(base_value: float, base_unit: Optional[str]) -> Optional[str]:
+    """Convert an floating-point value in some base unit to a human-friendly unit.
+
+    Same as :func:`convert_int_from_base_unit`, except we have to do the math a bit differently,
+    and there's a possibility that we don't find any exact divisor.
+
+    :param base_value: value to be converted from a base unit
+    :param base_unit: unit of *value*. Should be one of the base units (case sensitive):
+
+            * For space: ``B``, ``kB``, ``MB``;
+            * For time: ``ms``, ``s``, ``min``.
+
+    :returns: :class:`str` value representing *base_value* converted from *base_unit* to the greatest
+        possible human-friendly unit, or ``None`` if convertion failed.
+
+    :Example:
+
+        >>> convert_real_from_base_unit(5, 'ms')
+        '5ms'
+
+        >>> convert_real_from_base_unit(2.5, 'ms')
+        '2500us'
+
+        >>> convert_real_from_base_unit(4.0, '256MB')
+        '1GB'
+
+        >>> convert_real_from_base_unit(4.0, '256 MB') is None
+        True
+
+    """
+    base_value_mult, base_unit = strtol(base_unit, False)
+    if TYPE_CHECKING:  # pragma: no cover
+        assert isinstance(base_value_mult, int)
+    base_value *= base_value_mult
+
+    result = None
+    convert_tbl = get_conversion_table(base_unit)
+    for unit in convert_tbl:
+        value = base_value / convert_tbl[unit][base_unit]
+        result = '%g' % value + unit
+        if value > 0 and abs((round(value) / value) - 1.0) <= 1e-8:
+            break
+    return result
+
+
+def maybe_convert_from_base_unit(base_value: str, vartype: str, base_unit: Optional[str]) -> str:
+    """Try to convert integer or real value in a base unit to a human-readable unit.
+
+    Value is passed as a string. If parsing or subsequent convertion fails, the original
+    value is returned.
+
+    :param base_value: value to be converted from a base unit.
+    :param vartype: the target type to parse *base_value* before converting (``integer``
+        or ``real`` is expected, any other type results in return value being equal to the
+        *base_value* string).
+    :param base_unit: unit of *value*. Should be one of the base units (case sensitive):
+
+            * For space: ``B``, ``kB``, ``MB``;
+            * For time: ``ms``, ``s``, ``min``.
+
+    :returns: :class:`str` value representing *base_value* converted from *base_unit* to the greatest
+        possible human-friendly unit, or *base_value* string if convertion failed.
+    """
+    converters: Dict[str, Tuple[Callable[[str, Optional[str]], Union[int, float, str, None]],
+                                Callable[[Any, Optional[str]], Optional[str]]]] = {
+        'integer': (parse_int, convert_int_from_base_unit),
+        'real': (parse_real, convert_real_from_base_unit),
+        'default': (lambda v, _: v, lambda v, _: v)
+    }
+    parser, converter = converters.get(vartype, converters['default'])
+    parsed_value = parser(base_value, None)
+    if parsed_value:
+        return converter(parsed_value, base_unit) or base_value
+    return base_value
 
 
 def parse_int(value: Any, base_unit: Optional[str] = None) -> Optional[int]:


### PR DESCRIPTION
* Convert old value to a human-readable format
* Add log line about pg_controldata/global config mismatch that causes pending restart flag to be set

Effectively is a preparation for https://github.com/zalando/patroni/pull/2978