### PR TITLE
Adjust allow_in_place_tablespaces availability

### DIFF
--- a/patroni/postgresql/available_parameters/0_postgres.yml
+++ b/patroni/postgresql/available_parameters/0_postgres.yml
@@ -4,7 +4,7 @@ parameters:
     version_from: 170000
   allow_in_place_tablespaces:
   - type: Bool
-    version_from: 150000
+    version_from: 100000
   allow_system_table_mods:
   - type: Bool
     version_from: 90300


### PR DESCRIPTION
`allow_in_place_tablespaces` was actually backpatched to PG10-PG14 