### PR TITLE
Don't socket.getaddrinfo() from config_generator.py

### DIFF
--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -32,8 +32,7 @@ def mock_open(*args, **kwargs):
 @patch('subprocess.check_output', Mock(return_value=b"postgres (PostgreSQL) 16.2"))
 @patch('psutil.Process.exe', Mock(return_value='/bin/dir/from/running/postgres'))
 @patch('psutil.Process.__init__', Mock(return_value=None))
-@patch.object(AbstractConfigGenerator, '_HOSTNAME', HOSTNAME)
-@patch.object(AbstractConfigGenerator, '_IP', IP)
+@patch('patroni.config_generator.get_address', Mock(return_value=(HOSTNAME, IP)))
 class TestGenerateConfig(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
the get_address() function was called when config_generator.py is loaded because it was required to initialize _HOSTNAME and _IP properties of AbstractConfigGenerator and in some cases making unit tests very slow.