### PR TITLE
Docs: fix link to replication_modes

### DIFF
--- a/docs/ha_multi_dc.rst
+++ b/docs/ha_multi_dc.rst
@@ -4,7 +4,7 @@
 HA multi datacenter
 ===================
 
-The high availability of a PostgreSQL cluster deployed in multiple data centers is based on replication, which can be synchronous or asynchronous (`replication_modes <replication_modes.rst>`_).
+The high availability of a PostgreSQL cluster deployed in multiple data centers is based on replication, which can be synchronous or asynchronous (see :ref:`replication modes <replication_modes>`).
 
 In both cases, it is important to be clear about the following concepts:
 


### PR DESCRIPTION
Existing link is invalid:
https://patroni.readthedocs.io/en/latest/replication_modes.rst (from https://patroni.readthedocs.io/en/latest/ha_multi_dc.html )