### PR TITLE
Compatibility with latest changes in urlparse

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -182,6 +182,9 @@ def parse_dsn(value: str) -> Optional[Dict[str, str]]:
     >>> parse_dsn('requiressl = 0\\\\') == {'sslmode': 'prefer', 'gssencmode': 'prefer',\
                                             'channel_binding': 'prefer', 'sslnegotiation': 'postgres'}
     True
+    >>> parse_dsn('foo=bar') == {'foo': 'bar', 'sslmode': 'prefer', 'gssencmode': 'prefer',\
+                                 'channel_binding': 'prefer', 'sslnegotiation': 'postgres'}
+    True
     """
     ret = parse_conninfo(value, _conninfo_parse)
 
@@ -190,7 +193,6 @@ def parse_dsn(value: str) -> Optional[Dict[str, str]]:
         ret.setdefault('gssencmode', 'prefer')
         ret.setdefault('channel_binding', 'prefer')
         ret.setdefault('sslnegotiation', 'postgres')
-    logger.error('parse_dsn("%s") -> %s', value, ret)
     return ret
 
 
@@ -863,10 +865,7 @@ class ConfigHandler(object):
             else:
                 return False
 
-        ret = all(str(primary_conninfo.get(p)) == str(v) for p, v in wanted_primary_conninfo.items() if v is not None)
-        if not ret:
-            logger.error('_check_primary_conninfo "%s" != "%s"', primary_conninfo, wanted_primary_conninfo)
-        return ret
+        return all(str(primary_conninfo.get(p)) == str(v) for p, v in wanted_primary_conninfo.items() if v is not None)
 
     def check_recovery_conf(self, member: Union[Leader, Member, None]) -> Tuple[bool, bool]:
         """Returns a tuple. The first boolean element indicates that recovery params don't match

--- a/patroni/psycopg.py
+++ b/patroni/psycopg.py
@@ -36,8 +36,8 @@ try:
         _legacy = True
 
         def _parse_conninfo(conninfo: str, **kwargs: Any) -> Any:
-            """Exists only to please ``pyright``."""
-            pass
+            """Return ``None`` and rely on fallback."""
+            return None
 
     def quote_literal(value: Any, conn: Optional[Any] = None) -> str:
         """Quote *value* as a SQL literal.
@@ -161,9 +161,7 @@ def parse_conninfo(value: str, fallback: Callable[[str], Optional[Dict[str, str]
     :returns: a :class:`dict` object, or ``None`` if failed to parse.
     """
     try:
-        return fallback(value) if _legacy else _parse_conninfo(value)
+        ret = _parse_conninfo(value)
     except Exception:
-        import logging
-        logger = logging.getLogger(__name__)
-        logger.exception('failed to parse "%s"', value)
-        return None
+        ret = None
+    return ret or fallback(value)


### PR DESCRIPTION
It doesn't accept multiple hosts with [] character in URL anymore. To mitigate the problem we switch to native wrappers of PQconninfoParse() function from libpq when it is possible and use own implementation only when psycopg2 is too old.