### PR TITLE
Compatibility with latest Etcd

### DIFF
--- a/patroni/dcs/etcd3.py
+++ b/patroni/dcs/etcd3.py
@@ -1,4 +1,5 @@
 import base64
+import functools
 import json
 import logging
 import os
@@ -223,9 +224,19 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
         self._token = None
         self._cluster_version: Tuple[int, ...] = tuple()
         super(Etcd3Client, self).__init__({**config, 'version_prefix': '/v3beta'}, dns_resolver, cache_ttl)
+        if self._use_proxies and not self._cluster_version:
+            kwargs = self._prepare_common_parameters(1)
+            self._ensure_version_prefix(self._base_uri, **kwargs)
+            self.authenticate_on_start()
 
+    def authenticate_on_start(self, auth_request_func: Optional[Callable[..., Dict[str, Any]]] = None):
+        """Authenticate with Etcd v3 at startup and exit on invalid credentials.
+
+        :param auth_request_func: optional custom authentication request function,
+                                  if not provided, :meth:`call_rpc` will be used.
+        """
         try:
-            self.authenticate()
+            self.authenticate(auth_request_func=auth_request_func)
         except AuthFailed as e:
             logger.fatal('Etcd3 authentication failed: %r', e)
             sys.exit(1)
@@ -300,26 +311,82 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
         self._prepare_request(kwargs, {})
         return kwargs
 
+    def _do_auth_request(self, base_uri: str, kwargs: Dict[str, Any],
+                         method: str, fields: Dict[str, Any], retry: Optional[Retry] = None) -> Dict[str, Any]:
+        """Special method for handling authentication when discovering cluster members.
+
+        We can't use `call_rpc()` method for this purpose because it may cause infinite recursion.
+
+        :param base_uri: base url for authentication request, e.g. `http://etcd:2379/v3`
+        :param kwargs: common request parameters, e.g. headers.
+        :param method: `/auth/authenticate`
+        :param fields: authentication fields, e.g. `{'name': 'user', 'password': 'pass'}`.
+        :param retry: optional retry configuration, ignored.
+        """
+        request_kwargs = kwargs.copy()
+        request_kwargs['headers'] = {k: v for k, v in kwargs['headers'].items() if k != 'authorization'}
+        self._prepare_request(request_kwargs, fields)
+        response = self.http.urlopen(self._MPOST, base_uri + method, **request_kwargs)
+        return self._handle_server_response(response)
+
+    def _do_member_list_request(self, url: str, retry: Optional[Retry] = None, **kwargs: Any) -> Any:
+        """Special method for handling member list requests.
+
+        :param url: base url for member list request, e.g. `http://etcd:2379/v3/cluster/member/list`
+        :param kwargs: common request parameters, e.g. headers.
+        :param retry: optional retry configuration, ignored.
+        """
+        request_kwargs = kwargs.copy()
+        request_kwargs['headers'] = kwargs['headers'].copy()
+        # We want to update headers with authentication token if it was obtained during authentication request.
+        request_kwargs['headers'].update(self._get_headers())
+        response = self.http.urlopen(self._MPOST, url, **request_kwargs)
+        return self._handle_server_response(response)
+
     def _get_members(self, base_uri: str, **kwargs: Any) -> List[str]:
         self._ensure_version_prefix(base_uri, **kwargs)
-        resp = self.http.urlopen(self._MPOST, base_uri + self.version_prefix + '/cluster/member/list', **kwargs)
-        members = self._handle_server_response(resp)['members']
-        return [url for member in members for url in member.get('clientURLs', [])]
+        base_uri += self.version_prefix
+
+        retry = None
+        if self._update_machines_cache:
+            retry = Retry(deadline=self._config['retry_timeout'], max_delay=1, max_tries=-1)
+            # handle_auth_errors() calls retry.ensure_deadline(), which expects Retry.__call__()
+            # to have initialized the internal deadline state first.
+            retry(lambda: None)
+
+        # custom authentication request function, because we can't use `call_rpc()` method
+        # for this purpose as it may cause infinite recursion
+        auth_request_func = functools.partial(self._do_auth_request, base_uri, kwargs)
+
+        # if _machine_cache is empty, it means we are just starting and want to exit early if authentication fails.
+        if not self._machines_cache:
+            self.authenticate_on_start(auth_request_func)
+
+        response = self.handle_auth_errors(Etcd3Client._do_member_list_request, base_uri + '/cluster/member/list',
+                                           auth_request_func=auth_request_func, retry=retry, **kwargs)
+        return [url for member in response['members'] for url in member.get('clientURLs', [])]
 
     def call_rpc(self, method: str, fields: Dict[str, Any], retry: Optional[Retry] = None) -> Dict[str, Any]:
         fields['retry'] = retry
         return self.api_execute(self.version_prefix + method, self._MPOST, fields)
 
