### PR TITLE
Fix check_recovery_conf() when PostgreSQL is in the starting state

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -1508,6 +1508,9 @@ class Ha(object):
             if ret is not None:  # continue if we just deleted the stale failover key as a leader
                 return ret
 
+        if self.state_handler.is_starting():  # postgresql still starting up is unhealthy
+            return False
+
         if self.state_handler.is_primary():
             if self.is_paused():
                 # in pause leader is the healthiest only when no initialize or sysid matches with initialize!

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -1007,6 +1007,10 @@ class ConfigHandler(object):
 
             self._current_recovery_params = CaseInsensitiveDict({n: [v, restart_required(n), self._postgresql_conf]
                                                                  for n, v in recovery_params.items()})
+            self._current_recovery_params.setdefault('recovery_min_apply_delay', ['0', False, self._postgresql_conf])
+            self._current_recovery_params.update({param: ['', restart_required(param), self._postgresql_conf]
+                                                  for param in self._recovery_parameters_to_compare
+                                                  if param not in self._current_recovery_params})
         else:
             with self.config_writer(self._recovery_conf) as f:
                 self._write_recovery_params(f, recovery_params)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -1065,6 +1065,8 @@ class TestHa(PostgresInit):
         self.ha.dcs._last_failsafe = None
         with patch.object(Watchdog, 'is_healthy', PropertyMock(return_value=False)):
             self.assertFalse(self.ha.is_healthiest_node())
+        with patch('patroni.postgresql.Postgresql.is_starting', return_value=True):
+            self.assertFalse(self.ha.is_healthiest_node())
         self.ha.is_paused = true
         self.assertFalse(self.ha.is_healthiest_node())
 


### PR DESCRIPTION
For PostgreSQL v12 and newer, `pg_settings` cannot be queried while the server is still starting and not yet accepting connections. As a workaround, we update `self._current_recovery_params` when writing a new `postgresql.conf` file.

However, this logic did not account for the fact that `self._current_recovery_params` must contain all recovery parameters for correct comparison in `check_recovery_conf()`.

To address this, the missing recovery parameters are now added to `self._current_recovery_params` in `write_recovery_conf()`, mirroring the behavior of `_read_recovery_params_pre_v12()`.

Additionally, restore the `Postgresql.is_starting()` check in `Ha.is_healthiest_node()`, which was mistakenly removed in #2726.

Close https://github.com/patroni/patroni/discussions/3517