### PR TITLE
Adds action for build Docker images and push to ghcr.io 

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,76 @@
+name: Build Docker images and push to ghcr.io
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image citus
+        id: build-and-push-citus
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          file: Dockerfile.citus
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-citus
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-citus
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This pull request adds a **GitHub Actions** workflow to automate the **building and pushing** of Docker images to ghcr.io. The workflow triggers on pushes to tags with the format `v*.*.*` and on pull requests targeting the master branch.

Exaples:

[Test images](https://github.com/batonogov/patroni/pkgs/container/patroni).

```sh
➜  patroni git:(master) docker pull ghcr.io/batonogov/patroni:v0.1.0 && docker pull ghcr.io/batonogov/patroni:v0.1.0-citus && docker images
v0.1.0: Pulling from batonogov/patroni
e50920964e93: Pull complete 
669e65cdbde7: Pull complete 
458bf076b1cd: Pull complete 
4ea854f1edbe: Pull complete 
af8cd123d529: Pull complete 
8293f254a45d: Pull complete 
4f4fb700ef54: Pull complete 
5f484ca2085a: Pull complete 
Digest: sha256:44c4c340fc24a1a89e78ec0456db1bd6df867e72170beca758f931015e6ec4d8
Status: Downloaded newer image for ghcr.io/batonogov/patroni:v0.1.0
ghcr.io/batonogov/patroni:v0.1.0

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview ghcr.io/batonogov/patroni:v0.1.0
v0.1.0-citus: Pulling from batonogov/patroni
df93d5011fb2: Pull complete 
669e65cdbde7: Pull complete 
05e31c6fec3c: Pull complete 
c61a65a6e7d8: Pull complete 
af8cd123d529: Pull complete 
c03c47ea5e79: Pull complete 
4f4fb700ef54: Pull complete 
134a6158c57c: Pull complete 
Digest: sha256:d6dc6750916a69acf910295bf34f6f63b43833a2577c2c5985e025fd9d7d9121
Status: Downloaded newer image for ghcr.io/batonogov/patroni:v0.1.0-citus
ghcr.io/batonogov/patroni:v0.1.0-citus

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview ghcr.io/batonogov/patroni:v0.1.0-citus
REPOSITORY                  TAG            IMAGE ID       CREATED          SIZE
ghcr.io/batonogov/patroni   v0.1.0         f84842a83520   10 minutes ago   535MB
ghcr.io/batonogov/patroni   v0.1.0-citus   3c41ecce3d09   20 minutes ago   558MB
```