### PR TITLE
add available_parameters

### DIFF
--- a/patroni/postgresql/available_parameters/0_postgres.yml
+++ b/patroni/postgresql/available_parameters/0_postgres.yml
@@ -1,4 +1,7 @@
 parameters:
+  ac_ignore_maclabel:
+  - type: Bool
+    version_from: 90300
   allow_in_place_tablespaces:
   - type: Bool
     version_from: 150000


### PR DESCRIPTION
Add ac_ignore_maclabel parameter for Astra postgresql with Mandatory Access Control