### PR TITLE
drop dependency on ancient mock

### DIFF
--- a/.github/workflows/install_deps.py
+++ b/.github/workflows/install_deps.py
@@ -21,7 +21,7 @@ def install_requirements(what):
         from setup import EXTRAS_REQUIRE, read
     finally:
         sys.path = old_path
-    requirements = ['mock>=2.0.0', 'flake8', 'pytest', 'pytest-cov'] if what == 'all' else ['behave']
+    requirements = ['flake8', 'pytest', 'pytest-cov'] if what == 'all' else ['behave']
     requirements += ['coverage']
     # try to split tests between psycopg2 and psycopg3
     requirements += ['psycopg[binary]'] if sys.version_info >= (3, 8, 0) and\

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,6 @@ psycopg2-binary
 behave
 coverage
 flake8>=3.0.0
-mock
 pytest-cov
 pytest
 setuptools

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,8 +2,7 @@ import datetime
 import os
 import shutil
 import unittest
-
-from mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import urllib3
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,8 @@ import socket
 
 from http.server import HTTPServer
 from io import BytesIO as IO
-from mock import Mock, PropertyMock, patch
 from socketserver import ThreadingMixIn
+from unittest.mock import Mock, PropertyMock, patch
 
 from patroni import global_config
 from patroni.api import RestApiHandler, RestApiServer

--- a/tests/test_async_executor.py
+++ b/tests/test_async_executor.py
@@ -1,6 +1,6 @@
 import unittest
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from patroni.async_executor import AsyncExecutor, CriticalTask
 from threading import Thread
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -3,7 +3,7 @@ import botocore.awsrequest
 import sys
 import unittest
 
-from mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 from collections import namedtuple
 from patroni.scripts.aws import AWSConnection, main as _main
 

--- a/tests/test_barman.py
+++ b/tests/test_barman.py
@@ -1,6 +1,6 @@
 import logging
 import mock
-from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 import unittest
 from urllib3.exceptions import MaxRetryError
 

--- a/tests/test_barman.py
+++ b/tests/test_barman.py
@@ -1,7 +1,7 @@
 import logging
-import mock
-from unittest.mock import MagicMock, Mock, patch
 import unittest
+from unittest import mock
+from unittest.mock import MagicMock, Mock, patch
 from urllib3.exceptions import MaxRetryError
 
 from patroni.scripts.barman.cli import main

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,7 +1,6 @@
 import os
 import sys
-
-from mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 from patroni.async_executor import CriticalTask
 from patroni.collections import CaseInsensitiveDict

--- a/tests/test_callback_executor.py
+++ b/tests/test_callback_executor.py
@@ -1,7 +1,7 @@
 import psutil
 import unittest
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from patroni.postgresql.callback_executor import CallbackExecutor
 
 

--- a/tests/test_cancellable.py
+++ b/tests/test_cancellable.py
@@ -1,7 +1,7 @@
 import psutil
 import unittest
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from patroni.exceptions import PostgresException
 from patroni.postgresql.cancellable import CancellableSubprocess
 

--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -1,5 +1,6 @@
 import time
-from mock import Mock, patch, PropertyMock
+from unittest.mock import Mock, patch, PropertyMock
+
 from patroni.postgresql.mpp.citus import CitusHandler
 from patroni.psycopg import ProgrammingError
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import unittest
 import io
 
 from copy import deepcopy
-from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from patroni import global_config
 from patroni.config import ClusterConfig, Config, ConfigParseError

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -5,7 +5,7 @@ import yaml
 
 from . import MockConnect, MockCursor, MockConnectionInfo
 from copy import deepcopy
-from mock import MagicMock, Mock, PropertyMock, mock_open as _mock_open, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, mock_open as _mock_open, patch
 
 from patroni.__main__ import main as _main
 from patroni.config import Config

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -1,8 +1,8 @@
 import consul
 import unittest
+from unittest.mock import Mock, PropertyMock, patch
 
 from consul import ConsulException, NotFound
-from mock import Mock, PropertyMock, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.consul import AbstractDCS, Cluster, Consul, ConsulInternalError, \
     ConsulError, ConsulClient, HTTPClient, InvalidSessionTTL, InvalidSession, RetryFailedError

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -6,7 +6,6 @@ import unittest
 
 from click.testing import CliRunner
 from datetime import datetime, timedelta
-from mock import patch, Mock, PropertyMock
 from patroni import global_config
 from patroni.ctl import ctl, load_config, output_members, get_dcs, parse_dcs, \
     get_all_members, get_any_member, get_cursor, query_member, PatroniCtlException, apply_config_changes, \
