### PR TITLE
feat: add username/password parse to dcs-url

### DIFF
--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -54,7 +54,7 @@ Before jumping into each of the sub-commands of ``patronictl``, be aware that ``
 
     This argument can be used either to override the DCS and ``namespace`` settings from the ``patronictl`` configuration, or to define it if it's missing in the configuration.
 
-    The value should be in the format ``DCS://HOST:PORT/NAMESPACE``, e.g. ``etcd3://localhost:2379/service`` to connect to etcd v3 running on ``localhost`` with Patroni cluster stored under ``service`` namespace. Any part that is missing in the argument value will be replaced with the value present in the configuration or with its default.
+    The value should be in the format ``DCS://HOST:PORT/NAMESPACE`` or ``DCS://USERNAME:PASSWORD@HOST:PORT/NAMESPACE``, e.g. ``etcd3://localhost:2379/service`` to connect to etcd v3 running on ``localhost`` with Patroni cluster stored under ``service`` namespace. Any part that is missing in the argument value will be replaced with the value present in the configuration or with its default.
 
 ``-k`` / ``--insecure``
     Flag to bypass validation of REST API server SSL certificate.

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -207,7 +207,8 @@ class PatronictlPrettyTable(PrettyTable):
 def parse_dcs(dcs: Optional[str]) -> Optional[Dict[str, Any]]:
     """Parse a DCS URL.
 
-    :param dcs: the DCS URL in the format ``DCS://HOST:PORT/NAMESPACE``. ``DCS`` can be one among:
+    :param dcs: the DCS URL in the format ``DCS://HOST:PORT/NAMESPACE`` or ``DCS://USERNAME:PASSWORD@HOST:PORT/NAMESPACE``. 
+    ``DCS`` can be one among:
 
         * ``consul``
         * ``etcd``
@@ -217,7 +218,9 @@ def parse_dcs(dcs: Optional[str]) -> Optional[Dict[str, Any]]:
 
         If ``DCS`` is not specified, assume ``etcd`` by default. If ``HOST`` is not specified, assume ``localhost`` by
         default. If ``PORT`` is not specified, assume the default port of the given ``DCS``. If ``NAMESPACE`` is not
-        specified, use whatever is in config.
+        specified, use whatever is in config. IF ``USERNAME`` is not specified then user whatever is in the config.
+        If ``PASSWORD`` is not specified then use whatever is in the config. ``USERNAME`` and ``PASSWORD`` are only
+        valid optons for ``etcd`` and ``etcd3`` ``DCS``.
 
     :returns: ``None`` if *dcs* is ``None``, otherwise a dictionary. The dictionary represents *dcs* as if it were
         parsed from the Patroni configuration file. Additionally, if a namespace is specified in *dcs*, return a


### PR DESCRIPTION
This PR allows username and password to be specified as command line arguments for patronictl.

Currently the --dcs-url argument allows you to specify an etcd url but there is no way to supply a username and password. This means that the user basically just needs to add this in a config file which is not ideal if your goal is to not leave passwords lying around in plain text files unnecessarily.

This is an alternative implementation of the PR at #3540.

The implementation here uses the existing urlparse capabilities and allows the username and password to be input in a way similar to postgres connection strings (ie scheme://username:password@hostname:port/path). I think that this implementation is cleaner because it does not add any new CLI arguments and ends up only being 4 lines of code. 

I could possibly add validation to ensure that username/password is not set for schemes that do not support this concept, let me know if you think that is necessary.  

Thank you.
