### PR TITLE
Postpone CitusHandler.run()

### DIFF
--- a/patroni/postgresql/mpp/citus.py
+++ b/patroni/postgresql/mpp/citus.py
@@ -403,6 +403,7 @@ class CitusHandler(Citus, AbstractMPPHandler, Thread):
         self._in_flight: Optional[PgDistTask] = None  # Reference to the `PgDistTask` being changed in a transaction
         self._schedule_load_pg_dist_group = True  # Flag that "pg_dist_group" should be queried from the database
         self._condition = Condition()  # protects _pg_dist_group, _tasks, _in_flight, and _schedule_load_pg_dist_group
+        self._ready_to_run = Event()
         self.schedule_cache_rebuild()
         if self.is_coordinator():
             self.start()
@@ -469,6 +470,9 @@ class CitusHandler(Citus, AbstractMPPHandler, Thread):
 
         if not self.is_coordinator():
             return
+
+        # notify run() method that it should start doing its job
+        self._ready_to_run.set()
 
         self.add_task('after_promote', CITUS_COORDINATOR_GROUP_ID, cluster,
                       self._postgresql.name, self._postgresql.connection_string)
@@ -602,6 +606,9 @@ class CitusHandler(Citus, AbstractMPPHandler, Thread):
             task.wakeup()
 
     def run(self) -> None:
+        # we want to postpone "start" until first attempt to sync_meta_data
+        self._ready_to_run.wait()
+
         while True:
             try:
                 with self._condition:
@@ -681,7 +688,7 @@ class CitusHandler(Citus, AbstractMPPHandler, Thread):
         return task if self._add_task(task) else None
 
     def handle_event(self, cluster: Cluster, event: Dict[str, Any]) -> None:
-        if not self.is_coordinator():
+        if not self._ready_to_run.is_set():
             return
 
         worker = cluster.workers.get(event['group'])

--- a/tests/test_citus.py
+++ b/tests/test_citus.py
@@ -27,6 +27,7 @@ class TestCitus(BaseTestPostgresql):
     @patch('patroni.postgresql.mpp.citus.logger.warning')
     @patch('patroni.postgresql.mpp.citus.PgDistTask.wait', Mock())
     def test_run(self, mock_logger_warning):
+        self.c._ready_to_run.set()
         # `before_demote` or `before_promote` REST API calls starting a
         # transaction. We want to make sure that it finishes during
         # certain timeout. In case if it is not, we want to roll it back
@@ -49,8 +50,8 @@ class TestCitus(BaseTestPostgresql):
         self.c.sync_meta_data(self.cluster)
 
     def test_handle_event(self):
-        with patch.object(CitusHandler, 'is_coordinator', Mock(return_value=False)):
-            self.c.handle_event(self.cluster, {})
+        self.c.handle_event(self.cluster, {})
+        self.c._ready_to_run.set()
         self.c.handle_event(self.cluster, {'type': 'after_promote', 'group': 2,
                                            'leader': 'leader', 'timeout': 30, 'cooldown': 10})
 


### PR DESCRIPTION
Before #3526 thread was started with the first attempt to sync metadata, where we had guarantees that citus database is prepared (extension exists).
Early start caused enormous amount of errors.
We return to old behavior by using `self._ready_to_run = Event()`