@@ -17,6 +16,7 @@ from patroni.postgresql.mpp import get_mpp
 from patroni.psycopg import OperationalError
 from patroni.utils import tzutc
 from prettytable import PrettyTable, ALL
+from unittest.mock import patch, Mock, PropertyMock
 from urllib3 import PoolManager
 
 from . import MockConnect, MockCursor, MockResponse, psycopg_connect

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -1,6 +1,5 @@
 import click
 import etcd
-import mock
 import os
 import unittest
 
@@ -16,6 +15,7 @@ from patroni.postgresql.mpp import get_mpp
 from patroni.psycopg import OperationalError
 from patroni.utils import tzutc
 from prettytable import PrettyTable, ALL
+from unittest import mock
 from unittest.mock import patch, Mock, PropertyMock
 from urllib3 import PoolManager
 

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -4,12 +4,12 @@ import socket
 import unittest
 
 from dns.exception import DNSException
-from mock import Mock, PropertyMock, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.etcd import AbstractDCS, EtcdClient, Cluster, Etcd, EtcdError, DnsCachingResolver
 from patroni.exceptions import DCSError
 from patroni.postgresql.mpp import get_mpp
 from patroni.utils import Retry
+from unittest.mock import Mock, PropertyMock, patch
 from urllib3.exceptions import ReadTimeoutError
 
 from . import SleepException, MockResponse, requests_get

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -2,8 +2,8 @@ import etcd
 import json
 import unittest
 import urllib3
+from unittest.mock import Mock, PropertyMock, patch
 
-from mock import Mock, PropertyMock, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.etcd import DnsCachingResolver
 from patroni.dcs.etcd3 import PatroniEtcd3Client, Cluster, Etcd3, Etcd3Client, \

--- a/tests/test_exhibitor.py
+++ b/tests/test_exhibitor.py
@@ -1,7 +1,7 @@
 import unittest
 import urllib3
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.exhibitor import ExhibitorEnsembleProvider, Exhibitor
 from patroni.dcs.zookeeper import ZooKeeperError

--- a/tests/test_file_perm.py
+++ b/tests/test_file_perm.py
@@ -1,7 +1,6 @@
 import unittest
 import stat
-
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from patroni.file_perm import pg_perm
 

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -2,8 +2,8 @@ import datetime
 import etcd
 import os
 import sys
+from unittest.mock import Mock, MagicMock, PropertyMock, patch, mock_open
 
-from mock import Mock, MagicMock, PropertyMock, patch, mock_open
 from patroni import global_config
 from patroni.collections import CaseInsensitiveSet
 from patroni.config import Config

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -1,11 +1,11 @@
 import base64
 import datetime
 import json
-import mock
 import socket
 import time
 import unittest
 import urllib3
+from unittest import mock
 from unittest.mock import Mock, PropertyMock, mock_open, patch
 
 from patroni.dcs import get_dcs

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -6,8 +6,8 @@ import socket
 import time
 import unittest
 import urllib3
+from unittest.mock import Mock, PropertyMock, mock_open, patch
 
-from mock import Mock, PropertyMock, mock_open, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.kubernetes import Cluster, k8s_client, k8s_config, K8sConfig, K8sConnectionFailed, \
     K8sException, K8sObject, Kubernetes, KubernetesError, KubernetesRetriableException, \

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,11 +4,11 @@ import sys
 import unittest
 import yaml
 from io import StringIO
+from queue import Queue, Full
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from patroni.config import Config
 from patroni.log import PatroniLogger
-from queue import Queue, Full
 
 try:
     from pythonjsonlogger import jsonlogger

--- a/tests/test_patroni.py
+++ b/tests/test_patroni.py
@@ -4,10 +4,10 @@ import os
 import signal
 import time
 import unittest
+from unittest.mock import Mock, PropertyMock, patch
 
 import patroni.config as config
 from http.server import HTTPServer
-from mock import Mock, PropertyMock, patch
 from patroni.api import RestApiServer
 from patroni.async_executor import AsyncExecutor
 from patroni.dcs import Cluster, Member

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -6,8 +6,8 @@ import subprocess
 import time
 
 from copy import deepcopy
-from mock import Mock, MagicMock, PropertyMock, patch, mock_open
 from pathlib import Path
+from unittest.mock import Mock, MagicMock, PropertyMock, patch, mock_open
 
 import patroni.psycopg as psycopg
 