-    def authenticate(self, *, retry: Optional[Retry] = None) -> bool:
-        if self._use_proxies and not self._cluster_version:
-            kwargs = self._prepare_common_parameters(1)
-            self._ensure_version_prefix(self._base_uri, **kwargs)
+    def authenticate(self, *, retry: Optional[Retry] = None,
+                     auth_request_func: Optional[Callable[..., Dict[str, Any]]] = None) -> bool:
+        """Authenticate with the Etcd v3 cluster.
+
+        :param retry: optional retry configuration.
+        :param auth_request_func: optional custom authentication request function,
+                                  if not provided, `call_rpc()` method will be used.
+        """
         if not (self._cluster_version >= (3, 3) and self.username and self.password):
             return False
+        if not auth_request_func:
+            auth_request_func = self.call_rpc
         logger.info('Trying to authenticate on Etcd...')
         old_token, self._token = self._token, None
         try:
-            response = self.call_rpc('/auth/authenticate', {'name': self.username, 'password': self.password}, retry)
+            response = auth_request_func('/auth/authenticate',
+                                         {'name': self.username, 'password': self.password}, retry)
         except AuthNotEnabled:
             logger.info('Etcd authentication is not enabled')
             self._token = None
@@ -331,13 +398,23 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
         return old_token != self._token
 
     def handle_auth_errors(self: 'Etcd3Client', func: Callable[..., Any], *args: Any,
+                           auth_request_func: Optional[Callable[..., Dict[str, Any]]] = None,
                            retry: Optional[Retry] = None, **kwargs: Any) -> Any:
+        """Handle authentication errors for the given function.
+
+        :param func: function to call.
+        :param args: positional arguments for the function.
+        :param auth_request_func: optional custom authentication request function,
+                                  if not provided, `call_rpc()` method will be used.
+        :param retry: optional retry configuration.
+        :param kwargs: keyword arguments for the function.
+        """
         reauthenticated = False
         exc = None
         while True:
             if self._reauthenticate:
                 if self.username and self.password:
-                    self.authenticate(retry=retry)
+                    self.authenticate(retry=retry, auth_request_func=auth_request_func)
                     self._reauthenticate = False
                 else:
                     msg = 'Username or password not set, authentication is not possible'
@@ -381,6 +458,7 @@ class Etcd3Client(AbstractEtcdClientWithFailover):
     def lease_grant(self, ttl: int, *, retry: Optional[Retry] = None) -> str:
         return self.call_rpc('/lease/grant', {'TTL': ttl}, retry)['ID']
 
+    @_handle_auth_errors
     def lease_keepalive(self, ID: str, *, retry: Optional[Retry] = None) -> Optional[str]:
         return self.call_rpc('/lease/keepalive', {'ID': ID}, retry).get('result', {}).get('TTL')
 

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -79,6 +79,40 @@ class TestEtcd3Client(unittest.TestCase):
                             DnsCachingResolver())
         self.assertIsNotNone(etcd3._cluster_version)
 
+    @patch.object(urllib3.PoolManager, 'urlopen')
+    def test_get_members_retries_auth_errors(self, mock_urlopen):
+        auth_requests = []
+        member_list_requests = []
+
+        def urlopen_side_effect(method, url, **kwargs):
+            ret = MockResponse()
+            if method == 'GET' and url.endswith('/version'):
+                ret.content = '{"etcdserver": "3.6.10", "etcdcluster": "3.6.0"}'
+            elif url.endswith('/auth/authenticate'):
+                auth_requests.append(kwargs)
+                ret.content = '{{"token":"authtoken{0}"}}'.format(len(auth_requests))
+            elif url.endswith('/cluster/member/list'):
+                member_list_requests.append(kwargs)
+                if 1 < len(member_list_requests) < 4:
+                    ret.status_code = 401
+                    ret.content = '{"code":16,"error":"etcdserver: invalid auth token"}'
+                else:
+                    ret.content = '{"members":[{"clientURLs":["http://localhost:2379"]}]}'
+            return ret
+
+        mock_urlopen.side_effect = urlopen_side_effect
+        client = Etcd3Client({'host': '127.0.0.1', 'port': 2379, 'retry_timeout': 10, 'patronictl': True,
+                              'username': 'etcduser', 'password': 'etcdpassword'}, DnsCachingResolver())
+        client._update_machines_cache = True
+
+        kwargs = client._prepare_get_members(1)
+        self.assertEqual(client._get_members('http://127.0.0.1:2379', **kwargs), ['http://localhost:2379'])
+        self.assertEqual(len(auth_requests), 3)
+        self.assertEqual(json.loads(auth_requests[-1]['body']), {'name': 'etcduser', 'password': 'etcdpassword'})
+        self.assertNotIn('authorization', auth_requests[-1]['headers'])
+        self.assertEqual(len(member_list_requests), 4)
+        self.assertEqual(member_list_requests[-1]['headers']['authorization'], 'authtoken3')
+
 
 class BaseTestEtcd3(unittest.TestCase):
 


### PR DESCRIPTION
v3.6.9, v3.5.28, and v3.4.42 addressed some CVEs and now it is no longer possible to read cluster topology and perform lease keepalive requests without authentication.

Close https://github.com/patroni/patroni/issues/3573