### PR TITLE
Unpin sphinx-github-style and sphinx versions

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,5 +1,4 @@
-setuptools
-sphinx>=4,<8.2.0
+sphinx>=4
 sphinx_rtd_theme>1
 sphinxcontrib-apidoc
 sphinx-github-style


### PR DESCRIPTION
We pinned them because of some incompatibilities which were later addressed.