### PR TITLE
Doc improvement: mention use of gRPC gateway with EtcdV3

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -80,7 +80,7 @@ Etcdv3
 Environment names for Etcdv3 are similar as for Etcd, you just need to use ``ETCD3`` instead of ``ETCD`` in the variable name. Example: ``PATRONI_ETCD3_HOST``, ``PATRONI_ETCD3_CACERT``, and so on.
 
 .. warning::
-    Keys created with protocol version 2 are not visible with protocol version 3 and the other way around, therefore it is not possible to switch from Etcd to Etcdv3 just by updating Patroni configuration.
+    Keys created with protocol version 2 are not visible with protocol version 3 and the other way around, therefore it is not possible to switch from Etcd to Etcdv3 just by updating Patroni configuration. In addition, Patroni uses Etcd's gRPC-gateway (proxy) to communicate with the V3 API, which means that TLS common name authentication is not possible.
 
 
 ZooKeeper

--- a/docs/yaml_configuration.rst
+++ b/docs/yaml_configuration.rst
@@ -144,7 +144,7 @@ Etcdv3
 If you want that Patroni works with Etcd cluster via protocol version 3, you need to use the ``etcd3`` section in the Patroni configuration file. All configuration parameters are the same as for ``etcd``.
 
 .. warning::
-    Keys created with protocol version 2 are not visible with protocol version 3 and the other way around, therefore it is not possible to switch from ``etcd`` to ``etcd3`` just by updating Patroni config file.
+    Keys created with protocol version 2 are not visible with protocol version 3 and the other way around, therefore it is not possible to switch from ``etcd`` to ``etcd3`` just by updating Patroni config file. In addition, Patroni uses Etcd's gRPC-gateway (proxy) to communicate with the V3 API, which means that TLS common name authentication is not possible.
 
 
 ZooKeeper


### PR DESCRIPTION
I recently tried to use TLS common name authentication with patroni, which is currently not possible, as discussed in #3071 and #2036. In my opinion, the documentation should mention the use of the gRPC gateway (proxy) in the configuration section to better help new users (like me) set up patroni and etcdv3.  Currently this is only reflected in the release notes (as far as I can see).

So I suggest adding an additional note to the warning section in the EtcdV3 Configuration (YML and Environment) documentation. However, I am not married to my current proposed wording and placement of this note. Also, I am not sure if my direct mention of TLS common name authentication should be included directly in the Patroni documentation, as this is already discussed in the official etcd documentation. 