### PR TITLE
Add DEBUG logging for pg_rewind decisions

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -601,6 +601,7 @@ class Ha(object):
 
             msg = 'running pg_rewind from ' + leader.name
             return self._async_executor.try_run_async(msg, self._rewind.execute, args=(leader,)) or msg
+
         if self._rewind.should_remove_data_directory_on_diverged_timelines and not self.is_standby_cluster():
             msg = 'reinitializing due to diverged timelines'
             return self._async_executor.try_run_async(msg, self._do_reinitialize, args=(self.cluster,)) or msg

--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -57,7 +57,7 @@ class Rewind(object):
 
         cmd = [self._postgresql.pgcommand('pg_rewind'), '--help']
         try:
-            ret = subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            ret = subprocess.call(cmd, stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
             if ret != 0:  # pg_rewind is not there, close up the shop and go home
                 logger.debug('pg_rewind is not possible: pg_rewind command returned non-zero exit code %s', ret)
                 return False


### PR DESCRIPTION
When pg_rewind cannot be used, Patroni provides no indication of why. The replica silently fails to stream on the wrong timeline, and the user has to figure out on their own whether the issue is a missing binary, disabled use_pg_rewind, or lack of wal_log_hints/data checksums.

Added `can_rewind_reason()` method that returns a human-readable explanation. The `can_rewind` property now delegates to it, avoiding code duplication. DEBUG-level messages are logged at three decision points:

- in `trigger_check_diverged_lsn()` when diverged timeline check is skipped because neither pg_rewind nor `remove_data_directory_on_diverged_timelines` is available, including the specific reason why pg_rewind cannot be used — this is the main silent failure scenario from the issue
- in `_handle_rewind_or_reinitialize()` when rewind is needed but not possible
- in `execute()` when `can_rewind` flips to False after a failed rewind attempt

Close #3544