### PR TITLE
Properly handle Unavailable exception raised by Etcd v3

### DIFF
--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -164,7 +164,7 @@ def _raise_for_data(data: Union[bytes, str, Dict[str, Any]], status_code: Option
         data_error: Optional[Dict[str, Any]] = data.get('error') or data.get('Error')
         if isinstance(data_error, dict):  # streaming response
             status_code = data_error.get('http_code')
-            code: Optional[int] = data_error['grpc_code']
+            code: Optional[int] = data_error.get('code') or data_error['grpc_code']
             error: str = data_error['message']
         else:
             data_code = data.get('code') or data.get('Code')

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -197,7 +197,7 @@ class TestPatroniEtcd3Client(BaseTestEtcd3):
         self.assertRaises(etcd.EtcdException, self.client._handle_server_response, response)
         response.status_code = 400
         self.assertRaises(Unknown, self.client._handle_server_response, response)
-        response.content = '{"error":{"grpc_code":14,"message":"","http_code":400}}'
+        response.content = '{"error":{"code":14,"message":"","http_code":400}}'
         self.assertRaises(socket.timeout, self.client._handle_server_response, response)
         response.content = '{"error":{"grpc_code":0,"message":"","http_code":400}}'
         try:


### PR DESCRIPTION
The response JSON containing error code and message may vary depending on where it is raised from.

Follow up on #3338 and #3486