--- a/tests/test_postmaster.py
+++ b/tests/test_postmaster.py
@@ -1,12 +1,12 @@
 import multiprocessing
 import psutil
 import unittest
+from unittest.mock import Mock, patch, mock_open
 
-from mock import Mock, patch, mock_open
 from patroni.postgresql.postmaster import PostmasterProcess
 
 
-class MockProcess(object):
+class MockProcess:
     def __init__(self, target, args):
         self.target = target
         self.args = args

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -2,8 +2,8 @@ import os
 import unittest
 import tempfile
 import time
+from unittest.mock import Mock, PropertyMock, patch
 
-from mock import Mock, PropertyMock, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.raft import Cluster, DynMemberSyncObj, KVStoreTTL, \
     Raft, RaftError, SyncObjUtility, TCPTransport, _TCPTransport

--- a/tests/test_raft_controller.py
+++ b/tests/test_raft_controller.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import unittest
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from pysyncobj import SyncObj
 from patroni.config import Config
 from patroni.raft_controller import RaftController, main as _main

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -1,4 +1,4 @@
-from mock import Mock, PropertyMock, patch, mock_open
+from unittest.mock import Mock, PropertyMock, patch, mock_open
 
 from patroni.postgresql import Postgresql
 from patroni.postgresql.cancellable import CancellableSubprocess

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,10 +1,8 @@
 import mock
 import os
 import unittest
-
-
-from mock import Mock, PropertyMock, patch
 from threading import Thread
+from unittest.mock import Mock, PropertyMock, patch
 
 from patroni import global_config, psycopg
 from patroni.dcs import Cluster, ClusterConfig, Member, Status, SyncState

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,7 +1,7 @@
-import mock
 import os
 import unittest
 from threading import Thread
+from unittest import mock
 from unittest.mock import Mock, PropertyMock, patch
 
 from patroni import global_config, psycopg

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,5 @@
 import os
-
-from mock import Mock, patch, PropertyMock
+from unittest.mock import Mock, patch, PropertyMock
 
 from patroni import global_config
 from patroni.collections import CaseInsensitiveSet

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import unittest
-
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from patroni.exceptions import PatroniException
 from patroni.utils import Retry, RetryFailedError, enable_keepalive, polling_loop, validate_directory, unquote

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 
 from io import StringIO
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 from patroni.dcs import dcs_modules
 from patroni.validator import schema, Directory, Schema
 

--- a/tests/test_wale_restore.py
+++ b/tests/test_wale_restore.py
@@ -1,12 +1,11 @@
 import subprocess
 import unittest
+from threading import current_thread
+from unittest.mock import Mock, PropertyMock, patch, mock_open
 
 import patroni.psycopg as psycopg
-
-from mock import Mock, PropertyMock, patch, mock_open
 from patroni.scripts import wale_restore
 from patroni.scripts.wale_restore import WALERestore, main as _main, get_major_version
-from threading import current_thread
 
 from . import MockConnect, psycopg_connect
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -3,14 +3,14 @@ import patroni.watchdog.linux as linuxwd
 import sys
 import unittest
 import os
+from unittest.mock import patch, Mock, PropertyMock
 
-from mock import patch, Mock, PropertyMock
 from patroni.watchdog import Watchdog, WatchdogError
 from patroni.watchdog.base import NullWatchdog
 from patroni.watchdog.linux import LinuxWatchdogDevice
 
 
-class MockDevice(object):
+class MockDevice:
     def __init__(self, fd, filename, flag):
         self.fd = fd
         self.filename = filename

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -1,12 +1,12 @@
 import select
 import unittest
+from unittest.mock import Mock, PropertyMock, patch
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError, NodeExistsError
 from kazoo.handlers.threading import SequentialThreadingHandler
 from kazoo.protocol.states import KeeperState, WatchedEvent, ZnodeStat
 from kazoo.retry import RetryFailedError
-from mock import Mock, PropertyMock, patch
 from patroni.dcs import get_dcs
 from patroni.dcs.zookeeper import Cluster, PatroniKazooClient, \
     PatroniSequentialThreadingHandler, ZooKeeper, ZooKeeperError

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,6 @@ commands_post =
     - {tty:{env:OPEN_CMD} "{toxworkdir}{/}pytest_report_{env_name}.html":true}
 deps =
     -r requirements.txt
-    mock>=2.0.0
     pytest
     pytest-cov
     pytest-html


### PR DESCRIPTION

https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.
