### PR TITLE
Adjust NotifyAccess

### DIFF
--- a/extras/startup-scripts/patroni.service
+++ b/extras/startup-scripts/patroni.service
@@ -7,6 +7,7 @@ After=syslog.target network.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 
 User=postgres
 Group=postgres


### PR DESCRIPTION
I followed the switch to systemd notify introduced in #3301, but receive the following warning:

```
systemd[1]: patroni.service: Got notification message from PID 2572251, but reception only permitted for main PID 2572234
```

With `Type=notify` systemd implies `NotifyAccess=main` which restricts notify socket access only to the main process. Apparently patroni tries to send from a different one. This PR lifts this restriction and allows all process of the service to access the socket.

see https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#NotifyAccess=

> If `all`, all services updates from all members of the service's control group are accepted. This option should be set to open access to the notification socket when using `Type=notify`/`Type=notify-reload` or `WatchdogSec=` (see above). If those options are used but `NotifyAccess=` is not configured, it will be implicitly set to main.