### PR TITLE
Fix bug with primary_conninfo password comparison

### DIFF
--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -856,11 +856,11 @@ class ConfigHandler(object):
                     dbname = primary_conninfo.get('dbname')
                     if dbname:
                         wal_receiver_primary_conninfo['dbname'] = dbname
+                    # pg_stat_get_wal_receiver() returns masked password, therefore
+                    # we need to copy password value from primary_conninfo GUC.
+                    if 'password' in primary_conninfo:
+                        wal_receiver_primary_conninfo['password'] = primary_conninfo['password']
                     primary_conninfo = wal_receiver_primary_conninfo
-                    # There could be no password in the primary_conninfo or it is masked.
-                    # Just copy the "desired" value in order to make comparison succeed.
-                    if 'password' in wanted_primary_conninfo:
-                        primary_conninfo['password'] = wanted_primary_conninfo['password']
 
         if 'passfile' in primary_conninfo and 'password' not in primary_conninfo \
                 and 'password' in wanted_primary_conninfo:

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -310,6 +310,7 @@ class TestPostgresql(BaseTestPostgresql):
             self.p.config.write_postgresql_conf()
             self.assertEqual(self.p.config.check_recovery_conf(None), (False, False))
             with patch.object(Postgresql, 'primary_conninfo', Mock(return_value='host=1')):
+                mock_get_pg_settings.return_value['primary_conninfo'][1] = 'host=1 dbname=postgres password=a'
                 mock_get_pg_settings.return_value['primary_slot_name'] = [
                     'primary_slot_name', '', '', 'string', 'postmaster', self.p.config._postgresql_conf]
                 self.assertEqual(self.p.config.check_recovery_conf(None), (True, True))


### PR DESCRIPTION
Starting from PostgreSQL 10 we use passfile in primary_conninfo and we failed to update passfile after replication password was updated in patroni.yaml with reload.

Close https://github.com/patroni/patroni/pull/3470